### PR TITLE
First version of post-fit plotter

### DIFF
--- a/WMass/python/plotter/postFitPlots.py
+++ b/WMass/python/plotter/postFitPlots.py
@@ -19,165 +19,174 @@ mergeMap = {
 #    "TTGStar" : "TTZ",
 }
 
-swapMap = {
-    "ZM" : { "ZLL" : "ZNuNu" },
-    "ZE" : { "ZLL" : "ZNuNu" },
-    "WM" : { },
-    "WE" : { },
-}
+def roll1Dto2D(h1d,h2dname,plotfile,options):
+    pfile = PlotFile(plotfile,options)
+    pspecs = pfile.plots()
+    matchspec = [ p for p in pspecs if p.name == h2dname ]
+    if not matchspec: raise RuntimeError, "Error: plot %s not found" % h2dname
+    if len(matchspec)>1: print "WARNING! more than one plot matching %s. Taking the specifics from the first occurence in plotfile %s" % (h2dname,plotfile)
+    p2d = matchspec[0]
+    histo = makeHistFromBinsAndSpec("%s_%s" % (h2dname,h1d.GetName()),p2d.expr,p2d.bins,None)
+    histo.GetYaxis().SetTitle(p2d.getOption('YTitle'))
+    histo.GetXaxis().SetTitle(p2d.getOption('XTitle'))
+    histo.SetContour(100)
+    ROOT.gStyle.SetPaintTextFormat(p2d.getOption("PaintTextFormat","g"))
+    histo.SetMarkerSize(p2d.getOption("MarkerSize",1))
+    if p2d.hasOption('ZMin') and p2d.hasOption('ZMax'):
+        histo.GetZaxis().SetRangeUser(p2d.getOption('ZMin',1.0), p2d.getOption('ZMax',1.0))
+    if 'TH2' not in histo.ClassName(): raise RuntimeError, "Trying to roll the 1D histo on something that is not TH2"
+    for i in xrange(1,h1d.GetNbinsX()+1):
+        xbin = i % histo.GetNbinsX()
+        ybin = i / histo.GetNbinsX() + 1
+        val = h1d.GetBinContent(i)
+        if val>1: histo.SetBinContent(xbin,ybin,h1d.GetBinContent(i))
+    return histo
 
 options = None
 if __name__ == "__main__":
     from optparse import OptionParser
-    parser = OptionParser(usage="%prog [options] mca.txt plotfile varname mlfile region")
+    parser = OptionParser(usage="%prog [options] plotdir shapesfile varname mlfile channel plots.txt [onlyNorm]")
     addPlotMakerOptions(parser)
+    parser.add_option("--do-stack", dest="doStack", action="store_true", default=False, help="do the stack plot of all the processes and compare with data")
+    parser.add_option("--rollback2D", dest="rollBackTo2D", type='string', default=None, help="roll back to 2D. It uses the option variable, which has to be in plots.txt")
     (options, args) = parser.parse_args()
-    region = args[4];
-    options.path = "/data1/emanuele/monox/TREES_MET_80X_V4/" if region in ['SR','ZM','WM'] else "/data1/emanuele/monox/TREES_1LEP_80X_V4/"
-    if "HOSTNAME" in os.environ:  
-        if os.environ["HOSTNAME"] == "pccmsrm29.cern.ch":
-            options.path = "/u2/emanuele/TREES_MET_80X_V4/" if region in ['SR','ZM','WM'] else "/u2/emanuele/TREES_1LEP_80X_V4/"
-    options.lumi = 24.47
-    mcap = MCAnalysis(args[0],options)
-    basedir = dirname(args[1]);
+    options.path = ["/data1/emanuele/wmass/TREES_1LEP_80X_V3_WENUSKIM_V3/"]
+    options.lumi = 35.9
+    basedir = args[0]
     infile = ROOT.TFile(args[1]);
     var    = args[2];
     mlfile = ROOT.TFile(args[3]);
