### PR TITLE
Add script to make the PDF impacts

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -29,227 +29,155 @@ def mirrorShape(nominal,alternate,newname,alternateShapeOnly=False):
         mirror.Scale(mnorm/alternate.Integral())
     return (alternate,mirror)
 
-if __name__ == "__main__":
 
-    from optparse import OptionParser
-    parser = OptionParser(usage='%prog [options] cards/card*.txt')
-    parser.add_option('-m','--merge-root', dest='mergeRoot', default=False, action='store_true', help='Merge the root files with the inputs also')
-    parser.add_option('-i','--input', dest='inputdir', default='', type='string', help='input directory with all the cards inside')
-    parser.add_option('-b','--bin', dest='bin', default='ch1', type='string', help='name of the bin')
-    parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
-    parser.add_option('-c','--constrain-rates', dest='constrainRateParams', type='string', default='0,1,2', help='add constraints on the rate parameters of (comma-separated list of) rapidity bins. Give only the left ones (e.g. 1 will constrain 1 with n-1 ')
-    parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='', help='add here replacement of default rate-fixing. with format plusR=10,11,12;plusL=11,12;minusR=10,11,12;minusL=10,11 ')
-    parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
-    parser.add_option('-l','--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
-    parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
-    parser.add_option(     '--longToTotal', dest='longToTotal', type='float', default=None, help='Apply a constraint on the Wlong/Wtot rate. Implies fitting for absolute rates')
-    parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
-    (options, args) = parser.parse_args()
+from optparse import OptionParser
+parser = OptionParser(usage='%prog [options] cards/card*.txt')
+parser.add_option('-m','--merge-root', dest='mergeRoot', default=False, action='store_true', help='Merge the root files with the inputs also')
+parser.add_option('-i','--input', dest='inputdir', default='', type='string', help='input directory with all the cards inside')
+parser.add_option('-b','--bin', dest='bin', default='ch1', type='string', help='name of the bin')
+parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
+parser.add_option('-c','--constrain-rates', dest='constrainRateParams', type='string', default='0,1,2', help='add constraints on the rate parameters of (comma-separated list of) rapidity bins. Give only the left ones (e.g. 1 will constrain 1 with n-1 ')
+parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='', help='add here replacement of default rate-fixing. with format plusR=10,11,12;plusL=11,12;minusR=10,11,12;minusL=10,11 ')
+parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
+parser.add_option('-l','--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
+parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
+parser.add_option(     '--longToTotal', dest='longToTotal', type='float', default=None, help='Apply a constraint on the Wlong/Wtot rate. Implies fitting for absolute rates')
+parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
+(options, args) = parser.parse_args()
+
+from symmetrizeMatrixAbsY import getScales
+
+charges = options.charge.split(',')
+
+
+for charge in charges:
+
+    outfile  = os.path.join(options.inputdir,options.bin+'_{ch}_shapes.root'.format(ch=charge))
+    cardfile = os.path.join(options.inputdir,options.bin+'_{ch}_card.txt'   .format(ch=charge))
+
+    ## prepare the relevant files. only the datacards and the correct charge
+    files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
+    files = ( f for f in files if charge in f and 'pdf' not in f )
+    files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
+    files = list( ( os.path.join(options.inputdir, f) for f in files ) )
     
-    from symmetrizeMatrixAbsY import getScales
+    existing_bins = []
+    empty_bins = []
+
+    ## look for the maximum ybin bin number
+    nbins = 0
+    print "FILES = ",files
+    for f in files:
+        if 'Ybin_' in f:
+            n = int(f[f.find('Ybin_')+5 : f.find('.card')])
+            if n>nbins: nbins=n
+            if n not in existing_bins: existing_bins.append(n)
+    print 'found {n} bins of rapidity'.format(n=nbins+1)
+
+    fixedYBins = {'plusR' : [n,n-1,n-2],
+                  'plusL' : [n],
+                  'minusR': [n,n-1,n-2],
+                  'minusL': [n],
+                 }
     
-    charges = options.charge.split(',')
-    
-    
-    for charge in charges:
-    
-        outfile  = os.path.join(options.inputdir,options.bin+'_{ch}_shapes.root'.format(ch=charge))
-        cardfile = os.path.join(options.inputdir,options.bin+'_{ch}_card.txt'   .format(ch=charge))
-    
-        ## prepare the relevant files. only the datacards and the correct charge
-        files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
-        files = ( f for f in files if charge in f and 'pdf' not in f )
-        files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
-        files = list( ( os.path.join(options.inputdir, f) for f in files ) )
-        
-        existing_bins = []
-        empty_bins = []
-    
-        ## look for the maximum ybin bin number
-        nbins = 0
-        print "FILES = ",files
-        for f in files:
-            if 'Ybin_' in f:
-                n = int(f[f.find('Ybin_')+5 : f.find('.card')])
-                if n>nbins: nbins=n
-                if n not in existing_bins: existing_bins.append(n)
-        print 'found {n} bins of rapidity'.format(n=nbins+1)
-    
-        fixedYBins = {'plusR' : [n,n-1,n-2],
-                      'plusL' : [n],
-                      'minusR': [n,n-1,n-2],
-                      'minusL': [n],
-                     }
-        
-        if options.fixYBins:
-            splitted = options.fixYBins.split(';')
-            for comp in splitted:
-                chhel = comp.split('=')[0]
-                bins  = comp.split('=')[1]
-                fixedYBins[chhel] = list(int(i) for i in bins.split(','))
-                ## this doesn't work here anymore if not fixedYBins[chhel][0] == 0:
-                ## this doesn't work here anymore     raise RuntimeError, "Your fixed bins should start at 0!!"
-                ## this doesn't work here anymore if not max(fixedYBins[chhel]) == len(fixedYBins[chhel])-1:
-                ## this doesn't work here anymore     raise RuntimeError, "This list does not seem to be continuous. Fix!"
-        print fixedYBins
-    
-    
-        ybinfile = open(os.path.join(options.inputdir, 'binningYW.txt'),'r')
-        ybinline = ybinfile.readlines()[0]
-        ybins = list(float(i) for i in ybinline.split())
-        ybinfile.close()
-        #ybins = list(float(i) for i in options.Ybins.split(','))
-        for b in xrange(len(ybins)-1):
-            if b not in existing_bins: 
-                if b not in empty_bins:
-                    empty_bins.append(b)
-                    empty_bins.append(nbins+1-b)            
-    
-        longBKG = False
-        tmpfiles = []
-        for f in files:
-            dir = os.path.dirname(f)
-            bin = ''
-            isEmpty = False
-            with open(f) as file:
-                for l in file.readlines():
-                    if re.match('shapes.*',l):
-                        rootfile = dir+'/'+l.split()[3]
-                    if re.match('bin.*',l):
-                        if len(l.split()) < 2: continue ## skip the second bin line if empty
-                        bin = l.split()[1]
-                        binn = int(bin.split('_')[-1]) if 'Ybin_' in bin else -1
-                    basename = os.path.basename(f).split('.')[0]
-                    rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
-                    rootfiles_syst = [dir+'/'+x for x in rootfiles_syst]
-                    rootfiles_syst.sort()
-                    if re.match('process\s+',l): 
-                        if len(l.split()) > 1 and all(n.isdigit() for n in l.split()[1:]) : continue
-                        if not ('left' in l and 'right' in l):
-                            if not binn in empty_bins: 
-                                if binn >= 0:
-                                    empty_bins.append(binn)
-                                    empty_bins.append(nbins-binn)
-                            isEmpty = True
-                        processes = l.split()[1:]
-                    if re.match('process\s+W.*long',l) and 'bkg' in f:
-                        print "===> W long is treated as a background"
-                        longBKG = True
-            if options.mergeRoot:
-                if not binn in empty_bins:
-                    print 'processing bin = ',bin
-                    nominals = {}
-                    for irf,rf in enumerate([rootfile]+rootfiles_syst):
-                        print '\twith nominal/systematic file: ',rf
-                        tf = ROOT.TFile.Open(rf)
-                        tmpfile = os.path.join(options.inputdir,'tmp_{bin}_sys{sys}.root'.format(bin=bin,sys=irf))
-                        of=ROOT.TFile(tmpfile,'recreate')
-                        tmpfiles.append(tmpfile)
-                        # remove the duplicates also
-                        plots = {}
-                        for e in tf.GetListOfKeys() :
-                            name=e.GetName()
-                            obj=e.ReadObj()
-                            if (not re.match('Wplus|Wminus',os.path.basename(f))) and 'data_obs' in name: obj.Clone().Write()
-                            for p in processes:
-                                if p in name:
-                                    newprocname = p+'_'+bin if re.match('Wplus|Wminus',p) else p
-                                    if longBKG and re.match('(Wplus_long|Wminus_long)',p): newprocname = p
-                                    newname = name.replace(p,newprocname)
-                                    if irf==0:
-                                        if newname not in plots:
-                                            plots[newname] = obj.Clone(newname)
-                                            nominals[newname] = obj.Clone(newname+"0")
-                                            nominals[newname].SetDirectory(None)
-                                            #print 'replacing old %s with %s' % (name,newname)
-                                            plots[newname].Write()
-                                    else:
-                                        tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); pdf = tokens[-1]
-                                        ipdf = int(pdf.split('pdf')[-1])
-                                        newname = "{pfx}_pdf{ipdf}".format(pfx=pfx,ipdf=ipdf)
-                                        (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname)
-                                        for alt in [alternate,mirror]:
-                                            if alt.GetName() not in plots:
-                                                plots[alt.GetName()] = alt.Clone()
-                                                plots[alt.GetName()].Write()
-                        of.Close()
-        if len(empty_bins):
-            print 'found a bunch of empty bins:', empty_bins
-        if options.mergeRoot:
-            haddcmd = 'hadd -f {of} {tmpfiles}'.format(of=outfile, tmpfiles=' '.join(tmpfiles) )
-            #print 'would run this now: ', haddcmd
-            #sys.exit()
-            os.system(haddcmd)
-            os.system('rm {rm}'.format(rm=' '.join(tmpfiles)))
-    
-        print "Now trying to get info on PDF uncertainties..."
-        pdfsyst = {}
-        tf = ROOT.TFile.Open(outfile)
-        for e in tf.GetListOfKeys() :
-            name=e.GetName()
-            if 'pdf' in name:
-                if name.endswith("Up"): name = re.sub('Up$','',name)
-                if name.endswith("Down"): name = re.sub('Down$','',name)
-                syst = name.split('_')[-1]
-                binWsyst = '_'.join(name.split('_')[1:-1])
-                if syst not in pdfsyst: pdfsyst[syst] = [binWsyst]
-                else: pdfsyst[syst].append(binWsyst)
-        if len(pdfsyst): print "Found a bunch of PDF sysematics: ",pdfsyst.keys()
-        else: print "You are running w/o PDF systematics. Lucky you!"
-    
-        combineCmd="combineCards.py "
-        for f in files:
-            basename = os.path.basename(f).split(".")[0]
-            binn = int(basename.split('_')[-1]) if 'Ybin_' in basename else 999
-            binname = basename if re.match('Wplus|Wminus',basename) else "other"
-            if not binn in empty_bins:
-                combineCmd += " %s=%s " % (binname,f)
-        tmpcard = os.path.join(options.inputdir,'tmpcard.txt')
-        combineCmd += ' > {tmpcard}'.format(tmpcard=tmpcard)
-        #sys.exit()
-<<<<<<< HEAD
-        os.system(combineCmd)
-    
-        combinedCard = open(cardfile,'w')
-        combinedCard.write("imax 1\n")
-        combinedCard.write("jmax *\n")
-        combinedCard.write("kmax *\n")
-        combinedCard.write('##----------------------------------\n') 
-        realprocesses = [] # array to preserve the sorting
-        with open(tmpcard) as file:    
-            nmatchbin=0
-            nmatchprocess=0
+    if options.fixYBins:
+        splitted = options.fixYBins.split(';')
+        for comp in splitted:
+            chhel = comp.split('=')[0]
+            bins  = comp.split('=')[1]
+            fixedYBins[chhel] = list(int(i) for i in bins.split(','))
+            ## this doesn't work here anymore if not fixedYBins[chhel][0] == 0:
+            ## this doesn't work here anymore     raise RuntimeError, "Your fixed bins should start at 0!!"
+            ## this doesn't work here anymore if not max(fixedYBins[chhel]) == len(fixedYBins[chhel])-1:
+            ## this doesn't work here anymore     raise RuntimeError, "This list does not seem to be continuous. Fix!"
+    print fixedYBins
+
+
+    ybinfile = open(os.path.join(options.inputdir, 'binningYW.txt'),'r')
+    ybinline = ybinfile.readlines()[0]
+    ybins = list(float(i) for i in ybinline.split())
+    ybinfile.close()
+    #ybins = list(float(i) for i in options.Ybins.split(','))
+    for b in xrange(len(ybins)-1):
+        if b not in existing_bins: 
+            if b not in empty_bins:
+                empty_bins.append(b)
+                empty_bins.append(nbins+1-b)            
+
+    longBKG = False
+    tmpfiles = []
+    for f in files:
+        dir = os.path.dirname(f)
+        bin = ''
+        isEmpty = False
+        with open(f) as file:
             for l in file.readlines():
-                if re.match("shapes.*other",l):
-                    variables = l.split()[4:]
-                    combinedCard.write("shapes *  *  %s %s\n" % (os.path.abspath(outfile)," ".join(variables)))
-                    combinedCard.write('##----------------------------------\n')
-                if re.match("bin",l) and nmatchbin==0: 
-                    nmatchbin=1
-                    combinedCard.write('bin   %s\n' % options.bin) 
-                    bins = l.split()[1:]
-                if re.match("observation",l): 
-                    yields = l.split()[1:]
-                    observations = dict(zip(bins,yields))
-                    combinedCard.write('observation %s\n' % observations['other'])
-                    combinedCard.write('##----------------------------------\n')
-                if re.match("bin",l) and nmatchbin==1:
-                    pseudobins = l.split()[1:]
-                if re.match("process",l):
-                    if nmatchprocess==0:
-                        pseudoprocesses = l.split()[1:]
-                        klen = 7
-                        kpatt = " %%%ds "  % klen
-                        for i in xrange(len(pseudobins)):
-                            realprocesses.append(pseudoprocesses[i]+"_"+pseudobins[i] if ('Wminus' in pseudobins[i] or 'Wplus' in pseudobins[i]) else pseudoprocesses[i])
-                        combinedCard.write('bin            %s \n' % ' '.join([kpatt % options.bin for p in pseudoprocesses]))
-                        combinedCard.write('process        %s \n' % ' '.join([kpatt % p for p in realprocesses]))
-                        combinedCard.write('process        %s \n' % ' '.join([kpatt % str(i+1) for i in xrange(len(pseudobins))]))
-                    nmatchprocess += 1
-                if nmatchprocess==2: 
-                    nmatchprocess +=1
-                elif nmatchprocess>2: combinedCard.write(l)
-=======
+                if re.match('shapes.*',l):
+                    rootfile = dir+'/'+l.split()[3]
+                if re.match('bin.*',l):
+                    if len(l.split()) < 2: continue ## skip the second bin line if empty
+                    bin = l.split()[1]
+                    binn = int(bin.split('_')[-1]) if 'Ybin_' in bin else -1
+                basename = os.path.basename(f).split('.')[0]
+                rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
+                rootfiles_syst = [dir+'/'+x for x in rootfiles_syst]
+                rootfiles_syst.sort()
+                if re.match('process\s+',l): 
+                    if len(l.split()) > 1 and all(n.isdigit() for n in l.split()[1:]) : continue
+                    if not ('left' in l and 'right' in l):
+                        if not binn in empty_bins: 
+                            if binn >= 0:
+                                empty_bins.append(binn)
+                                empty_bins.append(nbins-binn)
+                        isEmpty = True
+                    processes = l.split()[1:]
+                if re.match('process\s+W.*long',l) and 'bkg' in f:
+                    print "===> W long is treated as a background"
+                    longBKG = True
+        if options.mergeRoot:
+            if not binn in empty_bins:
+                print 'processing bin = ',bin
+                nominals = {}
+                for irf,rf in enumerate([rootfile]+rootfiles_syst):
+                    print '\twith nominal/systematic file: ',rf
+                    tf = ROOT.TFile.Open(rf)
+                    tmpfile = os.path.join(options.inputdir,'tmp_{bin}_sys{sys}.root'.format(bin=bin,sys=irf))
+                    of=ROOT.TFile(tmpfile,'recreate')
+                    tmpfiles.append(tmpfile)
+                    # remove the duplicates also
+                    plots = {}
+                    for e in tf.GetListOfKeys() :
+                        name=e.GetName()
+                        obj=e.ReadObj()
+                        if (not re.match('Wplus|Wminus',os.path.basename(f))) and 'data_obs' in name: obj.Clone().Write()
+                        for p in processes:
+                            if p in name:
+                                newprocname = p+'_'+bin if re.match('Wplus|Wminus',p) else p
+                                if longBKG and re.match('(Wplus_long|Wminus_long)',p): newprocname = p
+                                newname = name.replace(p,newprocname)
+                                if irf==0:
+                                    if newname not in plots:
+                                        plots[newname] = obj.Clone(newname)
+                                        nominals[newname] = obj.Clone(newname+"0")
+                                        nominals[newname].SetDirectory(None)
+                                        #print 'replacing old %s with %s' % (name,newname)
+                                        plots[newname].Write()
+                                else:
+                                    tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); pdf = tokens[-1]
+                                    ipdf = int(pdf.split('pdf')[-1])
+                                    newname = "{pfx}_pdf{ipdf}".format(pfx=pfx,ipdf=ipdf)
+                                    (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname)
+                                    for alt in [alternate,mirror]:
+                                        if alt.GetName() not in plots:
+                                            plots[alt.GetName()] = alt.Clone()
+                                            plots[alt.GetName()].Write()
+                    of.Close()
+    if len(empty_bins):
+        print 'found a bunch of empty bins:', empty_bins
+    if options.mergeRoot:
+        haddcmd = 'hadd -f {of} {tmpfiles}'.format(of=outfile, tmpfiles=' '.join(tmpfiles) )
+        #print 'would run this now: ', haddcmd
+        #sys.exit()
         os.system(haddcmd)
         os.system('rm {rm}'.format(rm=' '.join(tmpfiles)))
 
@@ -340,14 +268,11 @@ if __name__ == "__main__":
     ProcsAndRates = zip(procs,rates)
     ProcsAndRatesDict = dict(zip(procs,rates))
 
-    efficiencies    = {}; efferrors    = {}
-    efficiencies_LO = {}; efferrors_LO = {}
+    efficiencies = {}; efferrors = {}
     if options.scaleFile:
         for pol in ['left','right','long']: 
