### PR TITLE
Some implementation of lumi and fixed W bins uncertainties

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
              hel_to_constrain = [signal_L,signal_R]
              bins_to_constrain = options.constrainRateParams.split(',')
              tightConstraint = 0.05
-             looseConstraint = 0.20
+             looseConstraint = tightConstraint
              for hel in hel_to_constrain:
                  for iy,helbin in enumerate(hel):
                      pol = helbin.split('_')[1]

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -44,6 +44,8 @@ if __name__ == "__main__":
      parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
      parser.add_option(     '--longToTotal', dest='longToTotal', type='float', default=None, help='Apply a constraint on the Wlong/Wtot rate. Implies fitting for absolute rates')
      parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
+     parser.add_option(     '--lumiLnU'    , dest='lumiLnU'    , default=0.026, type='float', help='Log-uniform constraint to be added to all the fixed MC processes')
+     parser.add_option(     '--wXsecLnN'   , dest='wLnN'       , default=0.038, type='float', help='Log-normal constraint to be added to all the fixed W processes')
      (options, args) = parser.parse_args()
      
      from symmetrizeMatrixAbsY import getScales
@@ -279,7 +281,8 @@ if __name__ == "__main__":
                  efferrors_LO   [pol] = [   x for x in getScales(ybins, charge, pol, os.path.abspath(options.scaleFile), doNLO=False, returnError=True)]
      
          combinedCard = open(cardfile,'a')
-         POIs = []
+
+         POIs = []; fixedPOIs = []; allPOIs = []
          if options.constrainRateParams:
              signal_procs = filter(lambda x: re.match('Wplus|Wminus',x), realprocesses)
              if longBKG: signal_procs = filter(lambda x: re.match('(?!Wplus_long|Wminus_long)',x), signal_procs)
@@ -291,7 +294,7 @@ if __name__ == "__main__":
              hel_to_constrain = [signal_L,signal_R]
              bins_to_constrain = options.constrainRateParams.split(',')
              tightConstraint = 0.05
-             looseConstraint = tightConstraint
+             looseConstraint = 0.20
              for hel in hel_to_constrain:
                  for iy,helbin in enumerate(hel):
                      pol = helbin.split('_')[1]
@@ -408,30 +411,35 @@ if __name__ == "__main__":
      
                  ## make an efficiency nuisance group
                  combinedCardNew.write('\nefficiencies group = '+' '.join([p.replace('norm','eff') for p in POIs])+'\n\n' )