+    channel = args[4];
+    plotfile = args[5];
+    onlynorm = (len(args)>6 and args[6]=='onlyNorm')
     ROOT.gROOT.ProcessLine(".x /afs/cern.ch/user/g/gpetrucc/cpp/tdrstyle.cc(0)")
     ROOT.gROOT.ForceStyle(False)
     ROOT.gStyle.SetErrorX(0.5)
     ROOT.gStyle.SetOptStat(0)
     ROOT.gStyle.SetPaperSize(20.,25.)
-    for O,MLD in ("prefit","prefit"), ("postfit_b","fit_b"), ("postfit_s","fit_s"):
+    for O,MLD in ("prefit","prefit"), ("postfit_s","fit_s"):
+      print "NOW PLOTTING ",O," ..."
+      normset = mlfile.Get("norm_"+MLD)
       mldir  = mlfile.GetDirectory("shapes_"+MLD);
       if not mldir: raise RuntimeError, mlfile
-      outfile = ROOT.TFile(basedir + "/"+O+"_" + basename(args[2]), "RECREATE")
-      processes = [p for p in reversed(mcap.listBackgrounds())] + mcap.listSignals()
-
-      hdata = infile.Get(var+"_data")
+      outfile = ROOT.TFile(basedir + "/"+O+".root", "RECREATE")
+      processes = ['_'.join(p.GetName().split('_')[1:]) for p in infile.GetListOfKeys()]
+      #print "prima ",processes,"\n"
+      processes = filter(lambda x: not re.match('(.*Up|.*Down|data\_obs)',x),processes)
+      #print "dopo: ",processes
+      hdata = infile.Get(var+"_data_obs")
+      htot = hdata.Clone(var+"_total")
+      htot.Reset()
       stack = ROOT.THStack(var+"_stack","")
       plots = {'data':hdata}
       if options.poisson:
             pdata = getDataPoissonErrors(hdata, False, True)
             hdata.poissonGraph = pdata ## attach it so it doesn't get deleted
-      argset =  mlfile.Get("norm_"+MLD)
       for p in processes:
-        pout = (swapMap[region])[p] if p in swapMap[region] else p
-        rvar = argset.find("%s/%s" % (region,pout))
-        if not rvar: continue
-        h = infile.Get(var+"_"+p)
+        pout = mergeMap[p] if p in mergeMap else p
+        h = infile.Get(var+"_"+pout)
         if not h: 
-            print "Missing %s_%s for %s" % (var,p, p)
+            print "Missing %s_%s for %s" % (var,pout, p)
             continue
         h = h.Clone(var+"_"+p)
         h.SetDirectory(0)
-        hpf = mldir.Get("%s/%s" % (region,pout))
-        hpf_scale = rvar.getVal()/hpf.Integral()
+        hpf = mldir.Get("%s/%s" % (channel,p))
+        hpn = normset.find("%s/%s" % (channel,p))
         if not hpf: 
-            if h.Integral() > 0 and p not in swapMap[region]: raise RuntimeError, "Could not find post-fit shape for %s" % p
+            if h.Integral() > 0 and p not in mergeMap: raise RuntimeError, "Could not find post-fit shape for %s" % p
             continue
