### PR TITLE
Improvements for post-processing skims and fake-rate friends

### DIFF
--- a/MonoXAnalysis/python/plotter/wmass/wmass_e/mca-includes/mca-ewkmc.txt
+++ b/MonoXAnalysis/python/plotter/wmass/wmass_e/mca-includes/mca-ewkmc.txt
@@ -1,4 +1,4 @@
-Z     : DYJetsToLL_M50_part* : 1921.8; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
+Z    : DYJetsToLL_M50_part* : 1921.8; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
 W+   : WJetsToLNu_part* :  xsec; FillColor=ROOT.kRed+2, Label="W", NormSystematic=0.03
 Top  : TTJets_SingleLeptonFromT_ext_part* :  xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
 Top  : TTJets_SingleLeptonFromTbar_part* :  xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
@@ -12,4 +12,3 @@ DiBosons : WZ+WZ_ext : xsec; FillColor=ROOT.kViolet+2, Label="DiBosons", NormSys
 DiBosons : ZZ+ZZ_ext : xsec; FillColor=ROOT.kViolet+2, Label="DiBosons", NormSystematic=0.05
 
 # Alternative samples
-

--- a/MonoXAnalysis/python/plotter/wmass/wmass_e/skim_fr_el.txt
+++ b/MonoXAnalysis/python/plotter/wmass/wmass_e/skim_fr_el.txt
@@ -1,4 +1,6 @@
 alwaystrue: 1
-trigger: HLT_FR_1e==1
-onelep: nLepGood == 1
-el : abs(LepGood1_pdgId)==11
+trigger: HLT_SingleEl==1
+one electron: nLepGood==1 && abs(LepGood1_pdgId)==11
+el acceptance: LepGood1_pt > 25 && abs(LepGood1_eta)<2.5
+el HLT-safe ID: LepGood1_hltId==1
+one away jet: LepGood1_awayJet_pt>30 

--- a/MonoXAnalysis/python/plotter/wmass/wmass_e/skim_wenu.txt
+++ b/MonoXAnalysis/python/plotter/wmass/wmass_e/skim_wenu.txt
@@ -1,6 +1,5 @@
 alwaystrue: 1
 trigger: HLT_SingleEl==1
-one reco el: nLepGood==1
-el acceptance: abs(LepGood1_pdgId)==11 && LepGood1_pt > 25 && abs(LepGood1_eta)<2.5
+one reco el: nLepGood==1 && abs(LepGood1_pdgId)==11
+el acceptance: LepGood1_pt > 25 && abs(LepGood1_eta)<2.5
 el HLT-safe ID: LepGood1_hltId==1
-pfmet: met_pt > 20

--- a/MonoXAnalysis/python/plotter/wmass/wmass_e/skim_zee.txt
+++ b/MonoXAnalysis/python/plotter/wmass/wmass_e/skim_zee.txt
@@ -1,5 +1,7 @@
 alwaystrue: 1
-trigger: HLT_DoubleEl==1
-el acceptance: abs(LepGood1_pdgId)==11 && LepCorr1_pt > 20 && LepCorr2_pt > 10 && abs(LepCorr1_eta)<2.5 && abs(LepCorr2_eta)<2.5 && LepGood1_pdgId == -LepGood2_pdgId
-el selection: LepGood1_eleMVAId >=2 && LepGood1_relIso04 < 0.15 && LepGood1_convVetoFull==1 && LepGood2_eleMVAId >=2 && LepGood2_relIso04 < 0.15 && LepGood2_convVetoFull==1
-inv mass: abs(mass_2(LepCorr1_pt,LepGood1_eta,LepGood1_phi,0.5e-3,LepCorr2_pt,LepGood2_eta,LepGood2_phi,0.5e-3)-91.1876) < 20
+trigger: HLT_SingleEl==1
+two electrons: abs(LepGood1_pdgId)==11 && LepGood1_pdgId == -LepGood2_pdgId
+el acceptance: LepGood1_pt > 25 && LepGood2_pt > 20 && abs(LepGood1_eta)<2.5 && abs(LepGood2_eta)<2.5
+el medium ID: LepGood1_tightId >=2 && LepGood2_tightId >=2
+el medium iso: LepGood1_relIso04EA < if3(abs(LepGood1_eta)<1.479,0.0695,0.0821) && LepGood2_relIso04EA < if3(abs(LepGood2_eta)<1.479,0.0695,0.0821)
+inv mass: abs(mass_2(LepGood1_pt,LepGood1_eta,LepGood1_phi,0.5e-3,LepGood2_pt,LepGood2_eta,LepGood2_phi,0.5e-3)-90) < 20

--- a/MonoXAnalysis/python/postprocessing/postproc_batch.py
+++ b/MonoXAnalysis/python/postprocessing/postproc_batch.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     parser.add_option("-J", "--json",  dest="json", type="string", default=None, help="Select events using this JSON file")
     parser.add_option("-C", "--cut",  dest="cut", type="string", default=None, help="Cut string")
     parser.add_option("-b", "--branch-selection",  dest="branchsel", type="string", default=None, help="Branch selection")
-    parser.add_option("--friend",  dest="friend", action="store_true", default=False, help="Produce friend trees in output (current default is to produce full trees)")
+    parser.add_option("--friend",  dest="friend", action="store_true", default=True, help="Produce friend trees in output (current default is to produce full trees)")
     parser.add_option("--full",  dest="friend", action="store_false",  default=False, help="Produce full trees in output (this is the current default)")
     parser.add_option("--noout",  dest="noOut", action="store_true",  default=False, help="Do not produce output, just run modules")
     parser.add_option("--justcount",   dest="justcount", default=False, action="store_true",  help="Just report the number of selected events") 

--- a/MonoXAnalysis/python/postprocessing/scripts/changeFriendName.py
+++ b/MonoXAnalysis/python/postprocessing/scripts/changeFriendName.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import os, sys
+from glob import glob
+
+if __name__ == "__main__":
+    from optparse import OptionParser
+    parser = OptionParser(usage="%prog [options] inputDir oldPrefix newPrefix")
+    parser.add_option("-p", "--pretend", dest="pretend",   action="store_true", default=False, help="Don't run anything");
+
+    (options, args) = parser.parse_args()
+
+if len(args)<3:
+    parser.print_help()
+    sys.exit(1)
+
+(inputdir,oldPfx,newPfx)=sys.argv[1:4]
+print "Changing prefix of files from inputdir %s, from %s_ to %s_" % (inputdir,oldPfx,newPfx)
+
+for f in glob(inputdir+"/*"):
+    tokens=f.split(oldPfx)
+    name=tokens[1]
+    command = "mv %s %s" % (f,inputdir+"/"+newPfx+name)
+    print command
+    if not options.pretend: os.system(command)


### PR DESCRIPTION
1. Friend trees additions: a new friend evaluating the away jet for each lepton: save the jet pt/eta/phi for the highest pT jet among the ones with pT>30 GeV and |eta|<2.4 with DeltaR>0.7 from the lepton
2. Additions for skims to be run on top of the ntuples:
   - add a compression algorithm for skimmed files (optional, default is LZMA:9)
   - update the We skim selection so that can be used also to apply the FR and evaluate the FR (i.e. remove the met cut)
   - update the Zee skim selection to use the fixed isolation 0.4 with EA corr
   - add a FR skim using the presence of 1 awayjet with pt>30