-            efficiencies   [pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
-            efferrors      [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
-            efficiencies_LO[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False)]
-            efferrors_LO   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False, returnError=True)]
+            efficiencies[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
+            efferrors   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
 
     combinedCard = open(cardfile,'a')
     POIs = []
@@ -358,198 +283,161 @@ if __name__ == "__main__":
         signal_L = filter(lambda x: re.match('.*left.*',x),signal_procs)
         signal_R = filter(lambda x: re.match('.*right.*',x),signal_procs)
         signal_0 = filter(lambda x: re.match('.*long.*',x),signal_procs)
->>>>>>> wmass-central/80X
         
-        os.system('rm {tmpcard}'.format(tmpcard=tmpcard))
-        
-        if options.longToTotal or options.scaleFile: options.absoluteRates = True
-        
-        kpatt = " %7s "
-        if options.longLnN and not options.longToTotal:
-            combinedCard.write('norm_long_'+options.bin+'       lnN    ' + ' '.join([kpatt % (options.longLnN if 'long' in x else '-') for x in realprocesses])+'\n')
-    
-        combinedCard = open(cardfile,'r')
-        procs = []
-        rates = []
-        for l in combinedCard.readlines():
-            if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
-                procs = (l.rstrip().split())[1:]
-            if re.match("rate\s+",l):
-                rates = (l.rstrip().split())[1:]
-            if len(procs) and len(rates): break
-        ProcsAndRates = zip(procs,rates)
-        ProcsAndRatesDict = dict(zip(procs,rates))
-    
-        efficiencies = {}; efferrors = {}
-        if options.scaleFile:
-            for pol in ['left','right','long']: 
-                efficiencies[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
-                efferrors   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
-    
-        combinedCard = open(cardfile,'a')
-        POIs = []
-        if options.constrainRateParams:
-            signal_procs = filter(lambda x: re.match('Wplus|Wminus',x), realprocesses)
-            if longBKG: signal_procs = filter(lambda x: re.match('(?!Wplus_long|Wminus_long)',x), signal_procs)
-            signal_procs.sort(key=lambda x: int(x.split('_')[-1]))
-            signal_L = filter(lambda x: re.match('.*left.*',x),signal_procs)
-            signal_R = filter(lambda x: re.match('.*right.*',x),signal_procs)
-            signal_0 = filter(lambda x: re.match('.*long.*',x),signal_procs)
-            
-            hel_to_constrain = [signal_L,signal_R]
-            bins_to_constrain = options.constrainRateParams.split(',')
-            tightConstraint = 0.05
-            looseConstraint = tightConstraint
-            for hel in hel_to_constrain:
-                for iy,helbin in enumerate(hel):
-                    pol = helbin.split('_')[1]
-                    index_procs = procs.index(helbin)
-                    lns = ' - '.join('' for i in range(index_procs+1))
-                    lns += ' {effunc:.4f} '.format(effunc=1.+efferrors[pol][iy])
-                    lns += ' - '.join('' for i in range(len(procs) - index_procs))
-                    combinedCard.write('eff_unc_{hb}    lnN {lns}\n'.format(hb=helbin,lns=lns))
-            for hel in hel_to_constrain:
-                for iy,helbin in enumerate(hel):
-                    sfx = str(iy)
-                    pol = helbin.split('_')[1]
-                    rateNuis = tightConstraint if iy in bins_to_constrain else looseConstraint
-                    normPOI = 'norm_{n}'.format(n=helbin)
-    
-                    ## if we fit absolute rates, we need to get them from the process and plug them in below
-                    if options.absoluteRates:
-    
-                        ## if we want to fit with the efficiency gen-reco, we need to add one efficiency parameter
-                        if options.scaleFile:
-                            tmp_eff = efficiencies[pol][iy]
-                            combinedCard.write('eff_{n}    rateParam * {n} \t {eff:.5f} [{dn:.5f},{up:.5f}]\n'.format(n=helbin,eff=tmp_eff,dn=(1-1E-04)*tmp_eff,up=(1+1E-04)*tmp_eff))
-                            expRate0 = float(ProcsAndRatesDict[helbin])/tmp_eff
-                            param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
-                            combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
-    
-                        ## if we do not want to fit the gen-level thing, we want to just put the absolute reco rates here
-                        else:
-                            expRate0 = float(ProcsAndRatesDict[helbin])
-                            param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
-                            combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
-    
-                    ## if not fitting full rates, we do the relative rateParams close to 1.
+        hel_to_constrain = [signal_L,signal_R]
+        bins_to_constrain = options.constrainRateParams.split(',')
+        tightConstraint = 0.05
+        looseConstraint = tightConstraint
+        for hel in hel_to_constrain:
+            for iy,helbin in enumerate(hel):
+                pol = helbin.split('_')[1]
+                index_procs = procs.index(helbin)
+                lns = ' - '.join('' for i in range(index_procs+1))
+                lns += ' {effunc:.4f} '.format(effunc=1.+efferrors[pol][iy])
+                lns += ' - '.join('' for i in range(len(procs) - index_procs))
+                combinedCard.write('eff_unc_{hb}    lnN {lns}\n'.format(hb=helbin,lns=lns))
+        for hel in hel_to_constrain:
+            for iy,helbin in enumerate(hel):
+                sfx = str(iy)
+                pol = helbin.split('_')[1]
+                rateNuis = tightConstraint if iy in bins_to_constrain else looseConstraint
+                normPOI = 'norm_{n}'.format(n=helbin)
+
+                ## if we fit absolute rates, we need to get them from the process and plug them in below
+                if options.absoluteRates:
+
+                    ## if we want to fit with the efficiency gen-reco, we need to add one efficiency parameter
+                    if options.scaleFile:
+                        tmp_eff = efficiencies[pol][iy]
+                        combinedCard.write('eff_{n}    rateParam * {n} \t {eff:.5f} [{dn:.5f},{up:.5f}]\n'.format(n=helbin,eff=tmp_eff,dn=(1-1E-04)*tmp_eff,up=(1+1E-04)*tmp_eff))
+                        expRate0 = float(ProcsAndRatesDict[helbin])/tmp_eff
+                        param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
+                        combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
+
+                    ## if we do not want to fit the gen-level thing, we want to just put the absolute reco rates here
                     else:
-                        param_range_0 = '1. [{dn:.2f},{up:.2f}]'.format(dn=1-rateNuis,up=1+rateNuis)
-                        param_range_1 = param_range_0
-                        combinedCard.write('norm_{n}   rateParam * {n}    {pr}\n'.format(n=helbin,pr=param_range_0))
-                    POIs.append(normPOI)
-    
-            ## not sure this below will still work with absY, but for now i don't care (marc)
-            if not longBKG and not options.longLnN:
-                for i in xrange(len(signal_0)):
-                    sfx = signal_0[i].split('_')[-1]
-                    param_range = '[0.95,1.05]' if sfx in bins_to_constrain else '[0.95,1.05]'
-                    combinedCard.write('norm_%-5s   rateParam * %-5s    1 %s\n' % (signal_0[i],signal_0[i],param_range))
-                    POIs.append('norm_%s' % signal_0[i])
-        
-            if options.absoluteRates:
-                combinedCard = open(cardfile,'r')
-                procs = []
-                rates = []
-                for l in combinedCard.readlines():
-                    if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
-                        procs = (l.rstrip().split())[1:]
-                    if re.match("rate\s+",l):
-                        rates = (l.rstrip().split())[1:]
-                    if len(procs) and len(rates): break
-                ProcsAndRates = zip(procs,rates)
-    
-                combinedCard = open(cardfile,'r')
-                ProcsAndRatesUnity = []
-                for (p,r) in ProcsAndRates:
-                    ProcsAndRatesUnity.append((p,'1') if ('left' in p or 'right' in p or 'long' in p) else (p,r))
-    
-                combinedCardNew = open(cardfile+"_new",'w')
-                for l in combinedCard.readlines():
-                    if re.match("rate\s+",l):
-                        combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRatesUnity])+'\n')
-                    else: combinedCardNew.write(l)
-                Wlong = [(p,r) for (p,r) in ProcsAndRates if re.match('W.*long',p)]
-                WLeftOrRight = [(p,r) for (p,r) in ProcsAndRates if ('left' in p or 'right' in p)]
-                if options.scaleFile:
-                    eff_long = 1./getScales([ybins[0],ybins[-1]], charge, 'long', options.scaleFile)[0]
-                    eff_left = 1./getScales([ybins[0],ybins[-1]], charge, 'left', options.scaleFile)[0]
-                    eff_right = 1./getScales([ybins[0],ybins[-1]], charge, 'right', options.scaleFile)[0]
-                    normWLong = sum([float(r) for (p,r) in Wlong])/eff_long # there should be only 1 Wlong/charge
-                    normWLeft = sum([float(r) for (p,r) in WLeftOrRight if 'left' in p])/eff_left
-                    normWRight = sum([float(r) for (p,r) in WLeftOrRight if 'right' in p])/eff_right
-                    normWLeftOrRight = normWLeft + normWRight
-                    combinedCardNew.write("eff_{n}   rateParam * {n}    {eff:.5f} [{dn:.5f},{up:.5f}]\n".format(n=Wlong[0][0],eff=eff_long,dn=(1-1E-04)*eff_long,up=(1+1E-04)*eff_long))
-    
-                    ## i have no idea what happens after here in this if block...
-                    if options.longToTotal:
-                        r0overLR = normWLong/normWLeftOrRight
-                        combinedCardNew.write("norm_%-50s    rateParam * %-5s    %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
-                        wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
-                            % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
-                        combinedCardNew.write(wLongNormString)
-    
-                    ## if we do not constrain the long to the total, we should write the long yield here
-                    else:
-                        nl = normWLong; tc = tightConstraint
-                        combinedCardNew.write("norm_{n} rateParam * {n} {r:15.1f} [{dn:.1f},{up:.1f}]\n".format(n=Wlong[0][0],r=nl,dn=(1-tc)*nl,up=(1+tc)*nl))
-                        POIs.append('norm_{n}'.format(n=Wlong[0][0]))
-    
-                ## if we do not scale gen-reco, then we go back to before...
+                        expRate0 = float(ProcsAndRatesDict[helbin])
+                        param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
+                        combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
+
+                ## if not fitting full rates, we do the relative rateParams close to 1.
                 else:
-                    normWLong = sum([float(r) for (p,r) in Wlong]) # there should be only 1 Wlong/charge
-                    normWLeftOrRight = sum([float(r) for (p,r) in WLeftOrRight])
-                    if options.longToTotal:
-                        r0overLR = normWLong/normWLeftOrRight
-                        combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
-                        wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
-                            % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
-                        combinedCardNew.write(wLongNormString)
-                    else:
-                        combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLong,(1-tightConstraint)*normWLong,(1+tightConstraint)*normWLong))
+                    param_range_0 = '1. [{dn:.2f},{up:.2f}]'.format(dn=1-rateNuis,up=1+rateNuis)
+                    param_range_1 = param_range_0
+                    combinedCard.write('norm_{n}   rateParam * {n}    {pr}\n'.format(n=helbin,pr=param_range_0))
+                POIs.append(normPOI)
+
+        ## not sure this below will still work with absY, but for now i don't care (marc)
+        if not longBKG and not options.longLnN:
+            for i in xrange(len(signal_0)):
+                sfx = signal_0[i].split('_')[-1]
+                param_range = '[0.95,1.05]' if sfx in bins_to_constrain else '[0.95,1.05]'
+                combinedCard.write('norm_%-5s   rateParam * %-5s    1 %s\n' % (signal_0[i],signal_0[i],param_range))
+                POIs.append('norm_%s' % signal_0[i])
     