-        
-        for b in xrange(1, h.GetNbinsX()+1):
-            h.SetBinContent(b, hpf.GetBinContent(b)*hpf.GetBinWidth(b))
-            h.SetBinError(b, hpf.GetBinError(b)*hpf.GetBinWidth(b))
-        plots[p] = h
-        h.SetName(var+"_"+p)
-        stack.Add(h)
-
-      dump = open("%s/%s_%s.txt" % (basedir,O,var), "w")
-      pyields = { "background":[0,0], "data":[plots["data"].Integral(), plots["data"].Integral()]}
-      #argset.Print("V")
-      for p in processes:
-        pout = (swapMap[region])[p] if p in swapMap[region] else p
-        #h = infile.Get(var+"_"+pout)
-        #if not h: continue
-        if pout not in pyields: pyields[pout] = [0,0]
-        rvar = argset.find("%s/%s" % (region,pout))
-        if not rvar: continue
-        pyields[pout][0] += rvar.getVal()       
-        pyields[pout][1] += rvar.getError() if pout == "ttH" else rvar.getError()**2
-        if not mcap.isSignal(p): 
-            pyields["background"][0] += rvar.getVal()       
-            pyields["background"][1] += rvar.getError()**2
-      for p in pyields.iterkeys():
-        if p != "ttH": pyields[p][1] = sqrt(pyields[p][1])
-      maxlen = max([len(mcap.getProcessOption(p,'Label',p)) for p in mcap.listSignals(allProcs=True) + mcap.listBackgrounds(allProcs=True)]+[7])
-      fmt    = "%%-%ds %%9.2f +/- %%9.2f\n" % (maxlen+1)
-      for p in mcap.listSignals(allProcs=True) + mcap.listBackgrounds(allProcs=True) + ["background","data"]:
-        if p not in pyields: continue
-        if p in ["background","data"]: dump.write(("-"*(maxlen+45))+"\n");
-        dump.write(fmt % (mcap.getProcessOption(p,'Label',p) if p not in ["background","data"] else p.upper(), pyields[p][0], pyields[p][1]))
-      dump.close() 
-
-      htot = hdata.Clone(var+"_total")
-      htotpf = mldir.Get(region+"/total")
-      scale_htotpf = (pyields["background"][0] + sum([pyields[p][0] for p in mcap.listSignals(allProcs=True)]))/htotpf.Integral()
-      hbkg = hdata.Clone(var+"_total_background")
-      hbkgpf = mldir.Get(region+"/total_background")
-      scale_hbkgpf = pyields["background"][0]/hbkgpf.Integral()
-      for b in xrange(1, h.GetNbinsX()+1):
-          htot.SetBinContent(b, htotpf.GetBinContent(b)*htotpf.GetBinWidth(b))
-          htot.SetBinError(b, htotpf.GetBinError(b)*htotpf.GetBinWidth(b))
-          hbkg.SetBinContent(b, hbkgpf.GetBinContent(b)*hbkgpf.GetBinWidth(b))
-          hbkg.SetBinError(b, hbkgpf.GetBinError(b)*hbkgpf.GetBinWidth(b))
-      for h in plots.values() + [htot]:
-         outfile.WriteTObject(h)
+        if not hpn:
+            if h.Integral() > 0 and p not in mergeMap: raise RuntimeError, "Could not find post-fit normalization for %s" % p
+        if onlynorm:
+            prev_integral = h.Integral()
+            scale_content = hpn.getVal()/prev_integral
+            for b in xrange(1, h.GetNbinsX()+1):
+                h.SetBinContent(b, h.GetBinContent(b)*scale_content)
+                h.SetBinError(b, h.GetBinError(b)*scale_content)
+        else:
+            for b in xrange(1, h.GetNbinsX()+1):
+                h.SetBinContent(b, hpf.GetBinContent(b))
+                h.SetBinError(b, hpf.GetBinError(b))
+        print 'adding',p,'with norm',h.Integral()
+        if pout in plots:
+            plots[pout].Add(h)
+            htot.Add(h)
+        else: 
+            plots[pout] = h
+            htot.Add(h)
+            h.SetName(var+"_"+pout)
+            stack.Add(h)
+      htotpf = mldir.Get(channel+"/total")
+#      hbkg = hdata.Clone(var+"_total_background")
+#      hbkgpf = mldir.Get(channel+"/total_background")
+      print 'tot norm is ',htot.Integral()
+      if onlynorm:
+          hpn = normset.find("%s/total" % channel)
+          rel_error = hpn.getError()/hpn.getVal()
+          print rel_error
+          for b in xrange(1, htot.GetNbinsX()+1):
+              htot.SetBinError(b, hypot(htot.GetBinError(b),htot.GetBinContent(b)*rel_error))
+      else:
+          for b in xrange(1, h.GetNbinsX()+1):
+              htot.SetBinContent(b, htotpf.GetBinContent(b))
+              htot.SetBinError(b, htotpf.GetBinError(b))
+#          hbkg.SetBinContent(b, hbkgpf.GetBinContent(b))
+#          hbkg.SetBinError(b, hbkgpf.GetBinError(b))
       doRatio = True
       htot.GetYaxis().SetRangeUser(0, 1.8*max(htot.GetMaximum(), hdata.GetMaximum()))
       ## Prepare split screen
