### PR TITLE
Electrons friends improvements

### DIFF
--- a/WMass/python/plotter/postFitPlots.py
+++ b/WMass/python/plotter/postFitPlots.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     parser.add_option("--do-stack", dest="doStack", action="store_true", default=False, help="do the stack plot of all the processes and compare with data")
     parser.add_option("--rollback2D", dest="rollBackTo2D", type='string', default=None, help="roll back to 2D. It uses the option variable, which has to be in plots.txt")
     (options, args) = parser.parse_args()
-    options.path = ["/data1/emanuele/wmass/TREES_1LEP_80X_V3_WENUSKIM_V3/"]
+    #options.path = ["/data1/emanuele/wmass/TREES_1LEP_80X_V3_WENUSKIM_V3/"]
     options.lumi = 35.9
     basedir = args[0]
     infile = ROOT.TFile(args[1]);
@@ -168,7 +168,7 @@ if __name__ == "__main__":
                   h2d.Draw("COLZ0")
                   outfile.WriteTObject(h2d)
               else:
-                  g.GetXaxis().SetTitle("rolled bin number")
+                  h.GetXaxis().SetTitle("rolled bin number")
                   h.Draw("HIST")
                   if options.showMCError:
                       totalError = doShadedUncertainty(p)

--- a/WMass/python/plotter/symmetrizeMatrix.py
+++ b/WMass/python/plotter/symmetrizeMatrix.py
@@ -3,6 +3,8 @@ import ROOT
 ROOT.gROOT.SetBatch()
 ROOT.gStyle.SetOptStat(0)
 
+ROOT.gStyle.SetPalette(1)
+
 infile = ROOT.TFile('multidimfit.root', 'read')
 
 fitresult = infile.Get('fit_mdf')
@@ -12,7 +14,8 @@ h2_corr = fitresult.correlationHist()
 c = ROOT.TCanvas()
 
 h2_corr.Draw('colz')
-c.SaveAs('~/www/private/w-helicity-13TeV/correlationMatrix_original_2017-12-14.pdf')
+c.SaveAs('./correlationMatrix_FR1p01_otherbkgnuis_original.pdf')
+c.SaveAs('./correlationMatrix_FR1p01_otherbkgnuis_original.png')
 
 bins = {}
 labels = []
@@ -20,7 +23,7 @@ labels = []
 for ix in range(1,h2_corr.GetXaxis().GetNbins()+1):
     labels.append(h2_corr.GetXaxis().GetBinLabel(ix))
 
-h2_new = h2_corr.Clone('correlationMatrix')
+h2_new = h2_corr.Clone('correlationMatrix_FR1p01_otherbkgnuis')
 h2_new.Reset()
 
 #l_sorted = sorted(labels, key = lambda x: int(x.split('_')[-1]) if not (x =='Wpt' or x =='longNuisance') else x[-1] )