-                ## make an efficiency nuisance group
-                combinedCardNew.write('\nefficiencies group = eff_'+Wlong[0][0]+' '+' '.join([p.replace('norm','eff') for p in POIs])+'\n\n' )
+        if options.absoluteRates:
+            combinedCard = open(cardfile,'r')
+            procs = []
+            rates = []
+            for l in combinedCard.readlines():
+                if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
+                    procs = (l.rstrip().split())[1:]
+                if re.match("rate\s+",l):
+                    rates = (l.rstrip().split())[1:]
+                if len(procs) and len(rates): break
+            ProcsAndRates = zip(procs,rates)
+
+            combinedCard = open(cardfile,'r')
+            ProcsAndRatesUnity = []
+            for (p,r) in ProcsAndRates:
+                ProcsAndRatesUnity.append((p,'1') if ('left' in p or 'right' in p or 'long' in p) else (p,r))
+
+            combinedCardNew = open(cardfile+"_new",'w')
+            for l in combinedCard.readlines():
+                if re.match("rate\s+",l):
+                    combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRatesUnity])+'\n')
+                else: combinedCardNew.write(l)
+            Wlong = [(p,r) for (p,r) in ProcsAndRates if re.match('W.*long',p)]
+            WLeftOrRight = [(p,r) for (p,r) in ProcsAndRates if ('left' in p or 'right' in p)]
+            if options.scaleFile:
+                eff_long = 1./getScales([ybins[0],ybins[-1]], charge, 'long', options.scaleFile)[0]
+                eff_left = 1./getScales([ybins[0],ybins[-1]], charge, 'left', options.scaleFile)[0]
+                eff_right = 1./getScales([ybins[0],ybins[-1]], charge, 'right', options.scaleFile)[0]
+                normWLong = sum([float(r) for (p,r) in Wlong])/eff_long # there should be only 1 Wlong/charge
+                normWLeft = sum([float(r) for (p,r) in WLeftOrRight if 'left' in p])/eff_left
+                normWRight = sum([float(r) for (p,r) in WLeftOrRight if 'right' in p])/eff_right
+                normWLeftOrRight = normWLeft + normWRight
+                combinedCardNew.write("eff_{n}   rateParam * {n}    {eff:.5f} [{dn:.5f},{up:.5f}]\n".format(n=Wlong[0][0],eff=eff_long,dn=(1-1E-04)*eff_long,up=(1+1E-04)*eff_long))
+
+                ## i have no idea what happens after here in this if block...
+                if options.longToTotal:
+                    r0overLR = normWLong/normWLeftOrRight
+                    combinedCardNew.write("norm_%-50s    rateParam * %-5s    %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
+                    wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
+                        % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
+                    combinedCardNew.write(wLongNormString)
+
+                ## if we do not constrain the long to the total, we should write the long yield here
+                else:
+                    nl = normWLong; tc = tightConstraint
+                    combinedCardNew.write("norm_{n} rateParam * {n} {r:15.1f} [{dn:.1f},{up:.1f}]\n".format(n=Wlong[0][0],r=nl,dn=(1-tc)*nl,up=(1+tc)*nl))
+                    POIs.append('norm_{n}'.format(n=Wlong[0][0]))
+
+            ## if we do not scale gen-reco, then we go back to before...
+            else:
+                normWLong = sum([float(r) for (p,r) in Wlong]) # there should be only 1 Wlong/charge
+                normWLeftOrRight = sum([float(r) for (p,r) in WLeftOrRight])
+                if options.longToTotal:
+                    r0overLR = normWLong/normWLeftOrRight
+                    combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
+                    wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
+                        % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
+                    combinedCardNew.write(wLongNormString)
+                else:
+                    combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLong,(1-tightConstraint)*normWLong,(1+tightConstraint)*normWLong))
+
+            ## make an efficiency nuisance group
+            combinedCardNew.write('\nefficiencies group = eff_'+Wlong[0][0]+' '+' '.join([p.replace('norm','eff') for p in POIs])+'\n\n' )
+
+            ## add the PDF systematics 
+            for sys,procs in pdfsyst.iteritems():
+                # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
+                combinedCardNew.write('%-15s   shape %s\n' % (sys,(" ".join([kpatt % '1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
+            combinedCardNew.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
+
+            combinedCardNew.close() ## for some reason this is really necessary
+            os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
+
     
-                ## add the PDF systematics 
-                for sys,procs in pdfsyst.iteritems():
-                    # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
-                    combinedCardNew.write('%-15s   shape %s\n' % (sys,(" ".join([kpatt % '1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
-                combinedCardNew.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
+    ## remove all the POIs that we want to fix
+    fixedPOIs = []
+    for poi in POIs:
+        if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
+            fixedPOIs.append(poi)
+        if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
+            fixedPOIs.append(poi)
+    floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
+    allPOIs = fixedPOIs+floatPOIs
+
+    ## define the combine POIs, i.e. the subset on which to run MINOS
+    minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
+
+    ## make a group for the fixed rate parameters. just append it to the file.
+    print 'adding a nuisance group for the fixed rateParams'
+    with open(cardfile,'a+') as finalCardfile:
+        finalCardfile.write('\nfixedY group = {fixed} '.format(fixed=' '.join(i.strip() for i in fixedPOIs)))
+        finalCardfile.write('\nfixedMcErr group = {fixed} '.format(fixed=' '.join(i.strip().replace('norm','eff_unc') for i in fixedPOIs))) # not used in the command, but may be useful to stabilize the fit
+        finalCardfile.write('\n\n## end of file')
+    #finalCardfile.close()
+
+    print "merged datacard in ",cardfile
     
-                combinedCardNew.close() ## for some reason this is really necessary
-                os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
-    
+    #ws = "%s_ws.root" % options.bin
+    ws = cardfile.replace('_card.txt', '_ws.root')
+    txt2wsCmd = 'text2workspace.py {cf} -o {ws} --X-allow-no-signal --X-no-check-norm '.format(cf=cardfile, ws=ws)
+    print txt2wsCmd
+    os.system(txt2wsCmd)
         
-        ## remove all the POIs that we want to fix
-        fixedPOIs = []
-        for poi in POIs:
-            if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
-                fixedPOIs.append(poi)
-            if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
-                fixedPOIs.append(poi)
-        floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
-        allPOIs = fixedPOIs+floatPOIs
-    
-        ## define the combine POIs, i.e. the subset on which to run MINOS
-        minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
-    
-        ## make a group for the fixed rate parameters. just append it to the file.
-        print 'adding a nuisance group for the fixed rateParams'
-        with open(cardfile,'a+') as finalCardfile:
-            finalCardfile.write('\nfixedY group = {fixed} '.format(fixed=' '.join(i.strip() for i in fixedPOIs)))
-            finalCardfile.write('\nfixedMcErr group = {fixed} '.format(fixed=' '.join(i.strip().replace('norm','eff_unc') for i in fixedPOIs))) # not used in the command, but may be useful to stabilize the fit
-            finalCardfile.write('\n\n## end of file')
-        #finalCardfile.close()
-    
-        print "merged datacard in ",cardfile
-        
-        #ws = "%s_ws.root" % options.bin
-        ws = cardfile.replace('_card.txt', '_ws.root')
-        txt2wsCmd = 'text2workspace.py {cf} -o {ws} --X-allow-no-signal --X-no-check-norm '.format(cf=cardfile, ws=ws)
-        print txt2wsCmd
-        os.system(txt2wsCmd)
-            
-        combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''))
-        print combineCmd
-    
+    combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''))
+    print combineCmd
+

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -29,418 +29,419 @@ def mirrorShape(nominal,alternate,newname,alternateShapeOnly=False):
         mirror.Scale(mnorm/alternate.Integral())
     return (alternate,mirror)
 
+if __name__ == "__main__":
 
-from optparse import OptionParser
-parser = OptionParser(usage='%prog [options] cards/card*.txt')
-parser.add_option('-m','--merge-root', dest='mergeRoot', default=False, action='store_true', help='Merge the root files with the inputs also')
-parser.add_option('-i','--input', dest='inputdir', default='', type='string', help='input directory with all the cards inside')
-parser.add_option('-b','--bin', dest='bin', default='ch1', type='string', help='name of the bin')
-parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
-parser.add_option('-c','--constrain-rates', dest='constrainRateParams', type='string', default='0,1,2', help='add constraints on the rate parameters of (comma-separated list of) rapidity bins. Give only the left ones (e.g. 1 will constrain 1 with n-1 ')
-parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='', help='add here replacement of default rate-fixing. with format plusR=10,11,12;plusL=11,12;minusR=10,11,12;minusL=10,11 ')
-parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
-parser.add_option('-l','--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
-parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
-parser.add_option(     '--longToTotal', dest='longToTotal', type='float', default=None, help='Apply a constraint on the Wlong/Wtot rate. Implies fitting for absolute rates')
-parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
-(options, args) = parser.parse_args()
-
-from symmetrizeMatrixAbsY import getScales
-
-charges = options.charge.split(',')
-
-
-for charge in charges:
-
-    outfile  = os.path.join(options.inputdir,options.bin+'_{ch}_shapes.root'.format(ch=charge))
-    cardfile = os.path.join(options.inputdir,options.bin+'_{ch}_card.txt'   .format(ch=charge))
-
-    ## prepare the relevant files. only the datacards and the correct charge
-    files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
-    files = ( f for f in files if charge in f and 'pdf' not in f )
-    files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
-    files = list( ( os.path.join(options.inputdir, f) for f in files ) )
-    
-    existing_bins = []
-    empty_bins = []
-
-    ## look for the maximum ybin bin number
-    nbins = 0
-    print "FILES = ",files
-    for f in files:
-        if 'Ybin_' in f:
-            n = int(f[f.find('Ybin_')+5 : f.find('.card')])
-            if n>nbins: nbins=n
-            if n not in existing_bins: existing_bins.append(n)
-    print 'found {n} bins of rapidity'.format(n=nbins+1)
-
-    fixedYBins = {'plusR' : [n,n-1,n-2],
-                  'plusL' : [n],
-                  'minusR': [n,n-1,n-2],
-                  'minusL': [n],
-                 }
-    
-    if options.fixYBins:
-        splitted = options.fixYBins.split(';')
-        for comp in splitted:
-            chhel = comp.split('=')[0]
-            bins  = comp.split('=')[1]
-            fixedYBins[chhel] = list(int(i) for i in bins.split(','))
-            ## this doesn't work here anymore if not fixedYBins[chhel][0] == 0:
-            ## this doesn't work here anymore     raise RuntimeError, "Your fixed bins should start at 0!!"
-            ## this doesn't work here anymore if not max(fixedYBins[chhel]) == len(fixedYBins[chhel])-1:
-            ## this doesn't work here anymore     raise RuntimeError, "This list does not seem to be continuous. Fix!"
-    print fixedYBins
-
-
-    ybinfile = open(os.path.join(options.inputdir, 'binningYW.txt'),'r')
-    ybinline = ybinfile.readlines()[0]
-    ybins = list(float(i) for i in ybinline.split())
-    ybinfile.close()
-    #ybins = list(float(i) for i in options.Ybins.split(','))
-    for b in xrange(len(ybins)-1):
-        if b not in existing_bins: 
-            if b not in empty_bins:
-                empty_bins.append(b)
-                empty_bins.append(nbins+1-b)            
-
-    longBKG = False
-    tmpfiles = []
-    for f in files:
-        dir = os.path.dirname(f)
-        bin = ''
-        isEmpty = False
-        with open(f) as file:
-            for l in file.readlines():
-                if re.match('shapes.*',l):
-                    rootfile = dir+'/'+l.split()[3]
-                if re.match('bin.*',l):
-                    if len(l.split()) < 2: continue ## skip the second bin line if empty
-                    bin = l.split()[1]
-                    binn = int(bin.split('_')[-1]) if 'Ybin_' in bin else -1
-                basename = os.path.basename(f).split('.')[0]
-                rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
-                rootfiles_syst = [dir+'/'+x for x in rootfiles_syst]
-                rootfiles_syst.sort()
-                if re.match('process\s+',l): 
-                    if len(l.split()) > 1 and all(n.isdigit() for n in l.split()[1:]) : continue
-                    if not ('left' in l and 'right' in l):
-                        if not binn in empty_bins: 
-                            if binn >= 0:
-                                empty_bins.append(binn)
-                                empty_bins.append(nbins-binn)
-                        isEmpty = True
-                    processes = l.split()[1:]
-                if re.match('process\s+W.*long',l) and 'bkg' in f:
-                    print "===> W long is treated as a background"
-                    longBKG = True
-        if options.mergeRoot:
-            if not binn in empty_bins:
-                print 'processing bin = ',bin
-                nominals = {}
-                for irf,rf in enumerate([rootfile]+rootfiles_syst):
-                    print '\twith nominal/systematic file: ',rf
-                    tf = ROOT.TFile.Open(rf)
-                    tmpfile = os.path.join(options.inputdir,'tmp_{bin}_sys{sys}.root'.format(bin=bin,sys=irf))
-                    of=ROOT.TFile(tmpfile,'recreate')
-                    tmpfiles.append(tmpfile)
-                    # remove the duplicates also
-                    plots = {}
-                    for e in tf.GetListOfKeys() :
-                        name=e.GetName()
-                        obj=e.ReadObj()
-                        if (not re.match('Wplus|Wminus',os.path.basename(f))) and 'data_obs' in name: obj.Clone().Write()
-                        for p in processes:
-                            if p in name:
-                                newprocname = p+'_'+bin if re.match('Wplus|Wminus',p) else p
-                                if longBKG and re.match('(Wplus_long|Wminus_long)',p): newprocname = p
-                                newname = name.replace(p,newprocname)
-                                if irf==0:
-                                    if newname not in plots:
-                                        plots[newname] = obj.Clone(newname)
-                                        nominals[newname] = obj.Clone(newname+"0")
-                                        nominals[newname].SetDirectory(None)
-                                        #print 'replacing old %s with %s' % (name,newname)
-                                        plots[newname].Write()
-                                else:
-                                    tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); pdf = tokens[-1]
-                                    ipdf = int(pdf.split('pdf')[-1])
-                                    newname = "{pfx}_pdf{ipdf}".format(pfx=pfx,ipdf=ipdf)
-                                    (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname)
-                                    for alt in [alternate,mirror]:
-                                        if alt.GetName() not in plots:
-                                            plots[alt.GetName()] = alt.Clone()
-                                            plots[alt.GetName()].Write()
-                    of.Close()
-    if len(empty_bins):
-        print 'found a bunch of empty bins:', empty_bins
-    if options.mergeRoot:
-        haddcmd = 'hadd -f {of} {tmpfiles}'.format(of=outfile, tmpfiles=' '.join(tmpfiles) )
-        #print 'would run this now: ', haddcmd
-        #sys.exit()
-        os.system(haddcmd)
-        os.system('rm {rm}'.format(rm=' '.join(tmpfiles)))
-
-    print "Now trying to get info on PDF uncertainties..."
-    pdfsyst = {}
-    tf = ROOT.TFile.Open(outfile)
-    for e in tf.GetListOfKeys() :
-        name=e.GetName()
-        if 'pdf' in name:
-            if name.endswith("Up"): name = re.sub('Up$','',name)
-            if name.endswith("Down"): name = re.sub('Down$','',name)
-            syst = name.split('_')[-1]
-            binWsyst = '_'.join(name.split('_')[1:-1])
-            if syst not in pdfsyst: pdfsyst[syst] = [binWsyst]
-            else: pdfsyst[syst].append(binWsyst)
-    if len(pdfsyst): print "Found a bunch of PDF sysematics: ",pdfsyst.keys()
-    else: print "You are running w/o PDF systematics. Lucky you!"
-
-    combineCmd="combineCards.py "
-    for f in files:
-        basename = os.path.basename(f).split(".")[0]
-        binn = int(basename.split('_')[-1]) if 'Ybin_' in basename else 999
-        binname = basename if re.match('Wplus|Wminus',basename) else "other"
-        if not binn in empty_bins:
-            combineCmd += " %s=%s " % (binname,f)
-    tmpcard = os.path.join(options.inputdir,'tmpcard.txt')
-    combineCmd += ' > {tmpcard}'.format(tmpcard=tmpcard)
-    #sys.exit()
-    os.system(combineCmd)
-
-    combinedCard = open(cardfile,'w')
-    combinedCard.write("imax 1\n")
-    combinedCard.write("jmax *\n")
-    combinedCard.write("kmax *\n")
-    combinedCard.write('##----------------------------------\n') 
-    realprocesses = [] # array to preserve the sorting
-    with open(tmpcard) as file:    
-        nmatchbin=0
-        nmatchprocess=0
-        for l in file.readlines():
-            if re.match("shapes.*other",l):
-                variables = l.split()[4:]
-                combinedCard.write("shapes *  *  %s %s\n" % (os.path.abspath(outfile)," ".join(variables)))
-                combinedCard.write('##----------------------------------\n')
-            if re.match("bin",l) and nmatchbin==0: 
-                nmatchbin=1
-                combinedCard.write('bin   %s\n' % options.bin) 
-                bins = l.split()[1:]
-            if re.match("observation",l): 
-                yields = l.split()[1:]
-                observations = dict(zip(bins,yields))
-                combinedCard.write('observation %s\n' % observations['other'])
-                combinedCard.write('##----------------------------------\n')
-            if re.match("bin",l) and nmatchbin==1:
-                pseudobins = l.split()[1:]
-            if re.match("process",l):
-                if nmatchprocess==0:
-                    pseudoprocesses = l.split()[1:]
-                    klen = 7
-                    kpatt = " %%%ds "  % klen
-                    for i in xrange(len(pseudobins)):
-                        realprocesses.append(pseudoprocesses[i]+"_"+pseudobins[i] if ('Wminus' in pseudobins[i] or 'Wplus' in pseudobins[i]) else pseudoprocesses[i])
-                    combinedCard.write('bin            %s \n' % ' '.join([kpatt % options.bin for p in pseudoprocesses]))
-                    combinedCard.write('process        %s \n' % ' '.join([kpatt % p for p in realprocesses]))
-                    combinedCard.write('process        %s \n' % ' '.join([kpatt % str(i+1) for i in xrange(len(pseudobins))]))
-                nmatchprocess += 1
-            if nmatchprocess==2: 
-                nmatchprocess +=1
-            elif nmatchprocess>2: combinedCard.write(l)
-    
-    os.system('rm {tmpcard}'.format(tmpcard=tmpcard))
-    
-    if options.longToTotal or options.scaleFile: options.absoluteRates = True
-    
-    kpatt = " %7s "
-    if options.longLnN and not options.longToTotal:
-        combinedCard.write('norm_long_'+options.bin+'       lnN    ' + ' '.join([kpatt % (options.longLnN if 'long' in x else '-') for x in realprocesses])+'\n')
-
-    combinedCard = open(cardfile,'r')
-    procs = []
-    rates = []
-    for l in combinedCard.readlines():
-        if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
-            procs = (l.rstrip().split())[1:]
-        if re.match("rate\s+",l):
-            rates = (l.rstrip().split())[1:]
-        if len(procs) and len(rates): break
-    ProcsAndRates = zip(procs,rates)
-    ProcsAndRatesDict = dict(zip(procs,rates))
-
-    efficiencies    = {}; efferrors    = {}
-    efficiencies_LO = {}; efferrors_LO = {}
-    if options.scaleFile:
-        for pol in ['left','right','long']: 
-            efficiencies   [pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
-            efferrors      [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
-            efficiencies_LO[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False)]
-            efferrors_LO   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False, returnError=True)]
-
-    combinedCard = open(cardfile,'a')
-    POIs = []
-    if options.constrainRateParams:
-        signal_procs = filter(lambda x: re.match('Wplus|Wminus',x), realprocesses)
-        if longBKG: signal_procs = filter(lambda x: re.match('(?!Wplus_long|Wminus_long)',x), signal_procs)
-        signal_procs.sort(key=lambda x: int(x.split('_')[-1]))
-        signal_L = filter(lambda x: re.match('.*left.*',x),signal_procs)
-        signal_R = filter(lambda x: re.match('.*right.*',x),signal_procs)
-        signal_0 = filter(lambda x: re.match('.*long.*',x),signal_procs)
-        
-        hel_to_constrain = [signal_L,signal_R]
-        bins_to_constrain = options.constrainRateParams.split(',')
-        tightConstraint = 0.05
-        looseConstraint = tightConstraint
-        for hel in hel_to_constrain:
-            for iy,helbin in enumerate(hel):
-                pol = helbin.split('_')[1]
-                index_procs = procs.index(helbin)
-                lns = ' - '.join('' for i in range(index_procs+1))
-                lns += ' {effunc:.4f} '.format(effunc=1.+efferrors[pol][iy])
-                lns += ' - '.join('' for i in range(len(procs) - index_procs))
-                combinedCard.write('eff_unc_{hb}    lnN {lns}\n'.format(hb=helbin,lns=lns))
-        for hel in hel_to_constrain:
-            for iy,helbin in enumerate(hel):
-                sfx = str(iy)
-                pol = helbin.split('_')[1]
-                rateNuis = tightConstraint if iy in bins_to_constrain else looseConstraint
-                normPOI = 'norm_{n}'.format(n=helbin)
-
-                ## if we fit absolute rates, we need to get them from the process and plug them in below
-                if options.absoluteRates:
-
-                    ## if we want to fit with the efficiency gen-reco, we need to add one efficiency parameter
-                    if options.scaleFile:
-                        tmp_eff = efficiencies[pol][iy]
-                        combinedCard.write('eff_{n}    rateParam * {n} \t {eff:.5f} [{dn:.5f},{up:.5f}]\n'.format(n=helbin,eff=tmp_eff,dn=(1-1E-04)*tmp_eff,up=(1+1E-04)*tmp_eff))
-                        expRate0 = float(ProcsAndRatesDict[helbin])/tmp_eff
-                        param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
-                        combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
-
-                    ## if we do not want to fit the gen-level thing, we want to just put the absolute reco rates here
-                    else:
-                        expRate0 = float(ProcsAndRatesDict[helbin])
-                        param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
-                        combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
-
-                ## if not fitting full rates, we do the relative rateParams close to 1.
-                else:
-                    param_range_0 = '1. [{dn:.2f},{up:.2f}]'.format(dn=1-rateNuis,up=1+rateNuis)
-                    param_range_1 = param_range_0
-                    combinedCard.write('norm_{n}   rateParam * {n}    {pr}\n'.format(n=helbin,pr=param_range_0))
-                POIs.append(normPOI)
-
-        ## not sure this below will still work with absY, but for now i don't care (marc)
-        if not longBKG and not options.longLnN:
-            for i in xrange(len(signal_0)):
-                sfx = signal_0[i].split('_')[-1]
-                param_range = '[0.95,1.05]' if sfx in bins_to_constrain else '[0.95,1.05]'
-                combinedCard.write('norm_%-5s   rateParam * %-5s    1 %s\n' % (signal_0[i],signal_0[i],param_range))
-                POIs.append('norm_%s' % signal_0[i])
-    
-        if options.absoluteRates:
-            combinedCard = open(cardfile,'r')
-            procs = []
-            rates = []
-            for l in combinedCard.readlines():
-                if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
-                    procs = (l.rstrip().split())[1:]
-                if re.match("rate\s+",l):
-                    rates = (l.rstrip().split())[1:]
-                if len(procs) and len(rates): break
-            ProcsAndRates = zip(procs,rates)
-
-            combinedCard = open(cardfile,'r')
-            ProcsAndRatesUnity = []
-            for (p,r) in ProcsAndRates:
-                ProcsAndRatesUnity.append((p,'1') if ('left' in p or 'right' in p or 'long' in p) else (p,r))
-
-            combinedCardNew = open(cardfile+"_new",'w')
-            for l in combinedCard.readlines():
-                if re.match("rate\s+",l):
-                    combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRatesUnity])+'\n')
-                else: combinedCardNew.write(l)
-            Wlong = [(p,r) for (p,r) in ProcsAndRates if re.match('W.*long',p)]
-            WLeftOrRight = [(p,r) for (p,r) in ProcsAndRates if ('left' in p or 'right' in p)]
-            if options.scaleFile:
-                eff_long = 1./getScales([ybins[0],ybins[-1]], charge, 'long', options.scaleFile)[0]
-                eff_left = 1./getScales([ybins[0],ybins[-1]], charge, 'left', options.scaleFile)[0]
-                eff_right = 1./getScales([ybins[0],ybins[-1]], charge, 'right', options.scaleFile)[0]
-                normWLong = sum([float(r) for (p,r) in Wlong])/eff_long # there should be only 1 Wlong/charge
-                normWLeft = sum([float(r) for (p,r) in WLeftOrRight if 'left' in p])/eff_left
-                normWRight = sum([float(r) for (p,r) in WLeftOrRight if 'right' in p])/eff_right
-                normWLeftOrRight = normWLeft + normWRight
-                combinedCardNew.write("eff_{n}   rateParam * {n}    {eff:.5f} [{dn:.5f},{up:.5f}]\n".format(n=Wlong[0][0],eff=eff_long,dn=(1-1E-04)*eff_long,up=(1+1E-04)*eff_long))
-
-                ## i have no idea what happens after here in this if block...
-                if options.longToTotal:
-                    r0overLR = normWLong/normWLeftOrRight
-                    combinedCardNew.write("norm_%-50s    rateParam * %-5s    %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
-                    wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
-                        % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
-                    combinedCardNew.write(wLongNormString)
-
-                ## if we do not constrain the long to the total, we should write the long yield here
-                else:
-                    nl = normWLong; tc = tightConstraint
-                    combinedCardNew.write("norm_{n} rateParam * {n} {r:15.1f} [{dn:.1f},{up:.1f}]\n".format(n=Wlong[0][0],r=nl,dn=(1-tc)*nl,up=(1+tc)*nl))
-                    POIs.append('norm_{n}'.format(n=Wlong[0][0]))
-
-            ## if we do not scale gen-reco, then we go back to before...
-            else:
-                normWLong = sum([float(r) for (p,r) in Wlong]) # there should be only 1 Wlong/charge
-                normWLeftOrRight = sum([float(r) for (p,r) in WLeftOrRight])
-                if options.longToTotal:
-                    r0overLR = normWLong/normWLeftOrRight
-                    combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
-                    wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
-                        % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
-                    combinedCardNew.write(wLongNormString)
-                else:
-                    combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLong,(1-tightConstraint)*normWLong,(1+tightConstraint)*normWLong))
-
-            ## make an efficiency nuisance group
-            combinedCardNew.write('\nefficiencies group = eff_'+Wlong[0][0]+' '+' '.join([p.replace('norm','eff') for p in POIs])+'\n\n' )
-
-            ## add the PDF systematics 
-            for sys,procs in pdfsyst.iteritems():
-                # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
-                combinedCardNew.write('%-15s   shape %s\n' % (sys,(" ".join([kpatt % '1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
-            combinedCardNew.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
-
-            combinedCardNew.close() ## for some reason this is really necessary
-            os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
-
-    
-    ## remove all the POIs that we want to fix
-    fixedPOIs = []
-    for poi in POIs:
-        if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
-            fixedPOIs.append(poi)
-        if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
-            fixedPOIs.append(poi)
-    floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
-    allPOIs = fixedPOIs+floatPOIs
-
-    ## define the combine POIs, i.e. the subset on which to run MINOS
-    minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
-
-    ## make a group for the fixed rate parameters. just append it to the file.
-    print 'adding a nuisance group for the fixed rateParams'
-    with open(cardfile,'a+') as finalCardfile:
-        finalCardfile.write('\nfixedY group = {fixed} '.format(fixed=' '.join(i.strip() for i in fixedPOIs)))
-        finalCardfile.write('\nfixedMcErr group = {fixed} '.format(fixed=' '.join(i.strip().replace('norm','eff_unc') for i in fixedPOIs))) # not used in the command, but may be useful to stabilize the fit
-        finalCardfile.write('\n\n## end of file')
-    #finalCardfile.close()
-
-    print "merged datacard in ",cardfile
-    
-    #ws = "%s_ws.root" % options.bin
-    ws = cardfile.replace('_card.txt', '_ws.root')
-    txt2wsCmd = 'text2workspace.py {cf} -o {ws} --X-allow-no-signal --X-no-check-norm '.format(cf=cardfile, ws=ws)
-    print txt2wsCmd
-    os.system(txt2wsCmd)
-        
-    combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''))
-    print combineCmd
-
+     from optparse import OptionParser
+     parser = OptionParser(usage='%prog [options] cards/card*.txt')
+     parser.add_option('-m','--merge-root', dest='mergeRoot', default=False, action='store_true', help='Merge the root files with the inputs also')
+     parser.add_option('-i','--input', dest='inputdir', default='', type='string', help='input directory with all the cards inside')
+     parser.add_option('-b','--bin', dest='bin', default='ch1', type='string', help='name of the bin')
+     parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
+     parser.add_option('-c','--constrain-rates', dest='constrainRateParams', type='string', default='0,1,2', help='add constraints on the rate parameters of (comma-separated list of) rapidity bins. Give only the left ones (e.g. 1 will constrain 1 with n-1 ')
+     parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='', help='add here replacement of default rate-fixing. with format plusR=10,11,12;plusL=11,12;minusR=10,11,12;minusL=10,11 ')
+     parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
+     parser.add_option('-l','--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
+     parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
+     parser.add_option(     '--longToTotal', dest='longToTotal', type='float', default=None, help='Apply a constraint on the Wlong/Wtot rate. Implies fitting for absolute rates')
+     parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
+     (options, args) = parser.parse_args()
+     
+     from symmetrizeMatrixAbsY import getScales
+     
+     charges = options.charge.split(',')
+     
+     
+     for charge in charges:
+     
+         outfile  = os.path.join(options.inputdir,options.bin+'_{ch}_shapes.root'.format(ch=charge))
+         cardfile = os.path.join(options.inputdir,options.bin+'_{ch}_card.txt'   .format(ch=charge))
+     
+         ## prepare the relevant files. only the datacards and the correct charge
+         files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
+         files = ( f for f in files if charge in f and 'pdf' not in f )
+         files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
+         files = list( ( os.path.join(options.inputdir, f) for f in files ) )
+         
+         existing_bins = []
+         empty_bins = []
+     
+         ## look for the maximum ybin bin number
+         nbins = 0
+         print "FILES = ",files
+         for f in files:
+             if 'Ybin_' in f:
+                 n = int(f[f.find('Ybin_')+5 : f.find('.card')])
+                 if n>nbins: nbins=n
+                 if n not in existing_bins: existing_bins.append(n)
+         print 'found {n} bins of rapidity'.format(n=nbins+1)
+     
+         fixedYBins = {'plusR' : [n,n-1,n-2],
+                       'plusL' : [n],
+                       'minusR': [n,n-1,n-2],
+                       'minusL': [n],
+                      }
+         
+         if options.fixYBins:
+             splitted = options.fixYBins.split(';')
+             for comp in splitted:
+                 chhel = comp.split('=')[0]
+                 bins  = comp.split('=')[1]
+                 fixedYBins[chhel] = list(int(i) for i in bins.split(','))
+                 ## this doesn't work here anymore if not fixedYBins[chhel][0] == 0:
+                 ## this doesn't work here anymore     raise RuntimeError, "Your fixed bins should start at 0!!"
+                 ## this doesn't work here anymore if not max(fixedYBins[chhel]) == len(fixedYBins[chhel])-1:
+                 ## this doesn't work here anymore     raise RuntimeError, "This list does not seem to be continuous. Fix!"
+         print fixedYBins
+     
+     
+         ybinfile = open(os.path.join(options.inputdir, 'binningYW.txt'),'r')
+         ybinline = ybinfile.readlines()[0]
+         ybins = list(float(i) for i in ybinline.split())
+         ybinfile.close()
+         #ybins = list(float(i) for i in options.Ybins.split(','))
+         for b in xrange(len(ybins)-1):
+             if b not in existing_bins: 
+                 if b not in empty_bins:
+                     empty_bins.append(b)
+                     empty_bins.append(nbins+1-b)            
+     
+         longBKG = False
+         tmpfiles = []
+         for f in files:
+             dir = os.path.dirname(f)
+             bin = ''
+             isEmpty = False
+             with open(f) as file:
+                 for l in file.readlines():
+                     if re.match('shapes.*',l):
+                         rootfile = dir+'/'+l.split()[3]
+                     if re.match('bin.*',l):
+                         if len(l.split()) < 2: continue ## skip the second bin line if empty
+                         bin = l.split()[1]
+                         binn = int(bin.split('_')[-1]) if 'Ybin_' in bin else -1
+                     basename = os.path.basename(f).split('.')[0]
+                     rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
+                     rootfiles_syst = [dir+'/'+x for x in rootfiles_syst]
+                     rootfiles_syst.sort()
+                     if re.match('process\s+',l): 
+                         if len(l.split()) > 1 and all(n.isdigit() for n in l.split()[1:]) : continue
+                         if not ('left' in l and 'right' in l):
+                             if not binn in empty_bins: 
+                                 if binn >= 0:
+                                     empty_bins.append(binn)
+                                     empty_bins.append(nbins-binn)
+                             isEmpty = True
+                         processes = l.split()[1:]
+                     if re.match('process\s+W.*long',l) and 'bkg' in f:
+                         print "===> W long is treated as a background"
+                         longBKG = True
+             if options.mergeRoot:
+                 if not binn in empty_bins:
+                     print 'processing bin = ',bin
+                     nominals = {}
+                     for irf,rf in enumerate([rootfile]+rootfiles_syst):
+                         print '\twith nominal/systematic file: ',rf
+                         tf = ROOT.TFile.Open(rf)
+                         tmpfile = os.path.join(options.inputdir,'tmp_{bin}_sys{sys}.root'.format(bin=bin,sys=irf))
+                         of=ROOT.TFile(tmpfile,'recreate')
+                         tmpfiles.append(tmpfile)
+                         # remove the duplicates also
+                         plots = {}
+                         for e in tf.GetListOfKeys() :
+                             name=e.GetName()
+                             obj=e.ReadObj()
+                             if (not re.match('Wplus|Wminus',os.path.basename(f))) and 'data_obs' in name: obj.Clone().Write()
+                             for p in processes:
+                                 if p in name:
+                                     newprocname = p+'_'+bin if re.match('Wplus|Wminus',p) else p
+                                     if longBKG and re.match('(Wplus_long|Wminus_long)',p): newprocname = p
+                                     newname = name.replace(p,newprocname)
+                                     if irf==0:
+                                         if newname not in plots:
+                                             plots[newname] = obj.Clone(newname)
+                                             nominals[newname] = obj.Clone(newname+"0")
+                                             nominals[newname].SetDirectory(None)
+                                             #print 'replacing old %s with %s' % (name,newname)
+                                             plots[newname].Write()
+                                     else:
+                                         tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); pdf = tokens[-1]
+                                         ipdf = int(pdf.split('pdf')[-1])
+                                         newname = "{pfx}_pdf{ipdf}".format(pfx=pfx,ipdf=ipdf)
+                                         (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname)
+                                         for alt in [alternate,mirror]:
+                                             if alt.GetName() not in plots:
+                                                 plots[alt.GetName()] = alt.Clone()
+                                                 plots[alt.GetName()].Write()
+                         of.Close()
+         if len(empty_bins):
+             print 'found a bunch of empty bins:', empty_bins
+         if options.mergeRoot:
+             haddcmd = 'hadd -f {of} {tmpfiles}'.format(of=outfile, tmpfiles=' '.join(tmpfiles) )
+             #print 'would run this now: ', haddcmd
+             #sys.exit()
+             os.system(haddcmd)
+             os.system('rm {rm}'.format(rm=' '.join(tmpfiles)))
+     
+         print "Now trying to get info on PDF uncertainties..."
+         pdfsyst = {}
+         tf = ROOT.TFile.Open(outfile)
+         for e in tf.GetListOfKeys() :
+             name=e.GetName()
+             if 'pdf' in name:
+                 if name.endswith("Up"): name = re.sub('Up$','',name)
+                 if name.endswith("Down"): name = re.sub('Down$','',name)
+                 syst = name.split('_')[-1]
+                 binWsyst = '_'.join(name.split('_')[1:-1])
+                 if syst not in pdfsyst: pdfsyst[syst] = [binWsyst]
+                 else: pdfsyst[syst].append(binWsyst)
+         if len(pdfsyst): print "Found a bunch of PDF sysematics: ",pdfsyst.keys()
+         else: print "You are running w/o PDF systematics. Lucky you!"
+     
+         combineCmd="combineCards.py "
+         for f in files:
+             basename = os.path.basename(f).split(".")[0]
+             binn = int(basename.split('_')[-1]) if 'Ybin_' in basename else 999
+             binname = basename if re.match('Wplus|Wminus',basename) else "other"
+             if not binn in empty_bins:
+                 combineCmd += " %s=%s " % (binname,f)
+         tmpcard = os.path.join(options.inputdir,'tmpcard.txt')
+         combineCmd += ' > {tmpcard}'.format(tmpcard=tmpcard)
+         #sys.exit()
+         os.system(combineCmd)
+     
+         combinedCard = open(cardfile,'w')
+         combinedCard.write("imax 1\n")
+         combinedCard.write("jmax *\n")
+         combinedCard.write("kmax *\n")
+         combinedCard.write('##----------------------------------\n') 
+         realprocesses = [] # array to preserve the sorting
+         with open(tmpcard) as file:    
+             nmatchbin=0
+             nmatchprocess=0
+             for l in file.readlines():
+                 if re.match("shapes.*other",l):
+                     variables = l.split()[4:]
+                     combinedCard.write("shapes *  *  %s %s\n" % (os.path.abspath(outfile)," ".join(variables)))
+                     combinedCard.write('##----------------------------------\n')
+                 if re.match("bin",l) and nmatchbin==0: 
+                     nmatchbin=1
+                     combinedCard.write('bin   %s\n' % options.bin) 
+                     bins = l.split()[1:]
+                 if re.match("observation",l): 
+                     yields = l.split()[1:]
+                     observations = dict(zip(bins,yields))
+                     combinedCard.write('observation %s\n' % observations['other'])
+                     combinedCard.write('##----------------------------------\n')
+                 if re.match("bin",l) and nmatchbin==1:
+                     pseudobins = l.split()[1:]
+                 if re.match("process",l):
+                     if nmatchprocess==0:
+                         pseudoprocesses = l.split()[1:]
+                         klen = 7
+                         kpatt = " %%%ds "  % klen
+                         for i in xrange(len(pseudobins)):
+                             realprocesses.append(pseudoprocesses[i]+"_"+pseudobins[i] if ('Wminus' in pseudobins[i] or 'Wplus' in pseudobins[i]) else pseudoprocesses[i])
+                         combinedCard.write('bin            %s \n' % ' '.join([kpatt % options.bin for p in pseudoprocesses]))
+                         combinedCard.write('process        %s \n' % ' '.join([kpatt % p for p in realprocesses]))
+                         combinedCard.write('process        %s \n' % ' '.join([kpatt % str(i+1) for i in xrange(len(pseudobins))]))
+                     nmatchprocess += 1
+                 if nmatchprocess==2: 
+                     nmatchprocess +=1
+                 elif nmatchprocess>2: combinedCard.write(l)
+         
+         os.system('rm {tmpcard}'.format(tmpcard=tmpcard))
+         
+         if options.longToTotal or options.scaleFile: options.absoluteRates = True
+         
+         kpatt = " %7s "
+         if options.longLnN and not options.longToTotal:
+             combinedCard.write('norm_long_'+options.bin+'       lnN    ' + ' '.join([kpatt % (options.longLnN if 'long' in x else '-') for x in realprocesses])+'\n')
+     
+         combinedCard = open(cardfile,'r')
+         procs = []
+         rates = []
+         for l in combinedCard.readlines():
+             if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
+                 procs = (l.rstrip().split())[1:]
+             if re.match("rate\s+",l):
+                 rates = (l.rstrip().split())[1:]
+             if len(procs) and len(rates): break
+         ProcsAndRates = zip(procs,rates)
+         ProcsAndRatesDict = dict(zip(procs,rates))
+     
+         efficiencies    = {}; efferrors    = {}
+         efficiencies_LO = {}; efferrors_LO = {}
+         if options.scaleFile:
+             for pol in ['left','right','long']: 
+                 efficiencies   [pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
+                 efferrors      [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
+                 efficiencies_LO[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False)]
+                 efferrors_LO   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False, returnError=True)]
+     
+         combinedCard = open(cardfile,'a')
+         POIs = []
+         if options.constrainRateParams:
+             signal_procs = filter(lambda x: re.match('Wplus|Wminus',x), realprocesses)
+             if longBKG: signal_procs = filter(lambda x: re.match('(?!Wplus_long|Wminus_long)',x), signal_procs)
+             signal_procs.sort(key=lambda x: int(x.split('_')[-1]))
+             signal_L = filter(lambda x: re.match('.*left.*',x),signal_procs)
+             signal_R = filter(lambda x: re.match('.*right.*',x),signal_procs)
+             signal_0 = filter(lambda x: re.match('.*long.*',x),signal_procs)
+             
+             hel_to_constrain = [signal_L,signal_R]
+             bins_to_constrain = options.constrainRateParams.split(',')
+             tightConstraint = 0.05
+             looseConstraint = tightConstraint
+             for hel in hel_to_constrain:
+                 for iy,helbin in enumerate(hel):
+                     pol = helbin.split('_')[1]
+                     index_procs = procs.index(helbin)
+                     lns = ' - '.join('' for i in range(index_procs+1))
+                     lns += ' {effunc:.4f} '.format(effunc=1.+efferrors[pol][iy])
+                     lns += ' - '.join('' for i in range(len(procs) - index_procs))
+                     combinedCard.write('eff_unc_{hb}    lnN {lns}\n'.format(hb=helbin,lns=lns))
+             for hel in hel_to_constrain:
+                 for iy,helbin in enumerate(hel):
+                     sfx = str(iy)
+                     pol = helbin.split('_')[1]
+                     rateNuis = tightConstraint if iy in bins_to_constrain else looseConstraint
+                     normPOI = 'norm_{n}'.format(n=helbin)
+     
+                     ## if we fit absolute rates, we need to get them from the process and plug them in below
+                     if options.absoluteRates:
+     
+                         ## if we want to fit with the efficiency gen-reco, we need to add one efficiency parameter
+                         if options.scaleFile:
+                             tmp_eff = efficiencies[pol][iy]
+                             combinedCard.write('eff_{n}    rateParam * {n} \t {eff:.5f} [{dn:.5f},{up:.5f}]\n'.format(n=helbin,eff=tmp_eff,dn=(1-1E-04)*tmp_eff,up=(1+1E-04)*tmp_eff))
+                             expRate0 = float(ProcsAndRatesDict[helbin])/tmp_eff
+                             param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
+                             combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
+     
+                         ## if we do not want to fit the gen-level thing, we want to just put the absolute reco rates here
+                         else:
+                             expRate0 = float(ProcsAndRatesDict[helbin])
+                             param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
+                             combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
+     
+                     ## if not fitting full rates, we do the relative rateParams close to 1.
+                     else:
+                         param_range_0 = '1. [{dn:.2f},{up:.2f}]'.format(dn=1-rateNuis,up=1+rateNuis)
+                         param_range_1 = param_range_0
+                         combinedCard.write('norm_{n}   rateParam * {n}    {pr}\n'.format(n=helbin,pr=param_range_0))
+                     POIs.append(normPOI)
+     
+             ## not sure this below will still work with absY, but for now i don't care (marc)
+             if not longBKG and not options.longLnN:
+                 for i in xrange(len(signal_0)):
+                     sfx = signal_0[i].split('_')[-1]
+                     param_range = '[0.95,1.05]' if sfx in bins_to_constrain else '[0.95,1.05]'
+                     combinedCard.write('norm_%-5s   rateParam * %-5s    1 %s\n' % (signal_0[i],signal_0[i],param_range))
+                     POIs.append('norm_%s' % signal_0[i])
+         
+             if options.absoluteRates:
+                 combinedCard = open(cardfile,'r')
+                 procs = []
+                 rates = []
+                 for l in combinedCard.readlines():
+                     if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
+                         procs = (l.rstrip().split())[1:]
+                     if re.match("rate\s+",l):
+                         rates = (l.rstrip().split())[1:]
+                     if len(procs) and len(rates): break
+                 ProcsAndRates = zip(procs,rates)
+     
+                 combinedCard = open(cardfile,'r')
+                 ProcsAndRatesUnity = []
+                 for (p,r) in ProcsAndRates:
+                     ProcsAndRatesUnity.append((p,'1') if ('left' in p or 'right' in p or 'long' in p) else (p,r))
+     
+                 combinedCardNew = open(cardfile+"_new",'w')
+                 for l in combinedCard.readlines():
+                     if re.match("rate\s+",l):
+                         combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRatesUnity])+'\n')
+                     else: combinedCardNew.write(l)
+                 Wlong = [(p,r) for (p,r) in ProcsAndRates if re.match('W.*long',p)]
+                 WLeftOrRight = [(p,r) for (p,r) in ProcsAndRates if ('left' in p or 'right' in p)]
+                 if options.scaleFile:
+                     eff_long = 1./getScales([ybins[0],ybins[-1]], charge, 'long', options.scaleFile)[0]
+                     eff_left = 1./getScales([ybins[0],ybins[-1]], charge, 'left', options.scaleFile)[0]
+                     eff_right = 1./getScales([ybins[0],ybins[-1]], charge, 'right', options.scaleFile)[0]
+                     normWLong = sum([float(r) for (p,r) in Wlong])/eff_long # there should be only 1 Wlong/charge
+                     normWLeft = sum([float(r) for (p,r) in WLeftOrRight if 'left' in p])/eff_left
+                     normWRight = sum([float(r) for (p,r) in WLeftOrRight if 'right' in p])/eff_right
+                     normWLeftOrRight = normWLeft + normWRight
+                     combinedCardNew.write("eff_{n}   rateParam * {n}    {eff:.5f} [{dn:.5f},{up:.5f}]\n".format(n=Wlong[0][0],eff=eff_long,dn=(1-1E-04)*eff_long,up=(1+1E-04)*eff_long))
+     
+                     ## i have no idea what happens after here in this if block...
+                     if options.longToTotal:
+                         r0overLR = normWLong/normWLeftOrRight
+                         combinedCardNew.write("norm_%-50s    rateParam * %-5s    %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
+                         wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
+                             % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
+                         combinedCardNew.write(wLongNormString)
+     
+                     ## if we do not constrain the long to the total, we should write the long yield here
+                     else:
+                         nl = normWLong; tc = tightConstraint
+                         combinedCardNew.write("norm_{n} rateParam * {n} {r:15.1f} [{dn:.1f},{up:.1f}]\n".format(n=Wlong[0][0],r=nl,dn=(1-tc)*nl,up=(1+tc)*nl))
+                         POIs.append('norm_{n}'.format(n=Wlong[0][0]))
+     
+                 ## if we do not scale gen-reco, then we go back to before...
+                 else:
+                     normWLong = sum([float(r) for (p,r) in Wlong]) # there should be only 1 Wlong/charge
+                     normWLeftOrRight = sum([float(r) for (p,r) in WLeftOrRight])
+                     if options.longToTotal:
+                         r0overLR = normWLong/normWLeftOrRight
+                         combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
+                         wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
+                             % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
+                         combinedCardNew.write(wLongNormString)
+                     else:
+                         combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLong,(1-tightConstraint)*normWLong,(1+tightConstraint)*normWLong))
+     
+                 ## make an efficiency nuisance group
+                 combinedCardNew.write('\nefficiencies group = eff_'+Wlong[0][0]+' '+' '.join([p.replace('norm','eff') for p in POIs])+'\n\n' )
+     
+                 ## add the PDF systematics 
+                 for sys,procs in pdfsyst.iteritems():
+                     # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
+                     combinedCardNew.write('%-15s   shape %s\n' % (sys,(" ".join([kpatt % '1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
+                 combinedCardNew.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
+     
+                 combinedCardNew.close() ## for some reason this is really necessary
+                 os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
+     
+         
+         ## remove all the POIs that we want to fix
+         fixedPOIs = []
+         for poi in POIs:
+             if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
+                 fixedPOIs.append(poi)
+             if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
+                 fixedPOIs.append(poi)
+         floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
+         allPOIs = fixedPOIs+floatPOIs
+     
+         ## define the combine POIs, i.e. the subset on which to run MINOS
+         minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
+     
+         ## make a group for the fixed rate parameters. just append it to the file.
+         print 'adding a nuisance group for the fixed rateParams'
+         with open(cardfile,'a+') as finalCardfile:
+             finalCardfile.write('\nfixedY group = {fixed} '.format(fixed=' '.join(i.strip() for i in fixedPOIs)))
+             finalCardfile.write('\nfixedMcErr group = {fixed} '.format(fixed=' '.join(i.strip().replace('norm','eff_unc') for i in fixedPOIs))) # not used in the command, but may be useful to stabilize the fit
+             finalCardfile.write('\n\n## end of file')
+         #finalCardfile.close()
+     
+         print "merged datacard in ",cardfile
+         
+         #ws = "%s_ws.root" % options.bin
+         ws = cardfile.replace('_card.txt', '_ws.root')
+         txt2wsCmd = 'text2workspace.py {cf} -o {ws} --X-allow-no-signal --X-no-check-norm '.format(cf=cardfile, ws=ws)
+         print txt2wsCmd
+         os.system(txt2wsCmd)
+             
+         combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''))
+         print combineCmd
+     

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -29,415 +29,416 @@ def mirrorShape(nominal,alternate,newname,alternateShapeOnly=False):
         mirror.Scale(mnorm/alternate.Integral())
     return (alternate,mirror)
 
+if __name__ == "__main__":
 
-from optparse import OptionParser
-parser = OptionParser(usage='%prog [options] cards/card*.txt')
-parser.add_option('-m','--merge-root', dest='mergeRoot', default=False, action='store_true', help='Merge the root files with the inputs also')
-parser.add_option('-i','--input', dest='inputdir', default='', type='string', help='input directory with all the cards inside')
-parser.add_option('-b','--bin', dest='bin', default='ch1', type='string', help='name of the bin')
-parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
-parser.add_option('-c','--constrain-rates', dest='constrainRateParams', type='string', default='0,1,2', help='add constraints on the rate parameters of (comma-separated list of) rapidity bins. Give only the left ones (e.g. 1 will constrain 1 with n-1 ')
-parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='', help='add here replacement of default rate-fixing. with format plusR=10,11,12;plusL=11,12;minusR=10,11,12;minusL=10,11 ')
-parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
-parser.add_option('-l','--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
-parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
-parser.add_option(     '--longToTotal', dest='longToTotal', type='float', default=None, help='Apply a constraint on the Wlong/Wtot rate. Implies fitting for absolute rates')
-parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
-(options, args) = parser.parse_args()
-
-from symmetrizeMatrixAbsY import getScales
-
-charges = options.charge.split(',')
-
-
-for charge in charges:
-
-    outfile  = os.path.join(options.inputdir,options.bin+'_{ch}_shapes.root'.format(ch=charge))
-    cardfile = os.path.join(options.inputdir,options.bin+'_{ch}_card.txt'   .format(ch=charge))
-
-    ## prepare the relevant files. only the datacards and the correct charge
-    files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
-    files = ( f for f in files if charge in f and 'pdf' not in f )
-    files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
-    files = list( ( os.path.join(options.inputdir, f) for f in files ) )
+    from optparse import OptionParser
+    parser = OptionParser(usage='%prog [options] cards/card*.txt')
+    parser.add_option('-m','--merge-root', dest='mergeRoot', default=False, action='store_true', help='Merge the root files with the inputs also')
+    parser.add_option('-i','--input', dest='inputdir', default='', type='string', help='input directory with all the cards inside')
+    parser.add_option('-b','--bin', dest='bin', default='ch1', type='string', help='name of the bin')
+    parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
+    parser.add_option('-c','--constrain-rates', dest='constrainRateParams', type='string', default='0,1,2', help='add constraints on the rate parameters of (comma-separated list of) rapidity bins. Give only the left ones (e.g. 1 will constrain 1 with n-1 ')
+    parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='', help='add here replacement of default rate-fixing. with format plusR=10,11,12;plusL=11,12;minusR=10,11,12;minusL=10,11 ')
+    parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
+    parser.add_option('-l','--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
+    parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
+    parser.add_option(     '--longToTotal', dest='longToTotal', type='float', default=None, help='Apply a constraint on the Wlong/Wtot rate. Implies fitting for absolute rates')
+    parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
+    (options, args) = parser.parse_args()
     
-    existing_bins = []
-    empty_bins = []
-
-    ## look for the maximum ybin bin number
-    nbins = 0
-    print "FILES = ",files
-    for f in files:
-        if 'Ybin_' in f:
-            n = int(f[f.find('Ybin_')+5 : f.find('.card')])
-            if n>nbins: nbins=n
-            if n not in existing_bins: existing_bins.append(n)
-    print 'found {n} bins of rapidity'.format(n=nbins+1)
-
-    fixedYBins = {'plusR' : [n,n-1,n-2],
-                  'plusL' : [n],
-                  'minusR': [n,n-1,n-2],
-                  'minusL': [n],
-                 }
+    from symmetrizeMatrixAbsY import getScales
     
-    if options.fixYBins:
-        splitted = options.fixYBins.split(';')
-        for comp in splitted:
-            chhel = comp.split('=')[0]
-            bins  = comp.split('=')[1]
-            fixedYBins[chhel] = list(int(i) for i in bins.split(','))
-            ## this doesn't work here anymore if not fixedYBins[chhel][0] == 0:
-            ## this doesn't work here anymore     raise RuntimeError, "Your fixed bins should start at 0!!"
-            ## this doesn't work here anymore if not max(fixedYBins[chhel]) == len(fixedYBins[chhel])-1:
-            ## this doesn't work here anymore     raise RuntimeError, "This list does not seem to be continuous. Fix!"
-    print fixedYBins
-
-
-    ybinfile = open(os.path.join(options.inputdir, 'binningYW.txt'),'r')
-    ybinline = ybinfile.readlines()[0]
-    ybins = list(float(i) for i in ybinline.split())
-    ybinfile.close()
-    #ybins = list(float(i) for i in options.Ybins.split(','))
-    for b in xrange(len(ybins)-1):
-        if b not in existing_bins: 
-            if b not in empty_bins:
-                empty_bins.append(b)
-                empty_bins.append(nbins+1-b)            
-
-    longBKG = False
-    tmpfiles = []
-    for f in files:
-        dir = os.path.dirname(f)
-        bin = ''
-        isEmpty = False
-        with open(f) as file:
-            for l in file.readlines():
-                if re.match('shapes.*',l):
-                    rootfile = dir+'/'+l.split()[3]
-                if re.match('bin.*',l):
-                    if len(l.split()) < 2: continue ## skip the second bin line if empty
-                    bin = l.split()[1]
-                    binn = int(bin.split('_')[-1]) if 'Ybin_' in bin else -1
-                basename = os.path.basename(f).split('.')[0]
-                rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
-                rootfiles_syst = [dir+'/'+x for x in rootfiles_syst]
-                rootfiles_syst.sort()
-                if re.match('process\s+',l): 
-                    if len(l.split()) > 1 and all(n.isdigit() for n in l.split()[1:]) : continue
-                    if not ('left' in l and 'right' in l):
-                        if not binn in empty_bins: 
-                            if binn >= 0:
-                                empty_bins.append(binn)
-                                empty_bins.append(nbins-binn)
-                        isEmpty = True
-                    processes = l.split()[1:]
-                if re.match('process\s+W.*long',l) and 'bkg' in f:
-                    print "===> W long is treated as a background"
-                    longBKG = True
+    charges = options.charge.split(',')
+    
+    
+    for charge in charges:
+    
+        outfile  = os.path.join(options.inputdir,options.bin+'_{ch}_shapes.root'.format(ch=charge))
+        cardfile = os.path.join(options.inputdir,options.bin+'_{ch}_card.txt'   .format(ch=charge))
+    
+        ## prepare the relevant files. only the datacards and the correct charge
+        files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
+        files = ( f for f in files if charge in f and 'pdf' not in f )
+        files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
+        files = list( ( os.path.join(options.inputdir, f) for f in files ) )
+        
+        existing_bins = []
+        empty_bins = []
+    
+        ## look for the maximum ybin bin number
+        nbins = 0
+        print "FILES = ",files
+        for f in files:
+            if 'Ybin_' in f:
+                n = int(f[f.find('Ybin_')+5 : f.find('.card')])
+                if n>nbins: nbins=n
+                if n not in existing_bins: existing_bins.append(n)
+        print 'found {n} bins of rapidity'.format(n=nbins+1)
+    
+        fixedYBins = {'plusR' : [n,n-1,n-2],
+                      'plusL' : [n],
+                      'minusR': [n,n-1,n-2],
+                      'minusL': [n],
+                     }
+        
+        if options.fixYBins:
+            splitted = options.fixYBins.split(';')
+            for comp in splitted:
+                chhel = comp.split('=')[0]
+                bins  = comp.split('=')[1]
+                fixedYBins[chhel] = list(int(i) for i in bins.split(','))
+                ## this doesn't work here anymore if not fixedYBins[chhel][0] == 0:
+                ## this doesn't work here anymore     raise RuntimeError, "Your fixed bins should start at 0!!"
+                ## this doesn't work here anymore if not max(fixedYBins[chhel]) == len(fixedYBins[chhel])-1:
+                ## this doesn't work here anymore     raise RuntimeError, "This list does not seem to be continuous. Fix!"
+        print fixedYBins
+    
+    
+        ybinfile = open(os.path.join(options.inputdir, 'binningYW.txt'),'r')
+        ybinline = ybinfile.readlines()[0]
+        ybins = list(float(i) for i in ybinline.split())
+        ybinfile.close()
+        #ybins = list(float(i) for i in options.Ybins.split(','))
+        for b in xrange(len(ybins)-1):
+            if b not in existing_bins: 
+                if b not in empty_bins:
+                    empty_bins.append(b)
+                    empty_bins.append(nbins+1-b)            
+    
+        longBKG = False
+        tmpfiles = []
+        for f in files:
+            dir = os.path.dirname(f)
+            bin = ''
+            isEmpty = False
+            with open(f) as file:
+                for l in file.readlines():
+                    if re.match('shapes.*',l):
+                        rootfile = dir+'/'+l.split()[3]
+                    if re.match('bin.*',l):
+                        if len(l.split()) < 2: continue ## skip the second bin line if empty
+                        bin = l.split()[1]
+                        binn = int(bin.split('_')[-1]) if 'Ybin_' in bin else -1
+                    basename = os.path.basename(f).split('.')[0]
+                    rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
+                    rootfiles_syst = [dir+'/'+x for x in rootfiles_syst]
+                    rootfiles_syst.sort()
+                    if re.match('process\s+',l): 
+                        if len(l.split()) > 1 and all(n.isdigit() for n in l.split()[1:]) : continue
+                        if not ('left' in l and 'right' in l):
+                            if not binn in empty_bins: 
+                                if binn >= 0:
+                                    empty_bins.append(binn)
+                                    empty_bins.append(nbins-binn)
+                            isEmpty = True
+                        processes = l.split()[1:]
+                    if re.match('process\s+W.*long',l) and 'bkg' in f:
+                        print "===> W long is treated as a background"
+                        longBKG = True
+            if options.mergeRoot:
+                if not binn in empty_bins:
+                    print 'processing bin = ',bin
+                    nominals = {}
+                    for irf,rf in enumerate([rootfile]+rootfiles_syst):
+                        print '\twith nominal/systematic file: ',rf
+                        tf = ROOT.TFile.Open(rf)
+                        tmpfile = os.path.join(options.inputdir,'tmp_{bin}_sys{sys}.root'.format(bin=bin,sys=irf))
+                        of=ROOT.TFile(tmpfile,'recreate')
+                        tmpfiles.append(tmpfile)
+                        # remove the duplicates also
+                        plots = {}
+                        for e in tf.GetListOfKeys() :
+                            name=e.GetName()
+                            obj=e.ReadObj()
+                            if (not re.match('Wplus|Wminus',os.path.basename(f))) and 'data_obs' in name: obj.Clone().Write()
+                            for p in processes:
+                                if p in name:
+                                    newprocname = p+'_'+bin if re.match('Wplus|Wminus',p) else p
+                                    if longBKG and re.match('(Wplus_long|Wminus_long)',p): newprocname = p
+                                    newname = name.replace(p,newprocname)
+                                    if irf==0:
+                                        if newname not in plots:
+                                            plots[newname] = obj.Clone(newname)
+                                            nominals[newname] = obj.Clone(newname+"0")
+                                            nominals[newname].SetDirectory(None)
+                                            #print 'replacing old %s with %s' % (name,newname)
+                                            plots[newname].Write()
+                                    else:
+                                        tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); pdf = tokens[-1]
+                                        ipdf = int(pdf.split('pdf')[-1])
+                                        newname = "{pfx}_pdf{ipdf}".format(pfx=pfx,ipdf=ipdf)
+                                        (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname)
+                                        for alt in [alternate,mirror]:
+                                            if alt.GetName() not in plots:
+                                                plots[alt.GetName()] = alt.Clone()
+                                                plots[alt.GetName()].Write()
+                        of.Close()
+        if len(empty_bins):
+            print 'found a bunch of empty bins:', empty_bins
         if options.mergeRoot:
+            haddcmd = 'hadd -f {of} {tmpfiles}'.format(of=outfile, tmpfiles=' '.join(tmpfiles) )
+            #print 'would run this now: ', haddcmd
+            #sys.exit()
+            os.system(haddcmd)
+            os.system('rm {rm}'.format(rm=' '.join(tmpfiles)))
+    
+        print "Now trying to get info on PDF uncertainties..."
+        pdfsyst = {}
+        tf = ROOT.TFile.Open(outfile)
+        for e in tf.GetListOfKeys() :
+            name=e.GetName()
+            if 'pdf' in name:
+                if name.endswith("Up"): name = re.sub('Up$','',name)
+                if name.endswith("Down"): name = re.sub('Down$','',name)
+                syst = name.split('_')[-1]
+                binWsyst = '_'.join(name.split('_')[1:-1])
+                if syst not in pdfsyst: pdfsyst[syst] = [binWsyst]
+                else: pdfsyst[syst].append(binWsyst)
+        if len(pdfsyst): print "Found a bunch of PDF sysematics: ",pdfsyst.keys()
+        else: print "You are running w/o PDF systematics. Lucky you!"
+    
+        combineCmd="combineCards.py "
+        for f in files:
+            basename = os.path.basename(f).split(".")[0]
+            binn = int(basename.split('_')[-1]) if 'Ybin_' in basename else 999
+            binname = basename if re.match('Wplus|Wminus',basename) else "other"
             if not binn in empty_bins:
-                print 'processing bin = ',bin
-                nominals = {}
-                for irf,rf in enumerate([rootfile]+rootfiles_syst):
-                    print '\twith nominal/systematic file: ',rf
-                    tf = ROOT.TFile.Open(rf)
-                    tmpfile = os.path.join(options.inputdir,'tmp_{bin}_sys{sys}.root'.format(bin=bin,sys=irf))
-                    of=ROOT.TFile(tmpfile,'recreate')
-                    tmpfiles.append(tmpfile)
-                    # remove the duplicates also
-                    plots = {}
-                    for e in tf.GetListOfKeys() :
-                        name=e.GetName()
-                        obj=e.ReadObj()
-                        if (not re.match('Wplus|Wminus',os.path.basename(f))) and 'data_obs' in name: obj.Clone().Write()
-                        for p in processes:
-                            if p in name:
-                                newprocname = p+'_'+bin if re.match('Wplus|Wminus',p) else p
-                                if longBKG and re.match('(Wplus_long|Wminus_long)',p): newprocname = p
-                                newname = name.replace(p,newprocname)
-                                if irf==0:
-                                    if newname not in plots:
-                                        plots[newname] = obj.Clone(newname)
-                                        nominals[newname] = obj.Clone(newname+"0")
-                                        nominals[newname].SetDirectory(None)
-                                        #print 'replacing old %s with %s' % (name,newname)
-                                        plots[newname].Write()
-                                else:
-                                    tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); pdf = tokens[-1]
-                                    ipdf = int(pdf.split('pdf')[-1])
-                                    newname = "{pfx}_pdf{ipdf}".format(pfx=pfx,ipdf=ipdf)
-                                    (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname)
-                                    for alt in [alternate,mirror]:
-                                        if alt.GetName() not in plots:
-                                            plots[alt.GetName()] = alt.Clone()
-                                            plots[alt.GetName()].Write()
-                    of.Close()
-    if len(empty_bins):
-        print 'found a bunch of empty bins:', empty_bins
-    if options.mergeRoot:
-        haddcmd = 'hadd -f {of} {tmpfiles}'.format(of=outfile, tmpfiles=' '.join(tmpfiles) )
-        #print 'would run this now: ', haddcmd
+                combineCmd += " %s=%s " % (binname,f)
+        tmpcard = os.path.join(options.inputdir,'tmpcard.txt')
+        combineCmd += ' > {tmpcard}'.format(tmpcard=tmpcard)
         #sys.exit()
-        os.system(haddcmd)
-        os.system('rm {rm}'.format(rm=' '.join(tmpfiles)))
-
-    print "Now trying to get info on PDF uncertainties..."
-    pdfsyst = {}
-    tf = ROOT.TFile.Open(outfile)
-    for e in tf.GetListOfKeys() :
-        name=e.GetName()
-        if 'pdf' in name:
-            if name.endswith("Up"): name = re.sub('Up$','',name)
-            if name.endswith("Down"): name = re.sub('Down$','',name)
-            syst = name.split('_')[-1]
-            binWsyst = '_'.join(name.split('_')[1:-1])
-            if syst not in pdfsyst: pdfsyst[syst] = [binWsyst]
-            else: pdfsyst[syst].append(binWsyst)
-    if len(pdfsyst): print "Found a bunch of PDF sysematics: ",pdfsyst.keys()
-    else: print "You are running w/o PDF systematics. Lucky you!"
-
-    combineCmd="combineCards.py "
-    for f in files:
-        basename = os.path.basename(f).split(".")[0]
-        binn = int(basename.split('_')[-1]) if 'Ybin_' in basename else 999
-        binname = basename if re.match('Wplus|Wminus',basename) else "other"
-        if not binn in empty_bins:
-            combineCmd += " %s=%s " % (binname,f)
-    tmpcard = os.path.join(options.inputdir,'tmpcard.txt')
-    combineCmd += ' > {tmpcard}'.format(tmpcard=tmpcard)
-    #sys.exit()
-    os.system(combineCmd)
-
-    combinedCard = open(cardfile,'w')
-    combinedCard.write("imax 1\n")
-    combinedCard.write("jmax *\n")
-    combinedCard.write("kmax *\n")
-    combinedCard.write('##----------------------------------\n') 
-    realprocesses = [] # array to preserve the sorting
-    with open(tmpcard) as file:    
-        nmatchbin=0
-        nmatchprocess=0
-        for l in file.readlines():
-            if re.match("shapes.*other",l):
-                variables = l.split()[4:]
-                combinedCard.write("shapes *  *  %s %s\n" % (os.path.abspath(outfile)," ".join(variables)))
-                combinedCard.write('##----------------------------------\n')
-            if re.match("bin",l) and nmatchbin==0: 
-                nmatchbin=1
-                combinedCard.write('bin   %s\n' % options.bin) 
-                bins = l.split()[1:]
-            if re.match("observation",l): 
-                yields = l.split()[1:]
-                observations = dict(zip(bins,yields))
-                combinedCard.write('observation %s\n' % observations['other'])
-                combinedCard.write('##----------------------------------\n')
-            if re.match("bin",l) and nmatchbin==1:
-                pseudobins = l.split()[1:]
-            if re.match("process",l):
-                if nmatchprocess==0:
-                    pseudoprocesses = l.split()[1:]
-                    klen = 7
-                    kpatt = " %%%ds "  % klen
-                    for i in xrange(len(pseudobins)):
-                        realprocesses.append(pseudoprocesses[i]+"_"+pseudobins[i] if ('Wminus' in pseudobins[i] or 'Wplus' in pseudobins[i]) else pseudoprocesses[i])
-                    combinedCard.write('bin            %s \n' % ' '.join([kpatt % options.bin for p in pseudoprocesses]))
-                    combinedCard.write('process        %s \n' % ' '.join([kpatt % p for p in realprocesses]))
-                    combinedCard.write('process        %s \n' % ' '.join([kpatt % str(i+1) for i in xrange(len(pseudobins))]))
-                nmatchprocess += 1
-            if nmatchprocess==2: 
-                nmatchprocess +=1
-            elif nmatchprocess>2: combinedCard.write(l)
+        os.system(combineCmd)
     
-    os.system('rm {tmpcard}'.format(tmpcard=tmpcard))
-    
-    if options.longToTotal or options.scaleFile: options.absoluteRates = True
-    
-    kpatt = " %7s "
-    if options.longLnN and not options.longToTotal:
-        combinedCard.write('norm_long_'+options.bin+'       lnN    ' + ' '.join([kpatt % (options.longLnN if 'long' in x else '-') for x in realprocesses])+'\n')
-
-    combinedCard = open(cardfile,'r')
-    procs = []
-    rates = []
-    for l in combinedCard.readlines():
-        if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
-            procs = (l.rstrip().split())[1:]
-        if re.match("rate\s+",l):
-            rates = (l.rstrip().split())[1:]
-        if len(procs) and len(rates): break
-    ProcsAndRates = zip(procs,rates)
-    ProcsAndRatesDict = dict(zip(procs,rates))
-
-    efficiencies = {}; efferrors = {}
-    if options.scaleFile:
-        for pol in ['left','right','long']: 
-            efficiencies[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
-            efferrors   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
-
-    combinedCard = open(cardfile,'a')
-    POIs = []
-    if options.constrainRateParams:
-        signal_procs = filter(lambda x: re.match('Wplus|Wminus',x), realprocesses)
-        if longBKG: signal_procs = filter(lambda x: re.match('(?!Wplus_long|Wminus_long)',x), signal_procs)
-        signal_procs.sort(key=lambda x: int(x.split('_')[-1]))
-        signal_L = filter(lambda x: re.match('.*left.*',x),signal_procs)
-        signal_R = filter(lambda x: re.match('.*right.*',x),signal_procs)
-        signal_0 = filter(lambda x: re.match('.*long.*',x),signal_procs)
+        combinedCard = open(cardfile,'w')
+        combinedCard.write("imax 1\n")
+        combinedCard.write("jmax *\n")
+        combinedCard.write("kmax *\n")
+        combinedCard.write('##----------------------------------\n') 
+        realprocesses = [] # array to preserve the sorting
+        with open(tmpcard) as file:    
+            nmatchbin=0
+            nmatchprocess=0
+            for l in file.readlines():
+                if re.match("shapes.*other",l):
+                    variables = l.split()[4:]
+                    combinedCard.write("shapes *  *  %s %s\n" % (os.path.abspath(outfile)," ".join(variables)))
+                    combinedCard.write('##----------------------------------\n')
+                if re.match("bin",l) and nmatchbin==0: 
+                    nmatchbin=1
+                    combinedCard.write('bin   %s\n' % options.bin) 
+                    bins = l.split()[1:]
+                if re.match("observation",l): 
+                    yields = l.split()[1:]
+                    observations = dict(zip(bins,yields))
+                    combinedCard.write('observation %s\n' % observations['other'])
+                    combinedCard.write('##----------------------------------\n')
+                if re.match("bin",l) and nmatchbin==1:
+                    pseudobins = l.split()[1:]
+                if re.match("process",l):
+                    if nmatchprocess==0:
+                        pseudoprocesses = l.split()[1:]
+                        klen = 7
+                        kpatt = " %%%ds "  % klen
+                        for i in xrange(len(pseudobins)):
+                            realprocesses.append(pseudoprocesses[i]+"_"+pseudobins[i] if ('Wminus' in pseudobins[i] or 'Wplus' in pseudobins[i]) else pseudoprocesses[i])
+                        combinedCard.write('bin            %s \n' % ' '.join([kpatt % options.bin for p in pseudoprocesses]))
+                        combinedCard.write('process        %s \n' % ' '.join([kpatt % p for p in realprocesses]))
+                        combinedCard.write('process        %s \n' % ' '.join([kpatt % str(i+1) for i in xrange(len(pseudobins))]))
+                    nmatchprocess += 1
+                if nmatchprocess==2: 
+                    nmatchprocess +=1
+                elif nmatchprocess>2: combinedCard.write(l)
         
-        hel_to_constrain = [signal_L,signal_R]
-        bins_to_constrain = options.constrainRateParams.split(',')
-        tightConstraint = 0.05
-        looseConstraint = tightConstraint
-        for hel in hel_to_constrain:
-            for iy,helbin in enumerate(hel):
-                pol = helbin.split('_')[1]
-                index_procs = procs.index(helbin)
-                lns = ' - '.join('' for i in range(index_procs+1))
-                lns += ' {effunc:.4f} '.format(effunc=1.+efferrors[pol][iy])
-                lns += ' - '.join('' for i in range(len(procs) - index_procs))
-                combinedCard.write('eff_unc_{hb}    lnN {lns}\n'.format(hb=helbin,lns=lns))
-        for hel in hel_to_constrain:
-            for iy,helbin in enumerate(hel):
-                sfx = str(iy)
-                pol = helbin.split('_')[1]
-                rateNuis = tightConstraint if iy in bins_to_constrain else looseConstraint
-                normPOI = 'norm_{n}'.format(n=helbin)
-
-                ## if we fit absolute rates, we need to get them from the process and plug them in below
-                if options.absoluteRates:
-
-                    ## if we want to fit with the efficiency gen-reco, we need to add one efficiency parameter
-                    if options.scaleFile:
-                        tmp_eff = efficiencies[pol][iy]
-                        combinedCard.write('eff_{n}    rateParam * {n} \t {eff:.5f} [{dn:.5f},{up:.5f}]\n'.format(n=helbin,eff=tmp_eff,dn=(1-1E-04)*tmp_eff,up=(1+1E-04)*tmp_eff))
-                        expRate0 = float(ProcsAndRatesDict[helbin])/tmp_eff
-                        param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
-                        combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
-
-                    ## if we do not want to fit the gen-level thing, we want to just put the absolute reco rates here
+        os.system('rm {tmpcard}'.format(tmpcard=tmpcard))
+        
+        if options.longToTotal or options.scaleFile: options.absoluteRates = True
+        
+        kpatt = " %7s "
+        if options.longLnN and not options.longToTotal:
+            combinedCard.write('norm_long_'+options.bin+'       lnN    ' + ' '.join([kpatt % (options.longLnN if 'long' in x else '-') for x in realprocesses])+'\n')
+    
+        combinedCard = open(cardfile,'r')
+        procs = []
+        rates = []
+        for l in combinedCard.readlines():
+            if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
+                procs = (l.rstrip().split())[1:]
+            if re.match("rate\s+",l):
+                rates = (l.rstrip().split())[1:]
+            if len(procs) and len(rates): break
+        ProcsAndRates = zip(procs,rates)
+        ProcsAndRatesDict = dict(zip(procs,rates))
+    
+        efficiencies = {}; efferrors = {}
+        if options.scaleFile:
+            for pol in ['left','right','long']: 
+                efficiencies[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
+                efferrors   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
+    
+        combinedCard = open(cardfile,'a')
+        POIs = []
+        if options.constrainRateParams:
+            signal_procs = filter(lambda x: re.match('Wplus|Wminus',x), realprocesses)
+            if longBKG: signal_procs = filter(lambda x: re.match('(?!Wplus_long|Wminus_long)',x), signal_procs)
+            signal_procs.sort(key=lambda x: int(x.split('_')[-1]))
+            signal_L = filter(lambda x: re.match('.*left.*',x),signal_procs)
+            signal_R = filter(lambda x: re.match('.*right.*',x),signal_procs)
+            signal_0 = filter(lambda x: re.match('.*long.*',x),signal_procs)
+            
+            hel_to_constrain = [signal_L,signal_R]
+            bins_to_constrain = options.constrainRateParams.split(',')
+            tightConstraint = 0.05
+            looseConstraint = tightConstraint
+            for hel in hel_to_constrain:
+                for iy,helbin in enumerate(hel):
+                    pol = helbin.split('_')[1]
+                    index_procs = procs.index(helbin)
+                    lns = ' - '.join('' for i in range(index_procs+1))
+                    lns += ' {effunc:.4f} '.format(effunc=1.+efferrors[pol][iy])
+                    lns += ' - '.join('' for i in range(len(procs) - index_procs))
+                    combinedCard.write('eff_unc_{hb}    lnN {lns}\n'.format(hb=helbin,lns=lns))
+            for hel in hel_to_constrain:
+                for iy,helbin in enumerate(hel):
+                    sfx = str(iy)
+                    pol = helbin.split('_')[1]
+                    rateNuis = tightConstraint if iy in bins_to_constrain else looseConstraint
+                    normPOI = 'norm_{n}'.format(n=helbin)
+    
+                    ## if we fit absolute rates, we need to get them from the process and plug them in below
+                    if options.absoluteRates:
+    
+                        ## if we want to fit with the efficiency gen-reco, we need to add one efficiency parameter
+                        if options.scaleFile:
+                            tmp_eff = efficiencies[pol][iy]
+                            combinedCard.write('eff_{n}    rateParam * {n} \t {eff:.5f} [{dn:.5f},{up:.5f}]\n'.format(n=helbin,eff=tmp_eff,dn=(1-1E-04)*tmp_eff,up=(1+1E-04)*tmp_eff))
+                            expRate0 = float(ProcsAndRatesDict[helbin])/tmp_eff
+                            param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
+                            combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
+    
+                        ## if we do not want to fit the gen-level thing, we want to just put the absolute reco rates here
+                        else:
+                            expRate0 = float(ProcsAndRatesDict[helbin])
+                            param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
+                            combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
+    
+                    ## if not fitting full rates, we do the relative rateParams close to 1.
                     else:
-                        expRate0 = float(ProcsAndRatesDict[helbin])
-                        param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
-                        combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
-
-                ## if not fitting full rates, we do the relative rateParams close to 1.
-                else:
-                    param_range_0 = '1. [{dn:.2f},{up:.2f}]'.format(dn=1-rateNuis,up=1+rateNuis)
-                    param_range_1 = param_range_0
-                    combinedCard.write('norm_{n}   rateParam * {n}    {pr}\n'.format(n=helbin,pr=param_range_0))
-                POIs.append(normPOI)
-
-        ## not sure this below will still work with absY, but for now i don't care (marc)
-        if not longBKG and not options.longLnN:
-            for i in xrange(len(signal_0)):
-                sfx = signal_0[i].split('_')[-1]
-                param_range = '[0.95,1.05]' if sfx in bins_to_constrain else '[0.95,1.05]'
-                combinedCard.write('norm_%-5s   rateParam * %-5s    1 %s\n' % (signal_0[i],signal_0[i],param_range))
-                POIs.append('norm_%s' % signal_0[i])
+                        param_range_0 = '1. [{dn:.2f},{up:.2f}]'.format(dn=1-rateNuis,up=1+rateNuis)
+                        param_range_1 = param_range_0
+                        combinedCard.write('norm_{n}   rateParam * {n}    {pr}\n'.format(n=helbin,pr=param_range_0))
+                    POIs.append(normPOI)
     
-        if options.absoluteRates:
-            combinedCard = open(cardfile,'r')
-            procs = []
-            rates = []
-            for l in combinedCard.readlines():
-                if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
-                    procs = (l.rstrip().split())[1:]
-                if re.match("rate\s+",l):
-                    rates = (l.rstrip().split())[1:]
-                if len(procs) and len(rates): break
-            ProcsAndRates = zip(procs,rates)
-
-            combinedCard = open(cardfile,'r')
-            ProcsAndRatesUnity = []
-            for (p,r) in ProcsAndRates:
-                ProcsAndRatesUnity.append((p,'1') if ('left' in p or 'right' in p or 'long' in p) else (p,r))
-
-            combinedCardNew = open(cardfile+"_new",'w')
-            for l in combinedCard.readlines():
-                if re.match("rate\s+",l):
-                    combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRatesUnity])+'\n')
-                else: combinedCardNew.write(l)
-            Wlong = [(p,r) for (p,r) in ProcsAndRates if re.match('W.*long',p)]
-            WLeftOrRight = [(p,r) for (p,r) in ProcsAndRates if ('left' in p or 'right' in p)]
-            if options.scaleFile:
-                eff_long = 1./getScales([ybins[0],ybins[-1]], charge, 'long', options.scaleFile)[0]
-                eff_left = 1./getScales([ybins[0],ybins[-1]], charge, 'left', options.scaleFile)[0]
-                eff_right = 1./getScales([ybins[0],ybins[-1]], charge, 'right', options.scaleFile)[0]
-                normWLong = sum([float(r) for (p,r) in Wlong])/eff_long # there should be only 1 Wlong/charge
-                normWLeft = sum([float(r) for (p,r) in WLeftOrRight if 'left' in p])/eff_left
-                normWRight = sum([float(r) for (p,r) in WLeftOrRight if 'right' in p])/eff_right
-                normWLeftOrRight = normWLeft + normWRight
-                combinedCardNew.write("eff_{n}   rateParam * {n}    {eff:.5f} [{dn:.5f},{up:.5f}]\n".format(n=Wlong[0][0],eff=eff_long,dn=(1-1E-04)*eff_long,up=(1+1E-04)*eff_long))
-
-                ## i have no idea what happens after here in this if block...
-                if options.longToTotal:
-                    r0overLR = normWLong/normWLeftOrRight
-                    combinedCardNew.write("norm_%-50s    rateParam * %-5s    %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
-                    wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
-                        % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
-                    combinedCardNew.write(wLongNormString)
-
-                ## if we do not constrain the long to the total, we should write the long yield here
-                else:
-                    nl = normWLong; tc = tightConstraint
-                    combinedCardNew.write("norm_{n} rateParam * {n} {r:15.1f} [{dn:.1f},{up:.1f}]\n".format(n=Wlong[0][0],r=nl,dn=(1-tc)*nl,up=(1+tc)*nl))
-                    POIs.append('norm_{n}'.format(n=Wlong[0][0]))
-
-            ## if we do not scale gen-reco, then we go back to before...
-            else:
-                normWLong = sum([float(r) for (p,r) in Wlong]) # there should be only 1 Wlong/charge
-                normWLeftOrRight = sum([float(r) for (p,r) in WLeftOrRight])
-                if options.longToTotal:
-                    r0overLR = normWLong/normWLeftOrRight
-                    combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
-                    wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
-                        % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
-                    combinedCardNew.write(wLongNormString)
-                else:
-                    combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLong,(1-tightConstraint)*normWLong,(1+tightConstraint)*normWLong))
-
-            ## make an efficiency nuisance group
-            combinedCardNew.write('\nefficiencies group = eff_'+Wlong[0][0]+' '+' '.join([p.replace('norm','eff') for p in POIs])+'\n\n' )
-
-            ## add the PDF systematics 
-            for sys,procs in pdfsyst.iteritems():
-                # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
-                combinedCardNew.write('%-15s   shape %s\n' % (sys,(" ".join([kpatt % '1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
-            combinedCardNew.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
-
-            combinedCardNew.close() ## for some reason this is really necessary
-            os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
-
-    
-    ## remove all the POIs that we want to fix
-    fixedPOIs = []
-    for poi in POIs:
-        if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
-            fixedPOIs.append(poi)
-        if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
-            fixedPOIs.append(poi)
-    floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
-    allPOIs = fixedPOIs+floatPOIs
-
-    ## define the combine POIs, i.e. the subset on which to run MINOS
-    minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
-
-    ## make a group for the fixed rate parameters. just append it to the file.
-    print 'adding a nuisance group for the fixed rateParams'
-    with open(cardfile,'a+') as finalCardfile:
-        finalCardfile.write('\nfixedY group = {fixed} '.format(fixed=' '.join(i.strip() for i in fixedPOIs)))
-        finalCardfile.write('\nfixedMcErr group = {fixed} '.format(fixed=' '.join(i.strip().replace('norm','eff_unc') for i in fixedPOIs))) # not used in the command, but may be useful to stabilize the fit
-        finalCardfile.write('\n\n## end of file')
-    #finalCardfile.close()
-
-    print "merged datacard in ",cardfile
-    
-    #ws = "%s_ws.root" % options.bin
-    ws = cardfile.replace('_card.txt', '_ws.root')
-    txt2wsCmd = 'text2workspace.py {cf} -o {ws} --X-allow-no-signal --X-no-check-norm '.format(cf=cardfile, ws=ws)
-    print txt2wsCmd
-    os.system(txt2wsCmd)
+            ## not sure this below will still work with absY, but for now i don't care (marc)
+            if not longBKG and not options.longLnN:
+                for i in xrange(len(signal_0)):
+                    sfx = signal_0[i].split('_')[-1]
+                    param_range = '[0.95,1.05]' if sfx in bins_to_constrain else '[0.95,1.05]'
+                    combinedCard.write('norm_%-5s   rateParam * %-5s    1 %s\n' % (signal_0[i],signal_0[i],param_range))
+                    POIs.append('norm_%s' % signal_0[i])
         
-    combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''))
-    print combineCmd
-
+            if options.absoluteRates:
+                combinedCard = open(cardfile,'r')
+                procs = []
+                rates = []
+                for l in combinedCard.readlines():
+                    if re.match("process\s+",l) and not re.match("process\s+\d",l): # my regexp qualities are bad... 
+                        procs = (l.rstrip().split())[1:]
+                    if re.match("rate\s+",l):
+                        rates = (l.rstrip().split())[1:]
+                    if len(procs) and len(rates): break
+                ProcsAndRates = zip(procs,rates)
+    
+                combinedCard = open(cardfile,'r')
+                ProcsAndRatesUnity = []
+                for (p,r) in ProcsAndRates:
+                    ProcsAndRatesUnity.append((p,'1') if ('left' in p or 'right' in p or 'long' in p) else (p,r))
+    
+                combinedCardNew = open(cardfile+"_new",'w')
+                for l in combinedCard.readlines():
+                    if re.match("rate\s+",l):
+                        combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRatesUnity])+'\n')
+                    else: combinedCardNew.write(l)
+                Wlong = [(p,r) for (p,r) in ProcsAndRates if re.match('W.*long',p)]
+                WLeftOrRight = [(p,r) for (p,r) in ProcsAndRates if ('left' in p or 'right' in p)]
+                if options.scaleFile:
+                    eff_long = 1./getScales([ybins[0],ybins[-1]], charge, 'long', options.scaleFile)[0]
+                    eff_left = 1./getScales([ybins[0],ybins[-1]], charge, 'left', options.scaleFile)[0]
+                    eff_right = 1./getScales([ybins[0],ybins[-1]], charge, 'right', options.scaleFile)[0]
+                    normWLong = sum([float(r) for (p,r) in Wlong])/eff_long # there should be only 1 Wlong/charge
+                    normWLeft = sum([float(r) for (p,r) in WLeftOrRight if 'left' in p])/eff_left
+                    normWRight = sum([float(r) for (p,r) in WLeftOrRight if 'right' in p])/eff_right
+                    normWLeftOrRight = normWLeft + normWRight
+                    combinedCardNew.write("eff_{n}   rateParam * {n}    {eff:.5f} [{dn:.5f},{up:.5f}]\n".format(n=Wlong[0][0],eff=eff_long,dn=(1-1E-04)*eff_long,up=(1+1E-04)*eff_long))
+    
+                    ## i have no idea what happens after here in this if block...
+                    if options.longToTotal:
+                        r0overLR = normWLong/normWLeftOrRight
+                        combinedCardNew.write("norm_%-50s    rateParam * %-5s    %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
+                        wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
+                            % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
+                        combinedCardNew.write(wLongNormString)
+    
+                    ## if we do not constrain the long to the total, we should write the long yield here
+                    else:
+                        nl = normWLong; tc = tightConstraint
+                        combinedCardNew.write("norm_{n} rateParam * {n} {r:15.1f} [{dn:.1f},{up:.1f}]\n".format(n=Wlong[0][0],r=nl,dn=(1-tc)*nl,up=(1+tc)*nl))
+                        POIs.append('norm_{n}'.format(n=Wlong[0][0]))
+    
+                ## if we do not scale gen-reco, then we go back to before...
+                else:
+                    normWLong = sum([float(r) for (p,r) in Wlong]) # there should be only 1 Wlong/charge
+                    normWLeftOrRight = sum([float(r) for (p,r) in WLeftOrRight])
+                    if options.longToTotal:
+                        r0overLR = normWLong/normWLeftOrRight
+                        combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLeftOrRight,(1-options.longToTotal)*normWLeftOrRight,(1+options.longToTotal)*normWLeftOrRight))
+                        wLongNormString = "ratio_%-5s   rateParam * %-5s   2*(%s)*%.3f %s\n" \
+                            % (Wlong[0][0],Wlong[0][0],'+'.join(['@%d'%i for i in xrange(len(POIs))]),r0overLR,','.join([p for p in POIs]))
+                        combinedCardNew.write(wLongNormString)
+                    else:
+                        combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLong,(1-tightConstraint)*normWLong,(1+tightConstraint)*normWLong))
+    
+                ## make an efficiency nuisance group
+                combinedCardNew.write('\nefficiencies group = eff_'+Wlong[0][0]+' '+' '.join([p.replace('norm','eff') for p in POIs])+'\n\n' )
+    
+                ## add the PDF systematics 
+                for sys,procs in pdfsyst.iteritems():
+                    # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
+                    combinedCardNew.write('%-15s   shape %s\n' % (sys,(" ".join([kpatt % '1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
+                combinedCardNew.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
+    
+                combinedCardNew.close() ## for some reason this is really necessary
+                os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
+    
+        
+        ## remove all the POIs that we want to fix
+        fixedPOIs = []
+        for poi in POIs:
+            if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
+                fixedPOIs.append(poi)
+            if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
+                fixedPOIs.append(poi)
+        floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
+        allPOIs = fixedPOIs+floatPOIs
+    
+        ## define the combine POIs, i.e. the subset on which to run MINOS
+        minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
+    
+        ## make a group for the fixed rate parameters. just append it to the file.
+        print 'adding a nuisance group for the fixed rateParams'
+        with open(cardfile,'a+') as finalCardfile:
+            finalCardfile.write('\nfixedY group = {fixed} '.format(fixed=' '.join(i.strip() for i in fixedPOIs)))
+            finalCardfile.write('\nfixedMcErr group = {fixed} '.format(fixed=' '.join(i.strip().replace('norm','eff_unc') for i in fixedPOIs))) # not used in the command, but may be useful to stabilize the fit
+            finalCardfile.write('\n\n## end of file')
+        #finalCardfile.close()
+    
+        print "merged datacard in ",cardfile
+        
+        #ws = "%s_ws.root" % options.bin
+        ws = cardfile.replace('_card.txt', '_ws.root')
+        txt2wsCmd = 'text2workspace.py {cf} -o {ws} --X-allow-no-signal --X-no-check-norm '.format(cf=cardfile, ws=ws)
+        print txt2wsCmd
+        os.system(txt2wsCmd)
+            
+        combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''))
+        print combineCmd
+    

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -1,10 +1,34 @@
-#!/bin/env python                                                                                                                                                                                          
+#!/bin/env python
 
 # usage: ./mergeCardComponents.py -b Wmu -m --long-lnN 1.10 -C minus,plus -i ../cards/helicity_xxxxx/
 # fit scaling by eff: ./mergeCardComponents.py -b Wel -m -C minus,plus -i ../cards/helicity_xxxxx/ --longToTotal 0.5 --sf mc_reco_eff.root --absolute
 
 import ROOT
 import sys,os,re
+
+def mirrorShape(nominal,alternate,newname,alternateShapeOnly=False):
+    alternate.SetName("%sUp" % newname)
+    if alternateShapeOnly:
+        alternate.Scale(nominal.Integral()/alternate.Integral())
+    mirror = nominal.Clone("%sDown" % newname)
+    for b in xrange(1,nominal.GetNbinsX()+1):
+        y0 = nominal.GetBinContent(b)
+        yA = alternate.GetBinContent(b)
+        yM = y0
+        if (y0 > 0 and yA > 0):
+            yM = y0*y0/yA
+        elif yA == 0:
+            yM = 2*y0
+        mirror.SetBinContent(b, yM)
+    if alternateShapeOnly:
+        # keep same normalization
+        mirror.Scale(nominal.Integral()/mirror.Integral())
+    else:
+        # mirror normalization
+        mnorm = (nominal.Integral()**2)/alternate.Integral()
+        mirror.Scale(mnorm/alternate.Integral())
+    return (alternate,mirror)
+
 
 from optparse import OptionParser
 parser = OptionParser(usage='%prog [options] cards/card*.txt')
@@ -13,7 +37,8 @@ parser.add_option('-i','--input', dest='inputdir', default='', type='string', he
 parser.add_option('-b','--bin', dest='bin', default='ch1', type='string', help='name of the bin')
 parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
 parser.add_option('-c','--constrain-rates', dest='constrainRateParams', type='string', default='0,1,2', help='add constraints on the rate parameters of (comma-separated list of) rapidity bins. Give only the left ones (e.g. 1 will constrain 1 with n-1 ')
-parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='', help='add here replacement of default rate-fixing. with format plusR=0,1,2;plusL=0,1;minusR=0,1,2;minusL=0,1 ')
+parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='', help='add here replacement of default rate-fixing. with format plusR=10,11,12;plusL=11,12;minusR=10,11,12;minusL=10,11 ')
+parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
 parser.add_option('-l','--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
 parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
 parser.add_option(     '--longToTotal', dest='longToTotal', type='float', default=None, help='Apply a constraint on the Wlong/Wtot rate. Implies fitting for absolute rates')
@@ -32,7 +57,7 @@ for charge in charges:
 
     ## prepare the relevant files. only the datacards and the correct charge
     files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
-    files = ( f for f in files if charge in f and not any(x in f for x in 'Up Dn'.split()))
+    files = ( f for f in files if charge in f and 'pdf' not in f )
     files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
     files = list( ( os.path.join(options.inputdir, f) for f in files ) )
     
@@ -94,7 +119,7 @@ for charge in charges:
                     bin = l.split()[1]
                     binn = int(bin.split('_')[-1]) if 'Ybin_' in bin else -1
                 basename = os.path.basename(f).split('.')[0]
-                rootfiles_syst = filter(lambda x: re.match('{base}_.*_(Up|Dn)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
+                rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
                 rootfiles_syst = [dir+'/'+x for x in rootfiles_syst]
                 rootfiles_syst.sort()
                 if re.match('process\s+',l): 
@@ -112,6 +137,7 @@ for charge in charges:
         if options.mergeRoot:
             if not binn in empty_bins:
                 print 'processing bin = ',bin
+                nominals = {}
                 for irf,rf in enumerate([rootfile]+rootfiles_syst):
                     print '\twith nominal/systematic file: ',rf
                     tf = ROOT.TFile.Open(rf)
@@ -129,13 +155,22 @@ for charge in charges:
                                 newprocname = p+'_'+bin if re.match('Wplus|Wminus',p) else p
                                 if longBKG and re.match('(Wplus_long|Wminus_long)',p): newprocname = p
                                 newname = name.replace(p,newprocname)
-                                if newname.endswith("_Up"): newname = re.sub('_Up$','Up',newname)
-                                if newname.endswith("_Dn"): newname = re.sub('_Dn$','Down',newname)
-                                if newname not in plots:
-                                    plots[newname] = obj.Clone(newname)
-                                    #print 'replacing old %s with %s' % (name,newname)
-                                    plots[newname].Write()
-                  
+                                if irf==0:
+                                    if newname not in plots:
+                                        plots[newname] = obj.Clone(newname)
+                                        nominals[newname] = obj.Clone(newname+"0")
+                                        nominals[newname].SetDirectory(None)
+                                        #print 'replacing old %s with %s' % (name,newname)
+                                        plots[newname].Write()
+                                else:
+                                    tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); pdf = tokens[-1]
+                                    ipdf = int(pdf.split('pdf')[-1])
+                                    newname = "{pfx}_pdf{ipdf}".format(pfx=pfx,ipdf=ipdf)
+                                    (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname)
+                                    for alt in [alternate,mirror]:
+                                        if alt.GetName() not in plots:
+                                            plots[alt.GetName()] = alt.Clone()
+                                            plots[alt.GetName()].Write()
                     of.Close()
     if len(empty_bins):
         print 'found a bunch of empty bins:', empty_bins
@@ -233,11 +268,14 @@ for charge in charges:
     ProcsAndRates = zip(procs,rates)
     ProcsAndRatesDict = dict(zip(procs,rates))
 
-    efficiencies = {}; efferrors = {}
+    efficiencies    = {}; efferrors    = {}
+    efficiencies_LO = {}; efferrors_LO = {}
     if options.scaleFile:
         for pol in ['left','right','long']: 
-            efficiencies[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
-            efferrors   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
+            efficiencies   [pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile))]
+            efferrors      [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), returnError=True)] ## these errors are relative to the effs
+            efficiencies_LO[pol] = [1./x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False)]
+            efferrors_LO   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False, returnError=True)]
 
     combinedCard = open(cardfile,'a')
     POIs = []