-      c1 = ROOT.TCanvas("c1", "c1", 600, 750); c1.Draw()
-      c1.SetWindowSize(600 + (600 - c1.GetWw()), (750 + (750 - c1.GetWh())));
+      plotformat = (1200,600) if options.rollBackTo2D else (600,600)
+      c1 = ROOT.TCanvas("c1", "c1", plotformat[0], plotformat[1]); c1.Draw()
+      c1.SetWindowSize(plotformat[0] + (plotformat[0] - c1.GetWw()), (plotformat[1] + (plotformat[1] - c1.GetWh())));
       p1 = ROOT.TPad("pad1","pad1",0,0.29,1,0.99);
       p1.SetBottomMargin(0.03);
       p1.Draw();
-      p2 = ROOT.TPad("pad2","pad2",0,0,1,0.31);
-      p2.SetTopMargin(0);
-      p2.SetBottomMargin(0.3);
-      p2.SetFillStyle(0);
-      p2.Draw();
-      p1.cd();
-      ## Draw absolute prediction in top frame
-      htot.Draw("HIST")
-      #htot.SetLabelOffset(9999.0);
-      #htot.SetTitleOffset(9999.0);
-      stack.Draw("HIST F SAME")
-      if options.showMCError:
-          totalError = doShadedUncertainty(htot)
-      if options.poisson:
-        hdata.poissonGraph.Draw("PZ SAME")
+      if options.doStack:
+          p2 = ROOT.TPad("pad2","pad2",0,0,1,0.31);
+          p2.SetTopMargin(0);
+          p2.SetBottomMargin(0.3);
+          p2.SetFillStyle(0);
+          p2.Draw();
+          p1.cd();
+          ## Draw absolute prediction in top frame
+          htot.Draw("HIST")
+          #htot.SetLabelOffset(9999.0);
+          #htot.SetTitleOffset(9999.0);
+          stack.Draw("HIST F SAME")
+          if options.showMCError:
+              totalError = doShadedUncertainty(htot)
+          if options.poisson:
+            hdata.poissonGraph.Draw("PZ SAME")
+          else:
+            hdata.Draw("E SAME")
+          htot.Draw("AXIS SAME")
       else:
-        hdata.Draw("E SAME")
-      htot.Draw("AXIS SAME")
-#      hSigOutline = plots["ttH"].Clone()
-#      hSigOutline.SetLineWidth(5)
-#      hSigOutline.SetLineStyle(7)
-#      hSigOutline.SetLineColor(205)
-#      hSigOutline.SetFillColor(0)
-#      hSigOutline.SetFillStyle(1)
-#      hSigOutline.Scale(5)
-#      hSigOutline.Draw("HIST SAME")
-      leg = doLegend(plots,mcap,corner='TR',textSize=0.045,cutoff=0.0001)
-      leg.SetHeader({'prefit': "Pre-fit", "postfit_b": "Post-fit, #mu = 1", "postfit_s": "Post-fit, #hat{#mu}"}[O]+"\n")
-      leg.SetLineColor(0)
-#      leg.AddEntry(hSigOutline, "ttH x 5", "L")
-#      lspam = "CMS Preliminary" #, options.lspam
-#      if "2lss" in args[2] and "/em/" in args[2]:
-#            lspam += r", e^{#pm}#mu^{#pm} region"
-#      if "2lss" in args[2] and "/ee/" in args[2]:
-#            lspam += r", e^{#pm}e^{#pm} region"
-#      if "2lss" in args[2] and "/mumu/" in args[2]:
-#            lspam += r", #mu^{#pm}#mu^{#pm} region"
-#      if "/3l" in args[2]:
-#            lspam += ", 3l region"
-#      if "/4l" in args[2]:
-#            lspam += ", 4l region"
-      doTinyCmsPrelim(hasExpo = False,textSize=(0.045 if doRatio else 0.033), xoffs=-0.03,
-                      textLeft = options.lspam, textRight = options.rspam, lumi = options.lumi)
+          for h in plots.values() + [htot]:
+              if options.rollBackTo2D:
+                  c1.SetRightMargin(0.20)
+                  h2d = roll1Dto2D(h,options.rollBackTo2D,plotfile,options)
+                  h2d.Draw("COLZ0")
+                  outfile.WriteTObject(h2d)
+              else:
+                  g.GetXaxis().SetTitle("rolled bin number")
+                  h.Draw("HIST")
+                  if options.showMCError:
+                      totalError = doShadedUncertainty(p)
+                  outfile.WriteTObject(h)
+              doTinyCmsPrelim(hasExpo = False,textSize=(0.045 if doRatio else 0.033), xoffs=-0.03,
+                              textLeft = options.lspam, textRight = options.rspam, lumi = options.lumi)
+              
+              c1.cd()
+              c1.Print("%s/%s_%s.png" % (basedir,O,h.GetName()))
+              c1.Print("%s/%s_%s.pdf" % (basedir,O,h.GetName()))              
       ## Draw relaive prediction in the bottom frame
