### PR TITLE
fixing bug in symmetrizeMatrixAbsY.py

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -83,6 +83,10 @@ if options.queue and not os.path.exists(outdir+"/jobs"):
     os.mkdir(outdir+"/jobs")
     os.mkdir(outdir+"/mca")
 
+# copy some cfg for bookkeeping
+os.system("cp %s %s" % (CUTFILE, outdir))
+os.system("cp %s %s" % (MCA, outdir))
+
 MCASYSTS=MCA
 if options.addPdfSyst:
     # write the additional systematic samples in the MCA file

--- a/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/symmetrizeMatrixAbsY.py
@@ -304,8 +304,9 @@ if __name__ == "__main__":
                         print "WARNING: getting name of efficiency parameter: we are adding 'us_%s_Ybin' to 'us_Ybin' " % "el" if channel_mu1_el2 == 2 else "mu" 
                         print "before " + tmp_par_eff_name
                         if channel_mu1_el2 == 2 and not '_el_Ybin' in tmp_par_eff_name:                        
-                            tmp_par_eff_name = tmp_par_eff_name.replace('us_Ybin','us_mu_Ybin')
+                            tmp_par_eff_name = tmp_par_eff_name.replace('us_Ybin','us_el_Ybin')
                         elif channel_mu1_el2 == 1 and not '_mu_Ybin' in tmp_par_eff_name:
+                            tmp_par_eff_name = tmp_par_eff_name.replace('us_Ybin','us_mu_Ybin')
                         print "after " + tmp_par_eff_name
                     #print "ip, p, eff_par = %d %s %s" % (ip, str(p), str(tmp_par_eff_name))
                     tmp_par_eff =  fitresult.constPars().find(tmp_par_eff_name)


### PR DESCRIPTION
I added a missing line when managing names of parameters between muon and electron channel.

I also modified w-helicity-13TeV/make_helicity_cards.py to save mca and cut file in the folder with datacard (useful to keep track of selection and samples used)