@@ -32,7 +35,6 @@ h2_new.Reset()
 
 
 l_sorted_new = [
-'norm_Wp_right_Wp_el_Ybin_2_13',
 'norm_Wp_right_Wp_el_Ybin_3_12',
 'norm_Wp_right_Wp_el_Ybin_4_11',
 'norm_Wp_right_Wp_el_Ybin_5_10',
@@ -43,17 +45,20 @@ l_sorted_new = [
 'norm_Wp_left_Wp_el_Ybin_5_10',
 'norm_Wp_left_Wp_el_Ybin_4_11',
 'norm_Wp_left_Wp_el_Ybin_3_12',
-'norm_Wp_left_Wp_el_Ybin_2_13',
 'CMS_We_FRe_norm',
 'CMS_We_VV',
-'CMS_We_elescale', 
-'CMS_We_lepEff',  
+'CMS_We_elescale',
+'CMS_We_lepEff',
 'lumi_8TeV',   
 'norm_long_Wp_el'   ]
 
 
 for il,l in enumerate(l_sorted_new):
-    new_l = l.lstrip('norm_').replace('right','WR ').replace('left','WL ')
+    new_l = l.lstrip('norm_').replace('right','WR').replace('left','WL').replace('Ybin_','')
+    new_l = new_l.replace('Wp_WL_Wp','WpL')
+    new_l = new_l.replace('Wp_WR_Wp','WpR')
+    new_l = new_l.replace('Wp_WL_Wp','WpL')
+    new_l = new_l.replace('Wp_WR_Wp','WpR')
     #print(new_l)
     h2_new.GetXaxis().SetBinLabel(il+1, new_l)
     h2_new.GetYaxis().SetBinLabel(il+1, new_l)
@@ -64,7 +69,8 @@ for il,l in enumerate(l_sorted_new):
         h2_new.SetBinContent(il+1, il2+1, h2_corr.GetBinContent(binx, biny))
 
 h2_new.Draw('colz')
-c.SaveAs('~/www/private/w-helicity-13TeV/correlationMatrix_new_2017-12-14.pdf')
+c.SaveAs('./correlationMatrix_FR1p01_otherbkgnuis_new.pdf')
+c.SaveAs('./correlationMatrix_FR1p01_otherbkgnuis_new.png')
 
 
 #print(labels)

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponents.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponents.py
@@ -5,11 +5,11 @@ import ROOT
 import sys,os,re
 
 from optparse import OptionParser
-parser = OptionParser(usage="%prog [options] shapes.root combinedcard.txt cards/card*.txt")
+parser = OptionParser(usage="%prog [options] cards/card*.txt")
 parser.add_option("-m","--merge-root", dest="mergeRoot", default=False, action="store_true", help="Merge the root files with the inputs also")
 parser.add_option("-b","--bin", dest="bin", default="ch1", type="string", help="name of the bin")
 parser.add_option("-c","--constrain-rates", dest="constrainRateParams", type="string", default="0,1,2", help="add constraints on the rate parameters of (comma-separated list of) rapidity bins. Give only the left ones (e.g. 1 will constrain 1 with n-1 ")
-parser.add_option("-l","--long-lnN", dest="longLnN", default=None, help="add a common lnN constraint to all longitudinal components")
+parser.add_option("-l","--long-lnN", dest="longLnN", type="float", default=None, help="add a common lnN constraint to all longitudinal components")
 (options, args) = parser.parse_args()
 
 outfile=options.bin+"_shapes.root"
@@ -121,14 +121,14 @@ if options.constrainRateParams:
         for i in xrange(len(hel)/2):
             pfx = '_'.join(hel[i].split('_')[:-1])
             sfx = (hel[i].split('_')[-1],hel[-i-1].split('_')[-1])
-            param_range = '[0.95,1.05]' if sfx[0] in bins_to_constrain else '[0.50,1.50]'
+            param_range = '[0.95,1.05]' if sfx[0] in bins_to_constrain else '[0.80,1.20]'
             combinedCard.write('norm_%s_%s_%-5s   rateParam * %s_%-5s    1 %s\n' % (pfx,sfx[0],sfx[1],pfx,sfx[0],param_range))
             combinedCard.write('norm_%s_%s_%-5s   rateParam * %s_%-5s    1 %s\n' % (pfx,sfx[0],sfx[1],pfx,sfx[1],param_range))
             POIs.append('norm_%s_%s_%s' % (pfx,sfx[0],sfx[1]))
     if not options.longLnN:
         for i in xrange(len(signal_0)/2):
             sfx = signal_0[i].split('_')[-1]
-            param_range = '[0.95,1.05]' if sfx in bins_to_constrain else '[0.50,1.50]'
+            param_range = '[0.95,1.05]' if sfx in bins_to_constrain else '[0.80,1.20]'
             combinedCard.write('norm_%-5s   rateParam * %-5s    1 %s\n' % (signal_0[i],signal_0[i],param_range))
             combinedCard.write('norm_%-5s   rateParam * %-5s    1 %s\n' % (signal_0[-1-i],signal_0[-1-i],param_range))
             POIs.append('norm_%s' % signal_0[i])
@@ -138,8 +138,7 @@ print "merged datacard in ",cardfile
 
 ws = "%s_ws.root" % options.bin
 txt2wsCmd = "text2workspace.py %s_card.txt -o %s --X-allow-no-signal " % (options.bin,ws)
-os.system(txt2wsCmd)
-print "workspace in %s_ws.root." % options.bin
+print txt2wsCmd
 
 print "combine -M FitDiagnostics %s --saveShapes --saveWithUncertainties -t -1 --expectSignal=1 -m 999 --redefineSignalPOIs %s" % (ws,','.join(POIs))
 print "combine -M MultiDimFit %s --saveFitResult -t -1 --expectSignal=1 -m 999 --redefineSignalPOIs %s" % (ws,','.join(POIs))

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
@@ -1,11 +1,11 @@
 # signal from the weighted uncut sample
-Wp_long  : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_0_plus.txt", Label="W+ long"
-Wp_left  : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kBlue-1   , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_L_plus.txt", Label="W+ left"
-Wp_right : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGreen+1  , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_R_plus.txt", Label="W+ right"
+Wplus_long  : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_0_plus.txt", Label="W+ long"
+Wplus_left  : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kBlue-1   , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_L_plus.txt", Label="W+ left"
+Wplus_right : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGreen+1  , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_R_plus.txt", Label="W+ right"
 
-Wm_long  : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kYellow+1 , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_0_minus.txt", Label="W- long"
-Wm_left  : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kViolet-1 , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_L_minus.txt", Label="W- left"
-Wm_right : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kAzure+1  , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_R_minus.txt", Label="W- right"
+Wminus_long  : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kYellow+1 , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_0_minus.txt", Label="W- long"
+Wminus_left  : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kViolet-1 , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_L_minus.txt", Label="W- left"
+Wminus_right : WJetsToLNu_NoSkim_part* : 3.*20508.9    : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kAzure+1  , FakeRate="w-helicity-13TeV/fractionReweighting/reweighting_R_minus.txt", Label="W- right"
 
 Z    : DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
 
@@ -28,19 +28,19 @@ incl_datafakes: + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data.t
 incl_data : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data.txt"
 
 # electron scale systematics 
-Wp_long_elescale_Up   : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_0_plus_lepUp.txt", Label="W+ long lep scale Up", SkipMe=True 
-Wp_left_elescale_Up   : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_L_plus_lepUp.txt", Label="W+ left lep scale Up", SkipMe=True 
-Wp_right_elescale_Up  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_plus_lepUp.txt", Label="W+ right lep scale Up", SkipMe=True 
-Wm_long_elescale_Up   : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_0_minus_lepUp.txt", Label="W- long lep scale Up", SkipMe=True 
-Wm_left_elescale_Up   : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_L_minus_lepUp.txt", Label="W- left lep scale Up", SkipMe=True 
-Wm_right_elescale_Up  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_minus_lepUp.txt", Label="W- right lep scale Up", SkipMe=True 
+Wplus_long_elescale_Up   : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_0_plus_lepUp.txt", Label="W+ long lep scale Up", SkipMe=True 
+Wplus_left_elescale_Up   : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_L_plus_lepUp.txt", Label="W+ left lep scale Up", SkipMe=True 
+Wplus_right_elescale_Up  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_plus_lepUp.txt", Label="W+ right lep scale Up", SkipMe=True 
+Wminus_long_elescale_Up   : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_0_minus_lepUp.txt", Label="W- long lep scale Up", SkipMe=True 
+Wminus_left_elescale_Up   : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_L_minus_lepUp.txt", Label="W- left lep scale Up", SkipMe=True 
+Wminus_right_elescale_Up  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_minus_lepUp.txt", Label="W- right lep scale Up", SkipMe=True 
 
-Wp_long_elescale_Dn  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_0_plus_lepDn.txt", Label="W+ long lep scale Dn", SkipMe=True 
-Wp_left_elescale_Dn  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_L_plus_lepDn.txt", Label="W+ left lep scale Dn", SkipMe=True 
-Wp_right_elescale_Dn : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_plus_lepDn.txt", Label="W+ right lep scale Dn", SkipMe=True 
-Wm_long_elescale_Dn  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_0_minus_lepDn.txt", Label="W- long lep scale Dn", SkipMe=True 
-Wm_left_elescale_Dn  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_L_minus_lepDn.txt", Label="W- left lep scale Dn", SkipMe=True 
-Wm_right_elescale_Dn : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_minus_lepDn.txt", Label="W- right lep scale Dn", SkipMe=True 
+Wplus_long_elescale_Dn  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_0_plus_lepDn.txt", Label="W+ long lep scale Dn", SkipMe=True 
+Wplus_left_elescale_Dn  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_L_plus_lepDn.txt", Label="W+ left lep scale Dn", SkipMe=True 
+Wplus_right_elescale_Dn : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge>0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_plus_lepDn.txt", Label="W+ right lep scale Dn", SkipMe=True 
+Wminus_long_elescale_Dn  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_0_minus_lepDn.txt", Label="W- long lep scale Dn", SkipMe=True 
+Wminus_left_elescale_Dn  : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_L_minus_lepDn.txt", Label="W- left lep scale Dn", SkipMe=True 
+Wminus_right_elescale_Dn : WJetsToLNu_NoSkim_part* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 ; FillColor=ROOT.kGray+1   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_minus_lepDn.txt", Label="W- right lep scale Dn", SkipMe=True 
 
 # recoil systematics
 #incl_ewkmc_recoil_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-ewkmc-helicity.txt", FakeRate="w-helicity-13TeV/wmass_e/fr-recoilUp.txt", SkipMe=True, PostFix="_recoil_Up" 

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/skim_wenu.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/skim_wenu.txt
@@ -1,5 +1,5 @@
 alwaystrue: 1
 trigger: HLT_SingleEl==1
 one reco el: nLepGood==1 && abs(LepGood1_pdgId)==11
-el acceptance: LepGood1_pt > 25 && abs(LepGood1_eta)<2.5
+el acceptance: LepGood1_pt > 30 && abs(LepGood1_eta)<2.5
 el HLT-safe ID: LepGood1_hltId==1

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
@@ -1,8 +1,8 @@
 # luminosity
-lumi_8TeV              : W.*|Z|Top|DiBosons: .* : 1.026
+lumi_8TeV              : W.*|TauDecaysW|Z|Top|DiBosons: .* : 1.026
 
 # lepton efficiencies
-CMS_We_lepEff   : W.*|Z|Top|DiBosons: .* : 1.01
+CMS_We_lepEff   : W.*|TauDecaysW|Z|Top|DiBosons: .* : 1.01
 
 # Diboson backgrounds 
 CMS_We_VV : DiBosons : .* : 1.16 

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
@@ -1,8 +1,8 @@
 # luminosity
-lumi_8TeV              : W_.*|Z|Top|DiBosons: .* : 1.026
+lumi_8TeV              : W.*|Z|Top|DiBosons: .* : 1.026
 
 # lepton efficiencies
-CMS_We_lepEff   : W.*|Z|Top|DiBosons: .* : 1.10
+CMS_We_lepEff   : W.*|Z|Top|DiBosons: .* : 1.01
 
 # Diboson backgrounds 
 CMS_We_VV : DiBosons : .* : 1.16 

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_plots.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_plots.txt
@@ -22,4 +22,5 @@ trkmt: mt_2(met_trkPt,met_trkPhi,LepGood1_pt,LepGood1_phi) : 35,40,110 ; XTitle=
 nVert: nVert : 20,0.5,40.5; XTitle="number of vertices", Legend='TR', IncludeOverflows=True 
 rho: rho : 20,0.5,40.5; XTitle="#rho", Legend='TR', IncludeOverflows=True 
 
-etaPt   : ptElFull(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_r9,run,isData,evt)\:LepGood1_eta : 48,-2.5,2.5,20,30.,50. ; XTitle="#eta^{e}", YTitle="p_{T}^{e} [GeV]"
+#etaPt   : ptElFull(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_r9,run,isData,evt)\:LepGood1_eta : 48,-2.5,2.5,20,30.,50. ; XTitle="#eta^{e}", YTitle="p_{T}^{e} [GeV]"
+etaPt   : ptElFull(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_r9,run,isData,evt)\:LepGood1_eta : 24,-2.5,2.5,20,30.,50. ; XTitle="#eta^{e}", YTitle="p_{T}^{e} [GeV]"

--- a/WMass/python/postprocessing/README.md
+++ b/WMass/python/postprocessing/README.md
@@ -53,4 +53,10 @@ The output branches should be filled calling the `fillBranch(branchname, value)`
 ## Typical use-cases:
 These examples run the lepton scale-factors and the PU-reweighting modules and put the output in friend trees.
 
-`python postproc.py test_output /eos/cms/store/cmst3/user/emanuele/wmass/TREES_1LEP_80X_V2_nano/QCD_Pt20to30_EMEnriched/treeProducerWMass/tree.root -I CMGTools.MonoXAnalysis.postprocessing.examples.lepSFProducer lepSF -I CMGTools.MonoXAnalysis.postprocessing.examples.puWeightProducer puWeight --friend`
+`python postproc.py test_output /eos/cms/store/cmst3/user/emanuele/wmass/TREES_1LEP_80X_V2_nano/QCD_Pt20to30_EMEnriched/treeProducerWMass/tree.root -I CMGTools.WMass.postprocessing.examples.lepSFProducer lepSF -I CMGTools.WMass.postprocessing.examples.puWeightProducer puWeight --friend`
+
+Typically one wants to run on all datasets splitting the processing in a number of batch jobs. To do this for example:
+`python postproc_batch.py -q 8nh ../plotter/TREES_1LEP_80X_V3/ friends --friend --log friends_log`
+
+To test interactively 30k events for one dataset:
+`python postproc_batch.py ../plotter/TREES_1LEP_80X_V3/ friends --friend --log friends_log -d DYJetsToLL_M50_part1 -c 0 -N 30000`

--- a/WMass/python/postprocessing/examples/collectionMerger.py
+++ b/WMass/python/postprocessing/examples/collectionMerger.py
@@ -3,8 +3,8 @@ import numpy as np
 import itertools
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from CMGTools.WMass.postprocessing.framework.datamodel import Collection
+from CMGTools.WMass.postprocessing.framework.eventloop import Module
 _rootLeafType2rootBranchType = { 'UChar_t':'b', 'Char_t':'B', 'UInt_t':'i', 'Int_t':'I', 'Float_t':'F', 'Double_t':'D', 'ULong64_t':'l', 'Long64_t':'L', 'Bool_t':'O' }
 
 class collectionMerger(Module):

--- a/WMass/python/postprocessing/examples/eventRecoilAnalyzer.py
+++ b/WMass/python/postprocessing/examples/eventRecoilAnalyzer.py
@@ -4,8 +4,8 @@ import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 from math import *
 
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection,Object
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from CMGTools.WMass.postprocessing.framework.datamodel import Collection,Object
+from CMGTools.WMass.postprocessing.framework.eventloop import Module
 from PhysicsTools.HeppyCore.utils.deltar import deltaR,deltaPhi
  
 class VisibleVectorBoson():

--- a/WMass/python/postprocessing/examples/example_postproc.py
+++ b/WMass/python/postprocessing/examples/example_postproc.py
@@ -3,7 +3,7 @@ import os, sys
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 from importlib import import_module
-from CMGTools.MonoXAnalysis.postprocessing.framework.postprocessor import PostProcessor
+from CMGTools.WMass.postprocessing.framework.postprocessor import PostProcessor
 
 from  mhtProducer import *
 p=PostProcessor(".",["../../../../NanoAOD/test/lzma.root"],"Jet_pt>150","keep_and_drop.txt",[mht()])

--- a/WMass/python/postprocessing/examples/genFriendProducer.py
+++ b/WMass/python/postprocessing/examples/genFriendProducer.py
@@ -3,8 +3,8 @@ import os
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection 
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from CMGTools.WMass.postprocessing.framework.datamodel import Collection 
+from CMGTools.WMass.postprocessing.framework.eventloop import Module
 from PhysicsTools.HeppyCore.utils.deltar import deltaPhi
 from math import *
 
@@ -77,7 +77,7 @@ class GenQEDJetProducer(Module):
         self.genwvars = ("charge","pt","eta","phi","mass","mt","y","costcs","phics","costcm","decayId")
         if "genQEDJetHelper_cc.so" not in ROOT.gSystem.GetLibraries():
             print "Load C++ Worker"
-            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/MonoXAnalysis/python/postprocessing/helpers/genQEDJetHelper.cc+" % os.environ['CMSSW_BASE'])
+            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/WMass/python/postprocessing/helpers/genQEDJetHelper.cc+" % os.environ['CMSSW_BASE'])
         else:
             print "genQEDJetHelper_cc.so found in ROOT libraries"
         self._worker = ROOT.GenQEDJetHelper(deltaR)

--- a/WMass/python/postprocessing/examples/jecUncertProducer.py
+++ b/WMass/python/postprocessing/examples/jecUncertProducer.py
@@ -3,13 +3,13 @@ import os
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection 
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from CMGTools.WMass.postprocessing.framework.datamodel import Collection 
+from CMGTools.WMass.postprocessing.framework.eventloop import Module
 
 class jecUncertProducer(Module):
     def __init__(self,globalTag,uncerts=["Total"],jetFlavour="AK4PFchs"):
 	self.uncerts=[(x,"Jet_jecUncert%s"%x) for x in uncerts]
-        self.unc_factorized_path = "%s/%s_UncertaintySources_%s.txt" % ("%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/jec/" % os.environ['CMSSW_BASE'], globalTag, jetFlavour)
+        self.unc_factorized_path = "%s/%s_UncertaintySources_%s.txt" % ("%s/src/CMGTools/WMass/python/postprocessing/data/jec/" % os.environ['CMSSW_BASE'], globalTag, jetFlavour)
 
 
     def beginJob(self):

--- a/WMass/python/postprocessing/examples/jetReCleaner.py
+++ b/WMass/python/postprocessing/examples/jetReCleaner.py
@@ -3,8 +3,8 @@ import os
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from CMGTools.WMass.postprocessing.framework.datamodel import Collection
+from CMGTools.WMass.postprocessing.framework.eventloop import Module
 import ROOT, os
 
 class JetReCleaner(Module):
@@ -13,7 +13,7 @@ class JetReCleaner(Module):
         self.vars = ("pt","eta","phi","mass","btagCSV")
         if "jetReCleanerHelper.cc_cc.so" not in ROOT.gSystem.GetLibraries():
             print "Load C++ Worker"
-            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/MonoXAnalysis/python/postprocessing/helpers/jetReCleanerHelper.cc+" % os.environ['CMSSW_BASE'])
+            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/WMass/python/postprocessing/helpers/jetReCleanerHelper.cc+" % os.environ['CMSSW_BASE'])
         self._worker = ROOT.JetReCleanerHelper(0.4)
     def beginJob(self):
         pass

--- a/WMass/python/postprocessing/examples/lepSFProducer.py
+++ b/WMass/python/postprocessing/examples/lepSFProducer.py
@@ -3,8 +3,8 @@ import os
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection 
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from CMGTools.WMass.postprocessing.framework.datamodel import Collection 
+from CMGTools.WMass.postprocessing.framework.eventloop import Module
 
 class lepSFProducer(Module):
     def __init__(self, muonSelectionTag, electronSelectionTag):
@@ -23,8 +23,8 @@ class lepSFProducer(Module):
             print "Not foreseen WP: ",electronSelectionTag
             el_f = []
         el_h = ["EGamma_SF2D", "EGamma_SF2D"]
-        mu_f = ["%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/leptonSF/" % os.environ['CMSSW_BASE'] + f for f in mu_f]
-        el_f = ["%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/leptonSF/" % os.environ['CMSSW_BASE'] + f for f in el_f]
+        mu_f = ["%s/src/CMGTools/WMass/python/postprocessing/data/leptonSF/" % os.environ['CMSSW_BASE'] + f for f in mu_f]
+        el_f = ["%s/src/CMGTools/WMass/python/postprocessing/data/leptonSF/" % os.environ['CMSSW_BASE'] + f for f in el_f]
 
         self.mu_f = ROOT.std.vector(str)(len(mu_f))
         self.mu_h = ROOT.std.vector(str)(len(mu_f))
@@ -35,7 +35,7 @@ class lepSFProducer(Module):
 
         if "/LeptonEfficiencyCorrector_cc.so" not in ROOT.gSystem.GetLibraries():
             print "Load C++ Worker"
-            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/MonoXAnalysis/python/postprocessing/helpers/LeptonEfficiencyCorrector.cc+" % os.environ['CMSSW_BASE'])
+            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/WMass/python/postprocessing/helpers/LeptonEfficiencyCorrector.cc+" % os.environ['CMSSW_BASE'])
     def beginJob(self):
         self._worker_mu = ROOT.LeptonEfficiencyCorrector(self.mu_f,self.mu_h)
         self._worker_el = ROOT.LeptonEfficiencyCorrector(self.el_f,self.el_h)
@@ -76,16 +76,16 @@ class lepTrgSFProducer(Module):
         self.var = prefer1Dvar
         if "/WeightCalculatorFromHistogram_cc.so" not in ROOT.gSystem.GetLibraries():
             print "Load C++ Worker"
-            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/MonoXAnalysis/python/postprocessing/helpers/WeightCalculatorFromHistogram.cc+" % os.environ['CMSSW_BASE'])
+            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/WMass/python/postprocessing/helpers/WeightCalculatorFromHistogram.cc+" % os.environ['CMSSW_BASE'])
     def beginJob(self):
         ver=None
         for k,v in self.versions.iteritems(): 
             if k[0] < self.maxrun < k[1]: ver = v
         if ver:
-            f = "%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/leptonSF/el_trg/%s/%s/passHLT/eff1D.root" % (os.environ['CMSSW_BASE'],ver,self.var)
+            f = "%s/src/CMGTools/WMass/python/postprocessing/data/leptonSF/el_trg/%s/%s/passHLT/eff1D.root" % (os.environ['CMSSW_BASE'],ver,self.var)
             h = "s1c_eff"
             if self.dim==2:
-                f2D = "%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/leptonSF/el_trg/%s/sf/passHLT/eff2D.root" % (os.environ['CMSSW_BASE'],ver)
+                f2D = "%s/src/CMGTools/WMass/python/postprocessing/data/leptonSF/el_trg/%s/sf/passHLT/eff2D.root" % (os.environ['CMSSW_BASE'],ver)
                 if os.path.isfile(f2D):
                     f = f2D
                     h = "s2c_eff"

--- a/WMass/python/postprocessing/examples/mhtProducer.py
+++ b/WMass/python/postprocessing/examples/mhtProducer.py
@@ -1,8 +1,8 @@
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection 
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from CMGTools.WMass.postprocessing.framework.datamodel import Collection 
+from CMGTools.WMass.postprocessing.framework.eventloop import Module
 
 class mhtProducer(Module):
     def __init__(self, jetSelection, muonSelection, electronSelection):

--- a/WMass/python/postprocessing/examples/puWeightProducer.py
+++ b/WMass/python/postprocessing/examples/puWeightProducer.py
@@ -3,8 +3,8 @@ import os
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Collection 
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import Module
+from CMGTools.WMass.postprocessing.framework.datamodel import Collection 
+from CMGTools.WMass.postprocessing.framework.eventloop import Module
 
 class puWeightProducer(Module):
     def __init__(self,myfile,targetfile,myhist="pu_mc",targethist="pileup",name="puWeight",norm=True,verbose=False,nvtx_var="nTrueInt"):
@@ -17,7 +17,7 @@ class puWeightProducer(Module):
         self.fixLargeWeights = True
         if "/WeightCalculatorFromHistogram_cc.so" not in ROOT.gSystem.GetLibraries():
             print "Load C++ Worker"
-            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/MonoXAnalysis/python/postprocessing/helpers/WeightCalculatorFromHistogram.cc+" % os.environ['CMSSW_BASE'])
+            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/WMass/python/postprocessing/helpers/WeightCalculatorFromHistogram.cc+" % os.environ['CMSSW_BASE'])
     def loadHisto(self,filename,hname):
         tf = ROOT.TFile.Open(filename)
         tf.Print()
@@ -45,10 +45,10 @@ class puWeightProducer(Module):
 
 # define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
 
-pufile_mc="%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/pileup/pileup_profile_Summer16.root" % os.environ['CMSSW_BASE']
-pufile_data="%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/pileup/PileupData_GoldenJSON_Full2016.root" % os.environ['CMSSW_BASE']
-pufile_data_2016BF="%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/pileup/PileupData_GoldenJSON_2016BF.root" % os.environ['CMSSW_BASE']
-pufile_data_mc_2016G="%s/src/CMGTools/MonoXAnalysis/python/postprocessing/data/pileup/Pileup_Data2016G_MCSummer16MC.root" % os.environ['CMSSW_BASE']
+pufile_mc="%s/src/CMGTools/WMass/python/postprocessing/data/pileup/pileup_profile_Summer16.root" % os.environ['CMSSW_BASE']
+pufile_data="%s/src/CMGTools/WMass/python/postprocessing/data/pileup/PileupData_GoldenJSON_Full2016.root" % os.environ['CMSSW_BASE']
+pufile_data_2016BF="%s/src/CMGTools/WMass/python/postprocessing/data/pileup/PileupData_GoldenJSON_2016BF.root" % os.environ['CMSSW_BASE']
+pufile_data_mc_2016G="%s/src/CMGTools/WMass/python/postprocessing/data/pileup/Pileup_Data2016G_MCSummer16MC.root" % os.environ['CMSSW_BASE']
 puWeight = lambda : puWeightProducer(pufile_mc,pufile_data,"pu_mc","pileup",name="puw",verbose=True)
 puWeight2016BF = lambda : puWeightProducer(pufile_mc,pufile_data_2016BF,"pu_mc","pileup",name="puwBF",verbose=True)
 puWeight2016G =lambda : puWeightProducer(pufile_data_mc_2016G,pufile_data_mc_2016G,"pu_mc","pileup",name="puwG",verbose=True)

--- a/WMass/python/postprocessing/examples/recoil_postproc.py
+++ b/WMass/python/postprocessing/examples/recoil_postproc.py
@@ -3,7 +3,7 @@ import os, sys
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 from importlib import import_module
-from CMGTools.MonoXAnalysis.postprocessing.framework.postprocessor import PostProcessor
+from CMGTools.WMass.postprocessing.framework.postprocessor import PostProcessor
 
 from genFriendProducer import *
 from eventRecoilAnalyzer import *

--- a/WMass/python/postprocessing/framework/datamodel.py
+++ b/WMass/python/postprocessing/framework/datamodel.py
@@ -1,6 +1,6 @@
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
-from CMGTools.MonoXAnalysis.postprocessing.framework.treeReaderArrayTools import InputTree 
+from CMGTools.WMass.postprocessing.framework.treeReaderArrayTools import InputTree 
 
 class Event:
     """Class that allows seeing an entry of a PyROOT TTree as an Event"""

--- a/WMass/python/postprocessing/framework/eventloop.py
+++ b/WMass/python/postprocessing/framework/eventloop.py
@@ -1,4 +1,4 @@
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import Event
+from CMGTools.WMass.postprocessing.framework.datamodel import Event
 import sys, time
 
 class Module:

--- a/WMass/python/postprocessing/framework/postprocessor.py
+++ b/WMass/python/postprocessing/framework/postprocessor.py
@@ -2,11 +2,11 @@
 import os
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
-from CMGTools.MonoXAnalysis.postprocessing.framework.branchselection import BranchSelection
-from CMGTools.MonoXAnalysis.postprocessing.framework.datamodel import InputTree
-from CMGTools.MonoXAnalysis.postprocessing.framework.eventloop import eventLoop
-from CMGTools.MonoXAnalysis.postprocessing.framework.output import FriendOutput, FullOutput
-from CMGTools.MonoXAnalysis.postprocessing.framework.preskimming import preSkim
+from CMGTools.WMass.postprocessing.framework.branchselection import BranchSelection
+from CMGTools.WMass.postprocessing.framework.datamodel import InputTree
+from CMGTools.WMass.postprocessing.framework.eventloop import eventLoop
+from CMGTools.WMass.postprocessing.framework.output import FriendOutput, FullOutput
+from CMGTools.WMass.postprocessing.framework.preskimming import preSkim
 
 class PostProcessor :
     def __init__(self,outputDir,inputFiles,cut=None,branchsel=None,modules=[],compression="LZMA:9",friend=False,postfix=None,json=None,noOut=False,justcount=False,eventRange=None):

--- a/WMass/python/postprocessing/helpers/LeptonEfficiencyCorrector.cc
+++ b/WMass/python/postprocessing/helpers/LeptonEfficiencyCorrector.cc
@@ -1,5 +1,5 @@
-#ifndef CMGTools_MonoXAnalysisTools_LeptonEfficiencyCorrector_h
-#define CMGTools_MonoXAnalysisTools_LeptonEfficiencyCorrector_h
+#ifndef CMGTools_WMassTools_LeptonEfficiencyCorrector_h
+#define CMGTools_WMassTools_LeptonEfficiencyCorrector_h
 
 #include <iostream>
 #include <string>

--- a/WMass/python/postprocessing/helpers/genQEDJetHelper.cc
+++ b/WMass/python/postprocessing/helpers/genQEDJetHelper.cc
@@ -1,5 +1,5 @@
-#ifndef CMGTools_MonoXAnalysisTools_genQEDJetHelperHelper_h
-#define CMGTools_MonoXAnalysisTools_genQEDJetHelperHelper_h
+#ifndef CMGTools_WMassTools_genQEDJetHelperHelper_h
+#define CMGTools_WMassTools_genQEDJetHelperHelper_h
 
 #include <iostream>
 #include <vector>

--- a/WMass/python/postprocessing/helpers/jetReCleanerHelper.cc
+++ b/WMass/python/postprocessing/helpers/jetReCleanerHelper.cc
@@ -1,5 +1,5 @@
-#ifndef CMGTools_MonoXAnalysisTools_JetReCleanerHelper_h
-#define CMGTools_MonoXAnalysisTools_JetReCleanerHelper_h
+#ifndef CMGTools_WMassTools_JetReCleanerHelper_h
+#define CMGTools_WMassTools_JetReCleanerHelper_h
 
 #include <iostream>
 #include <vector>

--- a/WMass/python/postprocessing/lxbatch_runner.sh
+++ b/WMass/python/postprocessing/lxbatch_runner.sh
@@ -7,7 +7,7 @@ WORK=$1; shift
 SRC=$1; shift
 cd $SRC; 
 eval $(scramv1 runtime -sh);
-export LD_LIBRARY_PATH=${CMSSW_BASE}/src/CMGTools/MonoXAnalysis/python/postprocessing/helpers:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${CMSSW_BASE}/src/CMGTools/WMass/python/postprocessing/helpers:${LD_LIBRARY_PATH}
 cd $WORK;
 ulimit -c 0
 exec $*

--- a/WMass/python/postprocessing/postproc.py
+++ b/WMass/python/postprocessing/postproc.py
@@ -3,8 +3,8 @@ import os, sys
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 from importlib import import_module
-from CMGTools.MonoXAnalysis.postprocessing.framework.postprocessor import PostProcessor
-from CMGTools.MonoXAnalysis.postprocessing.postproc_batch import * 
+from CMGTools.WMass.postprocessing.framework.postprocessor import PostProcessor
+from CMGTools.WMass.postprocessing.postproc_batch import * 
 
 if __name__ == "__main__":
     from optparse import OptionParser

--- a/WMass/python/postprocessing/postproc_batch.py
+++ b/WMass/python/postprocessing/postproc_batch.py
@@ -5,21 +5,21 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True
 from importlib import import_module
 from glob import glob
 import re, pickle, math
-from CMGTools.MonoXAnalysis.postprocessing.framework.postprocessor import PostProcessor
+from CMGTools.WMass.postprocessing.framework.postprocessor import PostProcessor
 
-DEFAULT_MODULES = [("CMGTools.MonoXAnalysis.postprocessing.examples.puWeightProducer", "puWeight,puWeight2016BF"),
-                   ("CMGTools.MonoXAnalysis.postprocessing.examples.lepSFProducer","lepSF,trgSF"),
-                   ("CMGTools.MonoXAnalysis.postprocessing.examples.lepVarProducer","eleRelIsoEA,lepQCDAwayJet"),
-                   ("CMGTools.MonoXAnalysis.postprocessing.examples.jetReCleaner","jetReCleaner"),
-                   #("CMGTools.MonoXAnalysis.postprocessing.examples.genFriendProducer","genQEDJets"),
+DEFAULT_MODULES = [("CMGTools.WMass.postprocessing.examples.puWeightProducer", "puWeight,puWeight2016BF"),
+                   ("CMGTools.WMass.postprocessing.examples.lepSFProducer","lepSF,trgSF"),
+                   ("CMGTools.WMass.postprocessing.examples.lepVarProducer","eleRelIsoEA,lepQCDAwayJet,eleCalibrated"),
+                   ("CMGTools.WMass.postprocessing.examples.jetReCleaner","jetReCleaner"),
+                   #("CMGTools.WMass.postprocessing.examples.genFriendProducer","genQEDJets"),
                    ]
 
-RECOILTEST_MODULES=[("CMGTools.MonoXAnalysis.postprocessing.examples.puWeightProducer", "puWeight2016G"),
-                    ("CMGTools.MonoXAnalysis.postprocessing.examples.lepSFProducer","lepSF,trgSF"),
-                    ("CMGTools.MonoXAnalysis.postprocessing.examples.lepVarProducer","eleRelIsoEA,lepQCDAwayJet"),
-                    ("CMGTools.MonoXAnalysis.postprocessing.examples.jetReCleaner","jetReCleaner"),
-                    ("CMGTools.MonoXAnalysis.postprocessing.examples.genFriendProducer","genQEDJets13TeV"),
-                    ("CMGTools.MonoXAnalysis.postprocessing.examples.eventRecoilAnalyzer","eventRecoilAnalyzer"),
+RECOILTEST_MODULES=[("CMGTools.WMass.postprocessing.examples.puWeightProducer", "puWeight2016G"),
+                    ("CMGTools.WMass.postprocessing.examples.lepSFProducer","lepSF,trgSF"),
+                    ("CMGTools.WMass.postprocessing.examples.lepVarProducer","eleRelIsoEA,lepQCDAwayJet,eleCalibrated"),
+                    ("CMGTools.WMass.postprocessing.examples.jetReCleaner","jetReCleaner"),
+                    ("CMGTools.WMass.postprocessing.examples.genFriendProducer","genQEDJets13TeV"),
+                    ("CMGTools.WMass.postprocessing.examples.eventRecoilAnalyzer","eventRecoilAnalyzer"),
                    ]
 
 if __name__ == "__main__":

--- a/WMass/python/postprocessing/postproc_batch.py
+++ b/WMass/python/postprocessing/postproc_batch.py
@@ -11,7 +11,7 @@ DEFAULT_MODULES = [("CMGTools.WMass.postprocessing.examples.puWeightProducer", "
                    ("CMGTools.WMass.postprocessing.examples.lepSFProducer","lepSF,trgSF"),
                    ("CMGTools.WMass.postprocessing.examples.lepVarProducer","eleRelIsoEA,lepQCDAwayJet,eleCalibrated"),
                    ("CMGTools.WMass.postprocessing.examples.jetReCleaner","jetReCleaner"),
-                   #("CMGTools.WMass.postprocessing.examples.genFriendProducer","genQEDJets"),
+                   ("CMGTools.WMass.postprocessing.examples.genFriendProducer","genQEDJets"),
                    ]
 
 RECOILTEST_MODULES=[("CMGTools.WMass.postprocessing.examples.puWeightProducer", "puWeight2016G"),
@@ -154,7 +154,7 @@ if __name__ == "__main__":
 
     maintimer = ROOT.TStopwatch()
     def _runIt(myargs):
-        (name,fin,sample_nevt,fout,data,range,chunk) = myargs
+        (dataset,fin,sample_nevt,fout,data,range,chunk) = myargs
         modules = []
         for mod, names in imports: 
             import_module(mod)
@@ -166,6 +166,9 @@ if __name__ == "__main__":
                     print "Modules to run: ",options.modules,"  name = ",name
                     if len(options.modules) and name not in options.modules: continue
                     print "Loading %s from %s " % (name, mod)
+                    print "Running on dataset = ",dataset
+                    signal = any(x in dataset for x in "WJetsToLNu_NoSkim".split())
+                    if name=='genQEDJets' and not signal: continue
                     modules.append(getattr(obj,name)())
         if options.noOut:
             if len(modules) == 0: 

--- a/WMass/python/postprocessing/scripts/friendChunkAdd.sh
+++ b/WMass/python/postprocessing/scripts/friendChunkAdd.sh
@@ -14,7 +14,7 @@ for F in $(ls ${dir}/*_Friend_*.chunk*.root | sed 's/\.chunk[0-9]\+//' | sort | 
             sort -n | \
             perl -npe 's/\.(\d+)\.root$/sprintf(".chunk%d.root",$1)/e' );
     echo -e "\nWill merge into $F:\n$FILES"; 
-    $CMSSW_BASE/src/CMGTools/MonoXAnalysis/python/postprocessing/scripts/haddnano.py $F $FILES
+    $CMSSW_BASE/src/CMGTools/WMass/python/postprocessing/scripts/haddnano.py $F $FILES
 done
 
 if [[ $clean == 1 ]]; then mv ${dir}/*_Friend_*.chunk*.root Chunks; fi


### PR DESCRIPTION
Some additions in the friend trees for electrons:
1. add the final momentum in the friend tree (official scale correction + residual correction), avoiding to run slow smearer for each plot in mcPlots. Moreover, it avoids to have a different momentum for the same event in different calls, due to random smearing when using on-the-fly functions
2. add the bits for the final electron ID in the friends, to simplify the expressions in the selections text files

N.B. it needs adaptation of the application part (txt files, functions, etc).

This PR has also some non complete improvement of the datacards making / massaging (to be finalised in a second PR)