### PR TITLE
Symmetrization of each PDF variation

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -27,9 +27,7 @@ def writePdfSystsToMCA(mcafile,odir,vec_weight="hessWgt",syst="pdf",incl_mca='in
         return
 
     for i in range(NPDFSYSTS):
-        pdfvar=str(i/2+1)
-        direction="Up" if i%2 else "Dn"
-        postfix = "_"+str(syst)+pdfvar+'_'+direction
+        postfix = "_%s%d" % (syst,i+1)
         mcafile_syst = open("%s/mca%s.txt" % (odir,postfix), "w")
         mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="'+vec_weight+'['+str(i)+']/genWeight", PostFix="'+postfix+'" \n')
         pdfsysts.append(postfix)

--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -30,6 +30,7 @@ def writePdfSystsToMCA(mcafile,odir,vec_weight="hessWgt",syst="pdf",incl_mca='in
         pdfvar=str(i/2+1)
         direction="Up" if i%2 else "Dn"
         postfix = "_"+str(syst)+pdfvar+'_'+direction
+        #postfix = "_%s%d" % (syst,i+1) # this is the change needed to make all alternative variations to be symmetrized
         mcafile_syst = open("%s/mca%s.txt" % (odir,postfix), "w")
         mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="'+vec_weight+'['+str(i)+']/genWeight", PostFix="'+postfix+'" \n')
         pdfsysts.append(postfix)


### PR DESCRIPTION
Now add the symmetrization of the PDF variations in mergeCardComponentsAbsY.py (done automatically). By default it changes both shape and normalization (is it correct @bendavid ? it should, since they may change a bit the acceptance), but we could change the shape only eventually.

Example of the effects (Up/Nominal and Down/Nominal) on one PDF hessian weight on one signal template below:

![image](https://user-images.githubusercontent.com/4517974/37236252-13b40772-2406-11e8-8bca-835b7299375e.png)

the code will be semplified a bit later labelling the systematics files/histograms simply with PDF index. The current is an intermediate step to use the datacards I had where even/odd weights were called Up/Down. Will make a PR later changing both
- make_helicity_cards.py
- mergeCardComponentsAbsY.py

when I have the files with new labels to test it, but it is a simple change.

