### PR TITLE
Adding Collins-Soper angles for the generator W

### DIFF
--- a/MonoXAnalysis/python/postprocessing/examples/genFriendProducer.py
+++ b/MonoXAnalysis/python/postprocessing/examples/genFriendProducer.py
@@ -5,11 +5,66 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection 
 from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from math import *
+
+class SimpleVBoson:
+    def __init__(self,legs):
+        self.legs = legs
+        if len(legs)<2:
+            print "ERROR: making a VBoson w/ < 2 legs!"
+        self.pt1 = legs[0].Pt()
+        self.pt2 = legs[1].Pt()
+        self.dphi = self.legs[0].Phi()-self.legs[1].Phi()
+        self.deta = self.legs[0].Eta()-self.legs[1].Eta()
+        self.px1 = legs[0].Px(); self.py1 = legs[0].Py();
+        self.px2 = legs[1].Px(); self.py2 = legs[1].Py();
+    def pt(self):
+        return (self.legs[0]+self.legs[1]).Pt()
+    def y(self):
+        return (self.legs[0]+self.legs[1]).Rapidity()
+    def mt(self):
+        return sqrt(2*self.pt1*self.pt2*(1-cos(self.dphi)))
+    def ux(self):
+        return (-self.px1-self.px2)
+    def uy(self):
+        return (-self.py1-self.py2)    
+    def mll(self):
+        return sqrt(2*self.pt1*self.pt2*(cosh(self.deta)-cos(self.dphi)))
+
+class KinematicVars:
+    def __init__(self,beamE=7000):
+        self.beamE = beamE
+    def CSFrame(self,dilepton):
+        pMass = 0.938272
+        sign = np.sign(dilepton.Z())
+        proton1 = ROOT.TLorentzVector(0.,0.,sign*self.beamE,hypot(self.beamE,pMass));  proton2 = ROOT.TLorentzVector(0.,0.,-sign*self.beamE,hypot(self.beamE,pMass))
+        proton1.Boost(-dilepton.BoostVector()); proton2.Boost(-dilepton.BoostVector())
+        CSAxis = (proton1.Vect().Unit()-proton2.Vect().Unit()).Unit()
+        yAxis = (proton1.Vect().Unit()).Cross((proton2.Vect().Unit()));
+        yAxis = yAxis.Unit();
+        xAxis = yAxis.Cross(CSAxis);
+        xAxis = xAxis.Unit();
+        return (xAxis,yAxis,CSAxis)
+    def cosThetaCS(self,lplus,lminus):
+        dilep = lplus + lminus
+        boostedLep = ROOT.TLorentzVector(lminus)
+        boostedLep.Boost(-dilep.BoostVector())
+        csframe = self.CSFrame(dilep)
+        return cos(boostedLep.Angle(csframe[2]))
+    def phiCS(self,lplus,lminus):
+        dilep = lplus + lminus
+        boostedLep = ROOT.TLorentzVector(lminus)
+        boostedLep.Boost(-dilep.BoostVector())
+        csframe = self.CSFrame(dilep)
+        phi = atan2((boostedLep.Vect()*csframe[1]),(boostedLep.Vect()*csframe[0]))
+        if(phi<0): return phi + 2*ROOT.TMath.Pi()
+        else: return phi
 
 class GenQEDJetProducer(Module):
     def __init__(self,deltaR):
         self.deltaR = deltaR
         self.vars = ("pt","eta","phi","mass","pdgId")
+        self.genwvars = ("pt","eta","phi","mass","y","costcs","phics")
         if "genQEDJetHelper_cc.so" not in ROOT.gSystem.GetLibraries():
             print "Load C++ Worker"
             ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/MonoXAnalysis/python/postprocessing/helpers/genQEDJetHelper.cc+" % os.environ['CMSSW_BASE'])
@@ -26,6 +81,8 @@ class GenQEDJetProducer(Module):
         for V in self.vars:
             self.out.branch("GenLepDressed_"+V, "F", lenVar="nGenLepDressed")
             self.out.branch("GenPromptNu_"+V, "F", lenVar="nGenPromptNu")
+        for V in self.genwvars:
+            self.out.branch("genw_"+V, "F")
     def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         pass
 
@@ -68,6 +125,22 @@ class GenQEDJetProducer(Module):
         for V in self.vars:
             self.out.fillBranch("GenPromptNu_"+V, retN[V])
         self.out.fillBranch("GenPromptNu_pdgId", [pdgId for pdgId in nuPdgIds])
+
+        if len(dressedLeptons) and len(neutrinos):
+            genw = dressedLeptons[0] + neutrinos[0]
+            self.out.fillBranch("genw_pt",genw.Pt())
+            self.out.fillBranch("genw_eta",genw.Eta())
+            self.out.fillBranch("genw_phi",genw.Phi())
+            self.out.fillBranch("genw_y",genw.Rapidity())
+            self.out.fillBranch("genw_mass",genw.M())
+            kv = KinematicVars()
+            # convention for phiCS: use l- direction for W-, use neutrino for W+
+            (lplus,lminus) = (neutrinos[0],dressedLeptons[0]) if lepPdgIds[0]<0 else (dressedLeptons[0],neutrinos[0])
+            self.out.fillBranch("genw_costcs",kv.cosThetaCS(lplus,lminus))
+            self.out.fillBranch("genw_phics",kv.phiCS(lplus,lminus))
+        else:
+            for V in self.genwvars:
+                self.out.fillBranch("genw_"+V, -999)
 
         return True
 


### PR DESCRIPTION
This adds the cosTheta* and phi* for the generator W build from the dressed lepton and neutrino. 
For the phi* this convention is used:
- for the W- the lepton is used to compute the direction
- for the W+ the neutrino is used to compute the direction

this spits the output in the same friend tree where the generator dressed leptons are.
From a test on 10k Madgraph W events:

PT(W)
![image](https://user-images.githubusercontent.com/4517974/32753190-3d9c4ad0-c8cc-11e7-838b-26d7c6f1fdba.png)

Rapidity:
![image](https://user-images.githubusercontent.com/4517974/32753208-504c2916-c8cc-11e7-9947-95e789cab8c4.png)

CosTheta* (inclusive, no selection on production):
![image](https://user-images.githubusercontent.com/4517974/32753244-651beb38-c8cc-11e7-9050-b98c76f215f8.png)

Phi* (inclusive, no selection on production):
![image](https://user-images.githubusercontent.com/4517974/32753268-770e97a0-c8cc-11e7-8ba4-bce2aa5bcedd.png)

@emanca @mdunser @bendavid  Do these variables shapes for CS angles make sense?
I'll produce friend trees for the unskimmed W samples