@@ -384,10 +422,14 @@ for charge in charges:
     floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
     allPOIs = fixedPOIs+floatPOIs
 
+    ## define the combine POIs, i.e. the subset on which to run MINOS
+    minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
+
     ## make a group for the fixed rate parameters. just append it to the file.
     print 'adding a nuisance group for the fixed rateParams'
     with open(cardfile,'a+') as finalCardfile:
         finalCardfile.write('\nfixedY group = {fixed} '.format(fixed=' '.join(i.strip() for i in fixedPOIs)))
+        finalCardfile.write('\nfixedMcErr group = {fixed} '.format(fixed=' '.join(i.strip().replace('norm','eff_unc') for i in fixedPOIs))) # not used in the command, but may be useful to stabilize the fit
         finalCardfile.write('\n\n## end of file')
     #finalCardfile.close()
 
@@ -399,6 +441,6 @@ for charge in charges:
     print txt2wsCmd
     os.system(txt2wsCmd)
         
-    combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs} -v 9'.format(ws=ws, pois=','.join(allPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''))
+    combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''))
     print combineCmd
 

--- a/WMass/python/plotter/w-helicity-13TeV/plotYsyst.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYsyst.py
@@ -1,3 +1,5 @@
+# USAGE:  python plotYsyst.py -C plus ../plots/gen/pdfvar/ ../cards/helicity_2018_03_09_testpdfsymm/binningYW.txt --fitResult multidimfit_plus_wpdf.root
+
 import ROOT, datetime, array, os, math
 ROOT.gROOT.SetBatch(True)
 ROOT.PyConfig.IgnoreCommandLineOptions = True