-      p2.cd() 
-      rdata,rnorm,rnorm2,rline = doRatioHists(PlotSpec(var,var,"",{}),plots,htot, htot, maxRange=options.maxRatioRange, fitRatio=options.fitRatio)
-      c1.cd()
-      c1.Print("%s/%s_%s.png" % (basedir,O,var))
-      c1.Print("%s/%s_%s.pdf" % (basedir,O,var))
+      if options.doStack:
+          p2.cd() 
+          rdata,rnorm,rnorm2,rline = doRatioHists(PlotSpec(var,var,"",{}), plots, htot, htot, maxRange=options.maxRatioRange, fixRange=options.fixRatioRange,
+                                                  fitRatio=options.fitRatio, errorsOnRef=options.errorBandOnRatio,
+                                                  ratioNums=options.ratioNums, ratioDen=options.ratioDen, ylabel="Data/pred.", doWide=options.wideplot, showStatTotLegend=False)
+          c1.cd()
+          c1.Print("%s/%s_%s.png" % (basedir,O,var))
+          c1.Print("%s/%s_%s.pdf" % (basedir,O,var))
       del c1
       outfile.Close()

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_plots.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_plots.txt
@@ -22,4 +22,4 @@ trkmt: mt_2(met_trkPt,met_trkPhi,LepGood1_pt,LepGood1_phi) : 35,40,110 ; XTitle=
 nVert: nVert : 20,0.5,40.5; XTitle="number of vertices", Legend='TR', IncludeOverflows=True 
 rho: rho : 20,0.5,40.5; XTitle="#rho", Legend='TR', IncludeOverflows=True 
 
-etaPt   : ptCorr(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_r9,run,isData)*residualScale(LepGood1_pt,LepGood1_eta,isData)\:LepGood1_eta  : 48,-2.1,2.1,20,30.,50. ; XTitle="#eta^{e}", YTitle="p_{T}^{e} [GeV]"
+etaPt   : ptElFull(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_r9,run,isData,evt)\:LepGood1_eta : 48,-2.5,2.5,20,30.,50. ; XTitle="#eta^{e}", YTitle="p_{T}^{e} [GeV]"


### PR DESCRIPTION
A first version of pre-fit and post-fit version to debug the inputs and check the fit output.
For the time being it takes:
- the shapes from the 1D-unrolled shapes used as inputs of the datacards
- the normalizations (pre-fit and post-fit) of the output of combine FitDiagnostics (ex MaximumLikelihoodFit) RooArgSet
- eventually the 2D variable from the plot.txt to roll back the 1D to the 2D

and it spits out either the unrolled 1D or the 2D with pre-fit and post fit normalizations for all the components separately. 

E.g. some of the outputs for one W Y bin:

![image](https://user-images.githubusercontent.com/4517974/34168437-cfe06992-e4e4-11e7-9739-bb72dba58f47.png)

to run it eg.

`python postFitPlots.py plots/fit Wp_el_shapes.root x fitDiagnostics_Wp_el.root Wp_el w-helicity-13TeV/wmass_e/wenu_plots.txt --rollback2D etaPt`

i.e. 

` %prog [options] plotdir shapesfile varname mlfile channel plots.txt `