### PR TITLE
Axis labels for correlation matrix and other fixes

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
 
     c.SetLeftMargin(0.09)
     c.SetRightMargin(0.11)
-    c.SetBottomMargin(0.14)
+    c.SetBottomMargin(0.15)
 
     ## some more ROOT "magic"
     parlist = fitresult.floatParsFinal()
@@ -129,6 +129,9 @@ if __name__ == "__main__":
     pars_l = sorted(pars_l, key = lambda x: int(x.split('_')[-1]), reverse=False)
 
     l_sorted_new = pars_r + pars_l + long_par + rest
+    print "######################################"
+    print "fitresult.floatParsFinal(): " + str(l_params)
+    print "######################################"
 
     helicities = ["right", "left", "long"]
 
@@ -157,7 +160,7 @@ if __name__ == "__main__":
             if l.startswith("norm"):
                 new_l = "W%s%s" % (helID, chargeID)
             elif l.startswith("eff_unc"):
-                new_l = "eff W%s%s" % (helID, chargeID)
+                new_l = "#deltaeff W%s%s" % (helID, chargeID)
             elif l.startswith("lumi"):
                 new_l = "lumi W%s%s" % (helID, chargeID)
 
@@ -199,6 +202,9 @@ if __name__ == "__main__":
 
         plist2 = fitresult.constPars()
         lpars2 = list(plist2.at(i).GetName() for i in range(len(plist2)))
+        print "######################################"
+        print "fitresult.constPars(): " + str(lpars2)
+        print "######################################"
 
         hel_pars2 = list(p for p in lpars2 if 'norm_W' in p)
         long_par2 = list(a for a in lpars2 if 'long' in a)
@@ -214,7 +220,7 @@ if __name__ == "__main__":
         pars_l = pars_l + lpars2
         pars_r = list(reversed(pars_r)) + list(reversed(rpars2))
 
-        if not len(ybins)-1 == len(sorted_rap):
+        if not  (2 * (len(ybins)-1)) == len(sorted_rap):
             print 'SOMETHING WENT TERRIBLY WRONG'
             print "len(ybins)-1 = %d;   len(sorted_rap) = %d" % (len(ybins)-1, len(sorted_rap))
 

--- a/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
@@ -59,8 +59,6 @@ if __name__ == "__main__":
     ROOT.gROOT.SetBatch()
     ROOT.gStyle.SetOptStat(0)
 
-    ROOT.gStyle.SetPalette(1)
-
     date = datetime.date.today().isoformat()
 
     from optparse import OptionParser
@@ -286,8 +284,8 @@ if __name__ == "__main__":
 
                     tmp_par_init = fitresult.floatParsInit().find(p) if p in l_sorted_new else fitresult.constPars().find(p)
                     arr_relv .append(tmp_par.getVal()/tmp_par_init.getVal())
-                    arr_rello.append(abs(tmp_par.getAsymErrorHi())/tmp_par_init.getVal())
-                    arr_relhi.append(abs(tmp_par.getAsymErrorLo() if tmp_par.hasAsymError() else tmp_par.getAsymErrorHi())/tmp_par_init.getVal())
+                    arr_rello.append(abs(tmp_par.getAsymErrorLo())/tmp_par_init.getVal() if tmp_par.hasAsymError() else tmp_par.getAsymErrorHi())/tmp_par_init.getVal()
+                    arr_relhi.append(abs(tmp_par.getAsymErrorHi()))
                 else:
                     tmp_rate = float(rates[procs.index(tmp_procname)])
                     arr_val.append(tmp_rate/totalrate/ybinwidths[ip]*tmp_par.getVal())

--- a/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
                     arr_ehiReco.append(abs(tmp_par.getAsymErrorHi())/totalrate/ybinwidths[ip]*tmp_eff)
                     arr_eloReco.append(abs(tmp_par.getAsymErrorLo() if tmp_par.hasAsymError() else tmp_par.getAsymErrorHi())/totalrate/ybinwidths[ip]*tmp_eff)
 
-                    tmp_par_init = fitresult.floatParsFinal().find(p) if p in l_sorted_new else fitresult.constPars().find(p)
+                    tmp_par_init = fitresult.floatParsInit().find(p) if p in l_sorted_new else fitresult.constPars().find(p)
                     arr_relv .append(tmp_par.getVal()/tmp_par_init.getVal())
                     arr_rello.append(abs(tmp_par.getAsymErrorHi())/tmp_par_init.getVal())
                     arr_relhi.append(abs(tmp_par.getAsymErrorLo() if tmp_par.hasAsymError() else tmp_par.getAsymErrorHi())/tmp_par_init.getVal())

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_80X.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_80X.txt
@@ -1,9 +1,7 @@
 alwaystrue: 1
-#HLT_SingleEL : HLT_SingleEl == 1
 HLT_SingleEL : HLT_BIT_HLT_Ele27_WPTight_Gsf_v == 1
 onelep : nLepGood == 1 && abs(LepGood1_pdgId)==11
 fiducial : abs(LepGood1_eta)<1.4442 || abs(LepGood1_eta)>1.566
 eleKin : ptElFull(LepGood1_calPt,LepGood1_eta) > 30 && ptElFull(LepGood1_calPt,LepGood1_eta) < 45 && abs(LepGood1_eta)<2.5
-#highEtaEE_HLTlowPt: abs(LepGood1_eta) < 2.1 || HLT_BIT_HLT_Ele27_WPTight_Gsf_v == 1 || HLT_BIT_HLT_Ele25_WPTight_Gsf_v == 1
 HLTid : LepGood1_hltId > 0
 numSel : LepGood1_customId == 1

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_80X.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_80X.txt
@@ -1,8 +1,9 @@
 alwaystrue: 1
-HLT_SingleEL : HLT_SingleEl == 1
+#HLT_SingleEL : HLT_SingleEl == 1
+HLT_SingleEL : HLT_BIT_HLT_Ele27_WPTight_Gsf_v == 1
 onelep : nLepGood == 1 && abs(LepGood1_pdgId)==11
 fiducial : abs(LepGood1_eta)<1.4442 || abs(LepGood1_eta)>1.566
 eleKin : ptElFull(LepGood1_calPt,LepGood1_eta) > 30 && ptElFull(LepGood1_calPt,LepGood1_eta) < 45 && abs(LepGood1_eta)<2.5
-highEtaEE_HLTlowPt: abs(LepGood1_eta) < 2.1 || HLT_BIT_HLT_Ele27_WPTight_Gsf_v == 1 || HLT_BIT_HLT_Ele25_WPTight_Gsf_v == 1
+#highEtaEE_HLTlowPt: abs(LepGood1_eta) < 2.1 || HLT_BIT_HLT_Ele27_WPTight_Gsf_v == 1 || HLT_BIT_HLT_Ele25_WPTight_Gsf_v == 1
 HLTid : LepGood1_hltId > 0
 numSel : LepGood1_customId == 1


### PR DESCRIPTION
- WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
Improving axis labels, setting canvas margins and doubling divisions in palette (40 from -1 to 1, 5% granularity)

- WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_80X.txt
using HLT_Ele27 as the only trigger

-  WMass/python/plotter/utilityMacros/src/makeVariableEfficiencyAndROC.C
some improvements. The macro is supposed to compare efficiencies and make ROC curve for one signal and one background, but now more of both can be passed (but they will still be summed up as a single signal or background).