--- a/WMass/python/plotter/w-helicity-13TeV/plotYsyst.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYsyst.py
@@ -1,0 +1,220 @@
+import ROOT, datetime, array, os, math
+ROOT.gROOT.SetBatch(True)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from mergeCardComponentsAbsY import mirrorShape
+
+def getRebinned(ybins, charge, infile):
+    histo_file = ROOT.TFile(infile, 'READ')
+
+    histos = {}
+    for pol in ['left','right','long']:
+        histo = histo_file.Get('w{ch}_wy_W{ch}_{pol}'.format(ch=charge, pol=pol))
+        conts = []
+        for iv, val in enumerate(ybins[:-1]):
+            err = ROOT.Double()
+            istart = histo.FindBin(val)
+            iend   = histo.FindBin(ybins[iv+1])
+            val = histo.IntegralAndError(istart, iend-1, err) ## do not include next bin
+            if 'pdfs' not in infile: print "pol = %s; ist,ie,val = %d,%d,%f" % (pol,istart,iend,val)
+            conts.append(2*val) ## input files are not abs(Y)
+        histos[pol] = conts
+    return histos
+
+NPDFs = 60
+
+if __name__ == "__main__":
+
+    from optparse import OptionParser
+    parser = OptionParser(usage='%prog inputdir ybinfile [options] ')
+    parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
+    parser.add_option('-o','--outdir', dest='outdir', default='.', type='string', help='outdput directory to save the matrix')
+    (options, args) = parser.parse_args()
+
+    inputdir = args[0]
+    ybinfile = args[1]
+
+    print "Taking histos from dir: %s" % inputdir
+
+    ybinfile = open(ybinfile, 'r')
+    ybinline = ybinfile.readlines()[0]
+    ybins = list(float(i) for i in ybinline.split())
+    ybinfile.close()
+
+    ## calculate the bin widths for the rapidity bins
+    ybinwidths = list(abs(i - ybins[ybins.index(i)+1]) for i in ybins[:-1])
+
+    charges = options.charge.split(',')
+    for charge in charges:
+
+        file_nom = '{dir}/wgen_nosel_{charge}_nominal.root'.format(dir=inputdir,charge=charge)
+        nominal = getRebinned(ybins,charge,file_nom)
+        
+        print "Now getting histograms from %s (will take some time)..." % inputdir
+        shape_syst = {}
+        for pol in ['left','right','long']:
+            histos = []
+            for ip in xrange(NPDFs):
+                print "Loading polarization %s, histograms for pdf %d" % (pol,ip)
+                filepdf = '{dir}/wgen_nosel_{charge}_pdfs_pdf{ipdf}.root'.format(dir=inputdir,charge=charge,ipdf=ip)
+                pdf = getRebinned(ybins,charge,'{dir}/wgen_nosel_{charge}_pdfs_pdf{ipdf}.root'.format(dir=inputdir,charge=charge,ipdf=ip))
+                hnom = nominal[pol]; hpdf = pdf[pol]
+                histos.append(hpdf)
+            shape_syst[pol] = histos
+        
+        systematics = {}
+        for pol in ['left','right','long']:
+            # print "===> Running pol = ",pol
+            systs=[]
+            for iy,y in enumerate(ybinwidths):
+                # print "\tBin iy=%d,y=%f = " % (iy,y)
+                nom = nominal[pol][iy]
+                totUp=0
+                for pdf in shape_syst[pol]:
+                    totUp += pow(nom-pdf[iy],2)
+                    # print "\t\tUp = %f; Dn = %f" % (totUp,totDn)
+                totUp=math.sqrt(totUp)
+                print "Rel systematic for Y bin %d = +/-%.3f" % (iy,totUp/nom)
+                systs.append(totUp)
+            systematics[pol]=systs
+
+        arr_val   = array.array('f', [])
+        arr_ehi   = array.array('f', [])
+        arr_elo   = array.array('f', [])
+        arr_relv  = array.array('f', [])
+        arr_relhi = array.array('f', [])
+        arr_rello = array.array('f', [])
+        arr_rap   = array.array('f', [])
+        arr_rlo   = array.array('f', [])
+        arr_rhi   = array.array('f', [])
+
+        for pol in ['left','right']:
+            totalrate = 0.
+            for iy,y in enumerate(ybinwidths):
+                totalrate += nominal[pol][iy]
+
+        for pol in ['left','right']:
+
+            arr_val   = array.array('f', []); arr_ehi   = array.array('f', []); arr_elo   = array.array('f', []);
+            arr_relv  = array.array('f', []); arr_relhi = array.array('f', []); arr_rello = array.array('f', []);
+            arr_rap   = array.array('f', []); arr_rlo   = array.array('f', []); arr_rhi   = array.array('f', []);
+
+            for iy,y in enumerate(ybinwidths):
+                arr_val.append(nominal[pol][iy]/totalrate/ybinwidths[iy])
+                arr_ehi.append(systematics[pol][iy]/totalrate/ybinwidths[iy])
+                arr_elo.append(systematics[pol][iy]/totalrate/ybinwidths[iy]) # symmetric for the expected
+
+                arr_relv. append(1.);
+                arr_rello.append(systematics[pol][iy]/nominal[pol][iy])
+                arr_relhi.append(systematics[pol][iy]/nominal[pol][iy]) # symmetric for the expected
+
+                arr_rap.append((ybins[iy]+ybins[iy+1])/2.)
+                arr_rlo.append(abs(ybins[iy]-arr_rap[-1]))
+                arr_rhi.append(abs(ybins[iy]-arr_rap[-1]))
+
+            if 'left' in pol:
+                print 'left {ch}: {i}'.format(ch=charge, i=sum(arr_val))
+                graphLeft      = ROOT.TGraphAsymmErrors(len(arr_val), arr_rap, arr_val, arr_rlo, arr_rhi, arr_elo, arr_ehi)
+                graphLeft_rel  = ROOT.TGraphAsymmErrors(len(arr_relv), arr_rap, arr_relv, arr_rlo, arr_rhi, arr_rello, arr_relhi)
+                graphLeft     .SetName('graphLeft')
+                graphLeft_rel .SetName('graphLeft_rel')
+            else:
+                print 'right {ch}: {i}'.format(ch=charge, i=sum(arr_val))
+                graphRight      = ROOT.TGraphAsymmErrors(len(arr_val), arr_rap, arr_val, arr_rlo, arr_rhi, arr_elo, arr_ehi)
+                graphRight_rel  = ROOT.TGraphAsymmErrors(len(arr_relv), arr_rap, arr_relv, arr_rlo, arr_rhi, arr_rello, arr_relhi)
+                graphRight     .SetName('graphRight')
+                graphRight_rel .SetName('graphRight_rel')
+
+        c2 = ROOT.TCanvas('foo','', 800, 800)
+        c2.GetPad(0).SetTopMargin(0.05)
+        c2.GetPad(0).SetBottomMargin(0.15)
+        c2.GetPad(0).SetLeftMargin(0.16)
+
+        ## these are the colors...
+        colorL = ROOT.kAzure+8
+        colorR = ROOT.kOrange+7
+
+        ## the four graphs exist now. now starting to draw them
+        ## ===========================================================
+        leg = ROOT.TLegend(0.60, 0.60, 0.85, 0.80)
+        leg.SetFillStyle(0)
+        leg.SetBorderSize(0)
+        leg.AddEntry(graphLeft , 'W^{{{ch}}} left' .format(ch='+' if charge == 'plus' else '-'), 'f')
+        leg.AddEntry(graphRight, 'W^{{{ch}}} right'.format(ch='+' if charge == 'plus' else '-'), 'f')
+
+        graphLeft.SetTitle('W {ch}: Y_{{W}}'.format(ch=charge))
+        graphLeft.SetFillColor(colorL)
+        graphRight.SetFillColor(colorR)
+
+        mg = ROOT.TMultiGraph()
+        mg.Add(graphLeft)
+        mg.Add(graphRight)
+
+        mg.Draw('Pa2')
+        mg.GetXaxis().SetRangeUser(0.,6.)
+        mg.GetXaxis().SetTitle('|Y_{W}|')
+        mg.GetYaxis().SetTitle('dN/dy')
+        mg.GetXaxis().SetTitleSize(0.06)
+        mg.GetXaxis().SetLabelSize(0.04)
+        mg.GetYaxis().SetTitleSize(0.06)
+        mg.GetYaxis().SetLabelSize(0.04)
+        mg.GetYaxis().SetTitleOffset(1.2)
+
+        leg.Draw('same')
+
+        date = datetime.date.today().isoformat()
+        for ext in ['png', 'pdf']:
+            c2.SaveAs('{od}/genAbsY_pdfs_{date}_{ch}.{ext}'.format(od=options.outdir, date=date, ch=charge, ext=ext))
+
+        ## now make the relative error plot:
+        ## ======================================
+
+        c2.Clear()
+        c2.Divide(1,2)
+
+        line = ROOT.TF1("horiz_line","1",0.0,3.0);
+        line.SetLineColor(ROOT.kBlack);
+        line.SetLineWidth(2);
+
+        padUp = c2.cd(1)
+        padUp.SetTickx(1)
+        padUp.SetTicky(1)
+        padUp.SetGridy(1)
+        padUp.SetBottomMargin(0.15)
+
+        graphLeft_rel.SetTitle('W^{{{ch}}}: left'.format(ch='+' if charge=='plus' else '-'))
+        graphLeft_rel.SetFillColor(colorL)
+        graphRight_rel.SetTitle('W^{{{ch}}}: right'.format(ch='+' if charge=='plus' else '-'))
+        graphRight_rel.SetFillColor(colorR)
+
+        graphLeft_rel.GetXaxis().SetRangeUser(0., 3.)
+        graphLeft_rel.GetYaxis().SetRangeUser(0.97, 1.033)
+        graphRight_rel.GetXaxis().SetRangeUser(0., 3.)
+        graphRight_rel.GetYaxis().SetRangeUser(0.97, 1.033)
+
+        graphRight_rel.GetXaxis().SetTitle('|Y_{W}|')
+
+        graphLeft_rel .GetXaxis().SetTitleSize(0.06)
+        graphLeft_rel .GetXaxis().SetLabelSize(0.06)
+        graphLeft_rel .GetYaxis().SetTitleSize(0.06)
+        graphLeft_rel .GetYaxis().SetLabelSize(0.06)
+        graphRight_rel.GetXaxis().SetTitleSize(0.06)
+        graphRight_rel.GetXaxis().SetLabelSize(0.06)
+        graphRight_rel.GetYaxis().SetTitleSize(0.06)
+        graphRight_rel.GetYaxis().SetLabelSize(0.06)
+
+        graphLeft_rel.Draw('Pa2')
+        line.Draw("Lsame");
+        padUp.RedrawAxis("sameaxis");
+
+        padDown = c2.cd(2)
+        padDown.SetTickx(1)
+        padDown.SetTicky(1)
+        padDown.SetGridy(1)
+        padDown.SetBottomMargin(0.15)
+        graphRight_rel.Draw('pa2')
+        line.Draw("Lsame");
+        padDown.RedrawAxis("sameaxis");
+
+        for ext in ['png', 'pdf']:
+            c2.SaveAs('{od}/genAbsY_pdfs_{date}_{ch}_relative.{ext}'.format(od=options.outdir, date=date, ch=charge, ext=ext))

