### PR TITLE
Add additional systematics and few things more

### DIFF
--- a/WMass/python/plotter/fakeRate.cc
+++ b/WMass/python/plotter/fakeRate.cc
@@ -81,6 +81,8 @@ float fakeRateWeight_1l_i_smoothed(float lpt, float leta, int lpdgId, bool passW
     float p1 = hist->GetBinContent(etabin, 2);
     if (iFR==1) p0 += hist->GetBinError(etabin, 1);
     if (iFR==2) p0 -= hist->GetBinError(etabin, 1);
+    if (iFR==3) p1 += hist->GetBinError(etabin, 2);
+    if (iFR==4) p1 -= hist->GetBinError(etabin, 2);
     float fr = p0 + p1*lpt;
     return fr/(1-fr);
   } else return 0;

--- a/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrix.py
+++ b/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrix.py
@@ -127,7 +127,6 @@ if options.Ybins:
     if fitAbsoluteRates:
         for ip,p in enumerate(sorted_rap):
             tmp_par = fitresult.floatParsFinal().find(p) if p in l_sorted_new else fitresult.constPars().find(p)
-            print tmp_par," has rate = ",tmp_par.getVal()
             totalrate += tmp_par.getVal()
         
     #totalrate=1.

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptdown.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptdown.txt
@@ -1,0 +1,3 @@
+cut-change: LepGood1_customId: 1
+load-histo: FR_el_i4 : $DATA/fakerate/fakeRateSmoothed_el.root : frSmoothParameter_data
+weight: fakeRateWeight_1l_i_smoothed(LepGood1_calPt,LepGood1_eta,LepGood1_pdgId,LepGood1_customId,4)

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptup.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptup.txt
@@ -1,0 +1,3 @@
+cut-change: LepGood1_customId: 1
+load-histo: FR_el_i3 : $DATA/fakerate/fakeRateSmoothed_el.root : frSmoothParameter_data
+weight: fakeRateWeight_1l_i_smoothed(LepGood1_calPt,LepGood1_eta,LepGood1_pdgId,LepGood1_customId,3)

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
@@ -49,8 +49,8 @@ Wminus_right_elescale_Dn : WJetsToLNu_NoSkim : 3.*20508.9   : genw_decayId == 12
 #incl_ewkmc_recoil_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-ewkmc-helicity.txt", FakeRate="w-helicity-13TeV/wmass_e/fr-recoilUp.txt", SkipMe=True, PostFix="_recoil_Up" 
 #incl_ewkmc_recoil_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-ewkmc-helicity.txt", FakeRate="w-helicity-13TeV/wmass_e/fr-recoilDn.txt", SkipMe=True, PostFix="_recoil_Dn" 
 
-# fake-lepton background systematics
-#incl_datafakes_FRe_norm_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-up.txt", SkipMe=True, PostFix='_fakes_FRe_norm_Up'
-#incl_datafakes_FRe_norm_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-down.txt", SkipMe=True, PostFix='_fakes_FRe_norm_Dn'
+# fake-lepton background systematics (shape systematics)
+#incl_datafakes_FRe_pt_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-up.txt", SkipMe=True, PostFix='_fakes_FRe_pt_Up'
+#incl_datafakes_FRe_pt_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-down.txt", SkipMe=True, PostFix='_fakes_FRe_pt_Dn'
 
 

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
@@ -50,7 +50,7 @@ Wminus_right_elescale_Dn : WJetsToLNu_NoSkim : 3.*20508.9   : genw_decayId == 12
 #incl_ewkmc_recoil_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-ewkmc-helicity.txt", FakeRate="w-helicity-13TeV/wmass_e/fr-recoilDn.txt", SkipMe=True, PostFix="_recoil_Dn" 
 
 # fake-lepton background systematics (shape systematics)
-#incl_datafakes_FRe_pt_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-up.txt", SkipMe=True, PostFix='_fakes_FRe_pt_Up'
-#incl_datafakes_FRe_pt_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-down.txt", SkipMe=True, PostFix='_fakes_FRe_pt_Dn'
+incl_datafakes_FRe_pt_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-up.txt", SkipMe=True, PostFix='_fakes_FRe_pt_Up'
+incl_datafakes_FRe_pt_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-down.txt", SkipMe=True, PostFix='_fakes_FRe_pt_Dn'
 
 

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
@@ -2,10 +2,15 @@
 lumi_8TeV              : W.*|TauDecaysW|Z|Top|DiBosons: .* : 1.026
 
 # lepton efficiencies
-CMS_We_lepEff   : W.*|TauDecaysW|Z|Top|DiBosons: .* : 1.01
+CMS_We_lepEff   : W.*|TauDecaysW|Z|Top|DiBosons: .* : 1.02
+CMS_We_lepVeto  : Z : .* : 1.03
 
-# Diboson backgrounds 
+# backgrounds normalizations
 CMS_We_VV : DiBosons : .* : 1.16 
+# Z xsec from FEWZ 3.1: https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV
+CMS_We_DY : Z : .* : 1.038
+# Top (take a conservative value as the maximum uncertainty among single-t and ttbar (ttbar from: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO)
+CMS_We_Top : Top : .* : 1.06 
 
 # lepton scale
 CMS_We_elescale :  W.*: .* : elescale       : templates 
@@ -16,7 +21,7 @@ CMS_We_elescale :  W.*: .* : elescale       : templates
 # Fake rate uncertainties
 # 1+2) Measurement of the fake rate: normalization and shapes
 #CMS_We_FRe_norm   : data_fakes  : .* : FRe_norm : templates
-#CMS_We_FRe_pt     : data_fakes  : .* : FRe_pt   : templatesShapeOnly
+CMS_We_FRe_pt     : data_fakes  : .* : FRe_pt   : templatesShapeOnly
 # for the time being just apply a flat normalization uncertainty
 CMS_We_FRe_norm   : data_fakes  : .* : 1.30
 


### PR DESCRIPTION
Systematics added (to the electron channel):

- shape uncertainty for the fakes by +/- 1 sigma of the angular coefficient of the pol1 in pT
- a lepton veto systematics of 3% (conservative number looking at the SFs uncertainties for the loose selection - assuming we will do a veto using a loose ele). Added only for the Z component for the time being
- DY normalization uncertainty, taken as 3.8% from [FEWZ 3.1]( https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV) including PDFs, alpha_s, muF, muS all summed up in quadrature
- Top normalization taken conservatively as 6% the [uncertainty on TTbar production](https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO), since single-t uncertainty is smaller

Changed symmetrizeMatrix.py such that it understands from dc if the fit is for absolute rates and not SF wrt the expected. 