+
+                 ## remove all the POIs that we want to fix
+                 if options.absoluteRates:
+                     # remove the channel to allow ele/mu combination when fitting for GEN
+                     channel = 'mu' if 'mu' in helbin else 'el'
+                     POIs = [poi.replace('W{charge}_{channel}_Ybin'.format(charge=charge,channel=channel),'W{charge}_Ybin'.format(charge=charge)) for poi in  POIs]
+                 for poi in POIs:
+                     if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
+                         fixedPOIs.append(poi)
+                     if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
+                         fixedPOIs.append(poi)
+                 floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
+                 allPOIs = fixedPOIs+floatPOIs
      
                  ## add the PDF systematics 
                  for sys,procs in pdfsyst.iteritems():
                      # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
                      combinedCardNew.write('%-15s   shape %s\n' % (sys,(" ".join([kpatt % '1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
                  combinedCardNew.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
-     
+
+                 ## now assign a uniform luminosity uncertainty to all the fixed processes, to avoid constraining 
+                 channel = 'mu' if 'mu' in helbin else 'el'
+                 combinedCardNew.write('\nCMS_lumi_13TeV   lnU %s\n' % (" ".join([kpatt % '-' if ('data' in p or any(p.replace('_%s_'%channel,'_')==fPOI.replace('norm_','') for fPOI in floatPOIs)) else '%.3f'%(1+5.0*options.lumiLnU) for p,r in ProcsAndRates])) )
+                 combinedCardNew.write('CMS_W   lnN %s\n' % (" ".join([kpatt % '%.3f' % (1+options.wLnN) if (p=='TauDecaysW' or p=='Wplus_long' or any(p.replace('_%s_'%channel,'_')==fPOI.replace('norm_','') for fPOI in fixedPOIs)) else '-' for p,r in ProcsAndRates])) )
+
                  combinedCardNew.close() ## for some reason this is really necessary
                  os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
      
          
-         ## remove all the POIs that we want to fix
-         if options.absoluteRates:
-             # remove the channel to allow ele/mu combination when fitting for GEN
-             channel = 'mu' if 'mu' in helbin else 'el'
-             POIs = [poi.replace('W{charge}_{channel}_Ybin'.format(charge=charge,channel=channel),'W{charge}_Ybin'.format(charge=charge)) for poi in  POIs]
-         fixedPOIs = []
-         for poi in POIs:
-             if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
-                 fixedPOIs.append(poi)
-             if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
-                 fixedPOIs.append(poi)
-         floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
-         allPOIs = fixedPOIs+floatPOIs
      
          ## define the combine POIs, i.e. the subset on which to run MINOS
          minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')

--- a/WMass/python/plotter/w-helicity-13TeV/plotYsyst.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYsyst.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
     parser.add_option(     '--fitResult', dest='fitResult', default=None, type='string', help='file with fitresult')
     parser.add_option('-o','--outdir', dest='outdir', default='.', type='string', help='outdput directory to save the matrix')
-    parser.add_option('-c','--channel', dest='channel', default='el', type='string', help='name of the channel')
+    parser.add_option(     '--suffix', dest='suffix', default='', type='string', help='suffix for the correlation matrix')
     (options, args) = parser.parse_args()
 
     inputdir = args[0]
@@ -122,7 +122,7 @@ if __name__ == "__main__":
             for iy,y in enumerate(ybinwidths):
                 totalrate += nominal[pol][iy]
                 if options.fitResult:
-                    parname = 'norm_W{charge}_{pol}_W{charge}_{channel}_Ybin_{iy}'.format(charge=charge,pol=pol,channel=options.channel,iy=iy)
+                    parname = 'norm_W{charge}_{pol}_W{charge}_Ybin_{iy}'.format(charge=charge,pol=pol,iy=iy)
                     tmp_par = fpars.find(parname) if parname in f_params else cpars.find(parname)
                     totalrate_fit += tmp_par.getVal()
 
@@ -144,7 +144,7 @@ if __name__ == "__main__":
                 arr_relhi.append(systematics[pol][iy]/nominal[pol][iy]) # symmetric for the expected
                 
                 if options.fitResult:
-                    parname = 'norm_W{charge}_{pol}_W{charge}_{channel}_Ybin_{iy}'.format(charge=charge,pol=pol,channel=options.channel,iy=iy)
+                    parname = 'norm_W{charge}_{pol}_W{charge}_Ybin_{iy}'.format(charge=charge,pol=pol,iy=iy)
 
                     tmp_par = fpars.find(parname) if parname in f_params else cpars.find(parname)
                     arr_val_fit.append(tmp_par.getVal()/totalrate_fit/ybinwidths[iy])
@@ -239,7 +239,7 @@ if __name__ == "__main__":
 
         date = datetime.date.today().isoformat()
         for ext in ['png', 'pdf']:
-            c2.SaveAs('{od}/genAbsY_pdfs_{date}_{ch}.{ext}'.format(od=options.outdir, date=date, ch=charge, ext=ext))
+            c2.SaveAs('{od}/genAbsY_pdfs_{date}_{ch}{suffix}.{ext}'.format(od=options.outdir, date=date, ch=charge, suffix=options.suffix, ext=ext))
 
         ## now make the relative error plot:
         ## ======================================
@@ -301,4 +301,4 @@ if __name__ == "__main__":
         padDown.RedrawAxis("sameaxis");
 
         for ext in ['png', 'pdf']:
-            c2.SaveAs('{od}/genAbsY_pdfs_{date}_{ch}_relative.{ext}'.format(od=options.outdir, date=date, ch=charge, ext=ext))
+            c2.SaveAs('{od}/genAbsY_pdfs_{date}_{ch}{suffix}_relative.{ext}'.format(od=options.outdir, date=date, ch=charge, suffix=options.suffix, ext=ext))


### PR DESCRIPTION
So, after some thinking and tries, this PR does:
1. adds log-uniform nuisance for lumi for all the MC processes:
   * non-W ones (Top, Z, dibosons) 
   * long W
   * the fixed rapidity bins
the reason is that if one fixes some W bins, this should have the lumi systematic applied. It is a lnU with a value of 5*sigma the actual value (sigma=2.6%) in order not to have it constrained by the large yields of these processes. 
It is not applied to the floating W rapidity bins because as far as I understand the rateParameters are freely floating 
2. adds a lnN nuisance for the fixed W processes (W->taus, Wlong, fixed W rapidity bins), equal to the cross section uncertainty (3.8% from [SM twiki x-sec](https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV) )

saying this, it doesn't change significantly the results shown at the meeting yesterday. 
Not merging now, want to discuss with @mdunser and @gpetruc