--- a/WMass/python/plotter/w-helicity-13TeV/plotYsyst.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYsyst.py
@@ -73,7 +73,6 @@ if __name__ == "__main__":
                 nom = nominal[pol][iy]
                 totUp=0
                 for ip,pdf in enumerate(shape_syst[pol]):
-                    if ip==4: continue
                     # debug
                     relsyst = abs(nom-pdf[iy])/nom
                     if relsyst>0.20:
@@ -205,11 +204,12 @@ if __name__ == "__main__":
         leg = ROOT.TLegend(0.60, 0.60, 0.85, 0.80)
         leg.SetFillStyle(0)
         leg.SetBorderSize(0)
-        leg.AddEntry(graphLeft , 'W^{{{ch}}} left (incl. PDFs)' .format(ch='+' if charge == 'plus' else '-'), 'f')
-        leg.AddEntry(graphRight, 'W^{{{ch}}} right (incl. PDFs)'.format(ch='+' if charge == 'plus' else '-'), 'f')
+        leg.AddEntry(graphLeft , 'W^{{{ch}}} left (PDF variations)' .format(ch='+' if charge == 'plus' else '-'), 'f')
         if options.fitResult:
-            leg.AddEntry(graphLeft_fit , 'W^{{{ch}}} left (fit PDFs)' .format(ch='+' if charge == 'plus' else '-'), 'f')
-            leg.AddEntry(graphRight_fit, 'W^{{{ch}}} right (fit PDFs)'.format(ch='+' if charge == 'plus' else '-'), 'f')
+            leg.AddEntry(graphLeft_fit , 'W^{{{ch}}} left (PDF fit)' .format(ch='+' if charge == 'plus' else '-'), 'f')
+        leg.AddEntry(graphRight, 'W^{{{ch}}} right (PDF variations)'.format(ch='+' if charge == 'plus' else '-'), 'f')
+        if options.fitResult:
+            leg.AddEntry(graphRight_fit, 'W^{{{ch}}} right (PDF fit)'.format(ch='+' if charge == 'plus' else '-'), 'f')
 
         graphLeft.SetTitle('W {ch}: Y_{{W}}'.format(ch=charge))
         graphLeft.SetFillColor(colorL)

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/wmass_plots.py
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/wmass_plots.py
@@ -15,8 +15,8 @@ dowhat = "plots"
 #dowhat = "yields" 
 
 TREES = "-F Friends '{P}/friends/tree_Friend_{cname}.root' "
