### PR TITLE
Add PDFs information, do not store LHE weights

### DIFF
--- a/MonoXAnalysis/cfg/run_wmass_cfg.py
+++ b/MonoXAnalysis/cfg/run_wmass_cfg.py
@@ -27,8 +27,8 @@ forcedFineSplitFactor = getHeppyOption("fineSplitFactor",-1)
 isTest = getHeppyOption("test",None) != None and not re.match("^\d+$",getHeppyOption("test"))
 selectedEvents=getHeppyOption("selectEvents","")
 
-# save LHE weights: very big! do only for needed MC samples
-runOnSignal = False
+# save PDF information and do not skim. Do only for needed MC samples
+runOnSignal = True
 keepLHEweights = False
 
 # Lepton Skimming
@@ -141,6 +141,8 @@ if not removeJecUncertainty:
             "met_jecDown" : NTupleObject("met_jecDown", metType, help="PF E_{T}^{miss}, after type 1 corrections (JEC minus 1sigma)"),
             })
 
+if runOnSignal: wmass_globalVariables += pdfsVariables
+
 ## Tree Producer
 treeProducer = cfg.Analyzer(
      AutoFillTreeProducer, name='treeProducerWMass',
@@ -227,10 +229,8 @@ configureSplittingFromTime(samples_1prompt,50,6)
 configureSplittingFromTime(samples_signal,100,6)
 
 if runOnSignal:
-    keepLHEweights = True
     selectedComponents = samples_signal
 else:
-    keepLHEweights = False
     #selectedComponents = samples_1prompt + samples_1fake 
     selectedComponents = QCDPtbcToE
 
@@ -517,6 +517,10 @@ if not keepLHEweights:
     if "LHE_weights" in treeProducer.collections: treeProducer.collections.pop("LHE_weights")
     if lheWeightAna in sequence: sequence.remove(lheWeightAna)
     histoCounter.doLHE = False
+
+if runOnSignal:
+    if ttHLepSkim in sequence: sequence.remove(ttHLepSkim)
+    if triggerFlagsAna in sequence: sequence.remove(triggerFlagsAna)
 
 ## Auto-AAA
 if not getHeppyOption("isCrab"):

--- a/MonoXAnalysis/python/analyzers/treeProducerWMass.py
+++ b/MonoXAnalysis/python/analyzers/treeProducerWMass.py
@@ -30,6 +30,17 @@ wmass_globalObjects = {
             "tkMetPVTight" : NTupleObject("tkMetPVTight", fourVectorType, help="PF E_{T}^{miss} from charged candidates with Tight chs"),
 }
 
+##------------------------------------------  
+## PDFs
+##------------------------------------------  
+
+pdfsVariables = [
+        NTupleVariable("x1", lambda ev: ev.pdf_x1, help="fraction of proton momentum carried by the first parton"),
+        NTupleVariable("x2", lambda ev: ev.pdf_x2, help="fraction of proton momentum carried by the second parton"),
+        NTupleVariable("id1", lambda ev: ev.pdf_id1, int, help="id of the first parton in the proton"),
+        NTupleVariable("id2", lambda ev: ev.pdf_id2, int, help="id of the second parton in the proton"),
+        ]
+
 wmass_collections = {
             "selectedLeptons" : NTupleCollection("LepGood",  leptonTypeWMass, 8, help="Leptons after the preselection"),
             #"otherLeptons"    : NTupleCollection("LepOther", leptonTypeSusy, 8, help="Leptons after the preselection"),
@@ -40,7 +51,7 @@ wmass_collections = {
             ##------------------------------------------------
             #"ivf"       : NTupleCollection("SV",     svType, 20, help="SVs from IVF"),
             ##------------------------------------------------
-            "LHE_weights"    : NTupleCollection("LHEweight",  weightsInfoType, 1000, mcOnly=True, help="LHE weight info"),
+            #"LHE_weights"    : NTupleCollection("LHEweight",  weightsInfoType, 1000, mcOnly=True, help="LHE weight info"),
             ##------------------------------------------------
             #"genleps"         : NTupleCollection("genLep",     genParticleWithLinksType, 10, help="Generated leptons (e/mu) from W/Z decays"),                                                                                                
             #"gentauleps"      : NTupleCollection("genLepFromTau", genParticleWithLinksType, 10, help="Generated leptons (e/mu) from decays of taus from W/Z/h decays"),                                                                       

--- a/MonoXAnalysis/python/postprocessing/postproc_batch.py
+++ b/MonoXAnalysis/python/postprocessing/postproc_batch.py
@@ -12,6 +12,8 @@ DEFAULT_MODULES = [("CMGTools.MonoXAnalysis.postprocessing.examples.puWeightProd
                    ("CMGTools.MonoXAnalysis.postprocessing.examples.lepVarProducer","eleRelIsoEA"),
                    ("CMGTools.MonoXAnalysis.postprocessing.examples.jetReCleaner","jetReCleaner")]
 
+DEFAULT_MODULES = []
+
 if __name__ == "__main__":
     from optparse import OptionParser
     parser = OptionParser(usage="%prog [options] inputDir outputDir")
@@ -67,7 +69,7 @@ if __name__ == "__main__":
             short = os.path.basename(D)
             if options.datasets != []:
                 if short not in options.datasets: continue
-            data = any(x in short for x in "DoubleMu DoubleEG MuEG MuonEG SingleMu SingleEl".split())
+            data = any(x in short for x in "DoubleMu DoubleEG MuEG MuonEG SingleMuon SingleElectron".split())
             pckobj  = pickle.load(open(pckfile,'r'))
             counters = dict(pckobj)
             if ('Sum Weights' in counters):


### PR DESCRIPTION
Changes that affects signal only tree production:
- save the x and id of the incoming partons
- do not store the huge LHE weights (and hope for NNPDF update for the "ultimate" samples)
- do not skim on leptons / trigger flags when running on signal (unbiased samples)