-TREESONLYSKIMW = "-P /eos/cms/store/group/dpg_ecal/comm_ecal/localreco/TREES_1LEP_80X_V3_WENUSKIM_V5"
-TREESONLYSKIMZ = "-P /eos/cms/store/group/dpg_ecal/comm_ecal/localreco/TREES_1LEP_80X_V3_ZEESKIM_V5"
+TREESONLYSKIMW = "-P /eos/cms/store/group/dpg_ecal/comm_ecal/localreco/TREES_1LEP_80X_V3_WENUSKIM_V5_TINY"
+TREESONLYSKIMZ = "-P /eos/cms/store/group/dpg_ecal/comm_ecal/localreco/TREES_1LEP_80X_V3_ZEESKIM_V6"
 TREESONLYFULL  = "-P /eos/cms/store/group/dpg_ecal/comm_ecal/localreco/TREES_1LEP_80X_V3"
 
 def base(selection,useSkim=True):
@@ -43,10 +43,11 @@ def base(selection,useSkim=True):
     elif selection=='wgen':
         GO="%s w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt w-helicity-13TeV/wmass_e/wenu_80X.txt "%CORE
         GO="%s -p Wplus_long,Wplus_left,Wplus_right --plotmode=nostack "%GO
-        GO="%s --sP wplus_mtwtk,wplus_etal1,wplus_ptl1,wplus_etal1gen,wplus_ptl1gen,wplus_wy,wplus_wpt "%GO
+        #GO="%s --sP wplus_mtwtk,wplus_etal1,wplus_ptl1,wplus_etal1gen,wplus_ptl1gen,wplus_wy,wplus_wpt "%GO
+        GO="%s --sP wplus_wy "%GO
         if dowhat in ["plots","ntuple"]: GO+=" w-helicity-13TeV/wmass_e/wenu_plots.txt "        
     elif selection=='zee':
-        GO="%s w-helicity-13TeV/wmass_e/mca-80X-skims.txt w-helicity-13TeV/wmass_e/zee.txt "%CORE
+        GO="%s w-helicity-13TeV/wmass_e/mca-80X-skims.txt w-helicity-13TeV/wmass_e/skim_zee.txt "%CORE
         GO="%s -W 'puw2016_nTrueInt_36fb(nTrueInt)*trgSF_We(LepGood1_pdgId,LepGood1_pt,LepGood1_eta,2)*leptonSF_We(LepGood1_pdgId,LepGood1_pt,LepGood1_eta)*leptonSF_We(LepGood2_pdgId,LepGood2_pt,LepGood2_eta)' --sp 'Z' "%GO
         if dowhat in ["plots","ntuple"]: GO+=" w-helicity-13TeV/wmass_e/zee_plots.txt "
     else:
@@ -59,11 +60,25 @@ def procs(GO,mylist):
 def sigprocs(GO,mylist):
     return procs(GO,mylist)+' --showIndivSigs --noStackSig'
 def runIt(GO,name,plots=[],noplots=[]):
-    if   dowhat == "plots":  print 'python mcPlots.py',"--pdir %s/%s"%(ODIR,name),GO,' '.join(['--sP \'%s\''%p for p in plots]),' '.join(['--xP \'%s\''%p for p in noplots]),' '.join(sys.argv[3:])
-    elif dowhat == "yields": print 'echo %s; python mcAnalysis.py'%name,GO,' '.join(sys.argv[3:])
-    elif dowhat == "dumps":  print 'echo %s; python mcDump.py'%name,GO,' '.join(sys.argv[3:])
-    elif dowhat == "ntuple": print 'echo %s; python mcNtuple.py'%name,GO,' '.join(sys.argv[3:])
-
+    if   dowhat == "plots":  print 'python mcPlots.py',"--pdir %s/%s"%(ODIR,name),GO,' '.join(['--sP \'%s\''%p for p in plots]),' '.join(['--xP \'%s\''%p for p in noplots])
+    elif dowhat == "yields": print 'echo %s; python mcAnalysis.py'%name,GO
+    elif dowhat == "dumps":  print 'echo %s; python mcDump.py'%name,GO
+    elif dowhat == "ntuple": print 'echo %s; python mcNtuple.py'%name,GO
+def submitIt(GO,name,plots=[],noplots=[],opts=None):
+    outdir=ODIR+"/jobs/"
+    if not os.path.isdir(outdir): os.mkdir(outdir)
+    srcfile = outdir+name+".sh"
+    logfile = outdir+name+".log"
+    srcfile_op = open(srcfile,"w")
+    srcfile_op.write("#! /bin/sh\n")
+    srcfile_op.write("ulimit -c 0\n")
+    srcfile_op.write("cd {cmssw};\neval $(scramv1 runtime -sh);\ncd {dir};\n".format( 
+            dir = os.getcwd(), cmssw = os.environ['CMSSW_BASE']))
+    srcfile_op.write("python mcPlots.py "+" --pdir %s/%s "%(ODIR,name)+GO+' '.join(['--sP \'%s\''%p for p in plots])+' '.join(['--xP \'%s\''%p for p in noplots])+'\n')
+    os.system("chmod a+x "+srcfile)
+    cmd = "bsub -q 8nh -o {dir}/{logfile} {dir}/{srcfile}\n".format(dir=os.getcwd(), logfile=logfile, srcfile=srcfile)
+    if opts.dryRun: print "[DRY-RUN]: ", cmd
+    else: os.system(cmd)
 def add(GO,opt):
     return '%s %s'%(GO,opt)
 def remove(GO,opt):
@@ -84,6 +99,12 @@ def fulltrees(x,selection):
 allow_unblinding = True
 
 if __name__ == '__main__':
+
+    from optparse import OptionParser
+    parser = OptionParser(usage="%prog outdir what [options] ")
+    parser.add_option("--dry-run", dest="dryRun",    action="store_true", default=False, help="Do not run the job, only print the command");
+    parser.add_option("-q", "--queue",    dest="queue",     type="string", default=None, help="Run jobs on lxbatch instead of locally");
+    (options, args) = parser.parse_args()
 
     torun = sys.argv[2]
 
@@ -106,9 +127,18 @@ if __name__ == '__main__':
         if 'plus' in torun: x = swapcharge(x,'plus')
         elif 'minus' in torun: x = swapcharge(x,'minus')
         if 'nosel' in torun:
-            x = add(x," -U 'alwaystrue' ")
+             x = add(x," -U 'alwaystrue' ")
         if 'fullsel' in torun:
             x = add(x," -W 'puw2016_nTrueInt_36fb(nTrueInt)*trgSF_We(LepGood1_pdgId,LepGood1_pt,LepGood1_eta,2)*leptonSF_We(LepGood1_pdgId,LepGood1_pt,LepGood1_eta)' ")
+        if torun.endswith('pdfs'):
+            for i in xrange(60):
+                wgt = 'hessWgt[%d]/genWeight' % i
+                output = '%s/%s_pdf%i.root' % (ODIR,torun,i)
+                xw = x
+                xw = add(xw," -W '{wgt}' -o {output}".format(wgt=wgt,output=output))
+                submitIt( xw,'%s_%s' % (torun,i), opts=options )
 
     plots = [] # if empty, to all the ones of the txt file
-    runIt(x,'%s'%torun,plots)
+    if not torun.endswith('pdfs'): 
+        if options.queue: submitIt(x,'%s'%torun,plots,opts=options)
+        else: runIt(x,'%s'%torun,plots)


### PR DESCRIPTION
* plotYsyst.py makes the plot of the rapidity including the PDFs variations from MC reweighting and compares (optionally) with the fit result where the PDFs are floated.
* It needs a series of files: the nominal and the 60 NNPDF 3.0 variations with the left, right, long Y distributions w/o cuts. 

Example of usage:

`python plotYsyst.py --channel el -C plus ../plots/gen/pdfvar/ ../cards/helicity_2018_03_09_testpdfsymm/binningYW.txt --fitResult multidimfit_plus_wpdf.root `

Example of output:
![image](https://user-images.githubusercontent.com/4517974/37687234-0809985e-2c9b-11e8-827a-837ea1afb0ab.png)

![image](https://user-images.githubusercontent.com/4517974/37687240-0f79481e-2c9b-11e8-9205-52b42a077f32.png)
