### PR TITLE
Fixes about fake rate usage and plot making

### DIFF
--- a/WMass/python/plotter/fakeRate.cc
+++ b/WMass/python/plotter/fakeRate.cc
@@ -44,7 +44,7 @@ bool loadFRHisto(const std::string &histoName, const std::string file, const cha
   if (histoName == "FR_mu")  { histo = & FR_mu;  hptr2 = & FRi_mu[0]; }
   else if (histoName == "FR_mu_qcdmc")  { histo = & FR_mu_qcdmc;  hptr2 = & FRi_mu_qcdmc[0]; }
   else if (histoName == "FR_el")  { histo = & FR_el;  hptr2 = & FRi_el[0]; }
-  else if (histoName == "FR_el_qcdmc")  { histo = & FR_elqcdmc;  hptr2 = & FRi_el_qcdmc[0]; }
+  else if (histoName == "FR_el_qcdmc")  { histo = & FR_el_qcdmc;  hptr2 = & FRi_el_qcdmc[0]; }
   else if (histoName == "PR_el")  { histo = & PR_el;  hptr2 = & PRi_el[0]; }
   // else if (histoName == "FR_correction")  { histo = & FRcorrectionForPFMET; hptr2 = & FRcorrectionForPFMET_i[0]; }
   else if (TString(histoName).BeginsWith("FR_mu_i")) {histo = & FR_temp; hptr2 = & FRi_mu[TString(histoName).ReplaceAll("FR_mu_i","").Atoi()];}

--- a/WMass/python/plotter/mcPlots.py
+++ b/WMass/python/plotter/mcPlots.py
@@ -156,31 +156,23 @@ def reMax(hist,hist2,islog,factorLin=1.3,factorLog=2.0,doWide=False):
     if  hist.ClassName() == 'THStack':
         #hist = hist.GetHistogram()  # better to use sum of all components, GetHistogram() returns a fake TH1 used to build the axis (could have no relation with the plot)
         hist = hist.GetStack().Last() # this is the sum of all components
-    #max0 = hist.GetMaximum()
-    #max2 = hist2.GetMaximum()*(factorLog if islog else factorLin)
     max0 = hist.GetBinContent(hist.GetMaximumBin())
     max2 = hist2.GetBinContent(hist2.GetMaximumBin())*(factorLog if islog else factorLin)
-    # centerBinMax0 = hist.GetBinCenter(hist.GetMaximumBin())
-    # centerBinMax2 = hist2.GetBinCenter(hist2.GetMaximumBin())
-    # print "hist = " + hist.GetName() + "   hist2 = " + hist2.GetName()
-    # print "before: max0,max2 = " + str(max0) +  " " + str(max2) + "   bin(max0),bin(max2) = " + str(centerBinMax0) + " " + str(centerBinMax2)
     # Below, use a protection against cases where uncertainty is much bigger than value (might happen with weird situations or QCD MC)
     if hasattr(hist2,'poissonGraph'):
        for i in xrange(hist2.poissonGraph.GetN()):
           if (hist2.poissonGraph.GetErrorYhigh(i) > hist2.poissonGraph.GetY()[i]):
-              tmpvalue = 1.1 * hist2.poissonGraph.GetY()[i]
+              tmpvalue = (factorLog if islog else factorLin) * hist2.poissonGraph.GetY()[i]
           else:
               tmpvalue = (hist2.poissonGraph.GetY()[i] + 1.3*hist2.poissonGraph.GetErrorYhigh(i))
           max2 = max(max2, tmpvalue*(factorLog if islog else factorLin))
     elif "TH1" in hist2.ClassName():
        for b in xrange(1,hist2.GetNbinsX()+1):
           if (hist2.GetBinError(b) > hist2.GetBinContent(b)):
-              tmpvalue = 1.1 * hist2.GetBinContent(b)
+              tmpvalue = (factorLog if islog else factorLin) * hist2.GetBinContent(b)
           else:
               tmpvalue = hist2.GetBinContent(b) + 1.3*hist2.GetBinError(b)
           max2 = max(max2, tmpvalue*(factorLog if islog else factorLin))
-          #print "hist2: bin,center,content,error,max2 = %d  %.1f  %.1f  %.1f  %.1f" % (b,hist2.GetBinCenter(b),hist2.GetBinContent(b),hist2.GetBinError(b),max2)
-    #print "after: max0,max2 = " + str(max0) +  " " + str(max2)
     if max2 > max0:
         max0 = max2;
         if islog: hist.GetYaxis().SetRangeUser(0.1 if doWide else 0.9, max0)

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt
@@ -1,4 +1,4 @@
 cut-change: LepGood1_customId: 1
 cut-change: LepGood1_tightChargeFix: 2
-load-histo: FR_el : $DATA/fakerate/fakeRateSmoothed_el.root : frSmoothParameter_qcd
+load-histo: FR_el_qcdmc : $DATA/fakerate/fakeRateSmoothed_el.root : frSmoothParameter_qcd
 weight: fakeRateWeight_1l_i_smoothed(ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_eta,LepGood1_pdgId,LepGood1_customId && LepGood1_tightChargeFix == 2,0)

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-qcdClosureTest.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-qcdClosureTest.txt
@@ -34,11 +34,11 @@ QCD: QCD_Pt* : xsec; FillColor=ROOT.kBlack, Label="QCD", NormSystematic=1.00
 #W   : WJetsToLNu_NLO_part* : 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kRed+2, Label="W (amc@NLO)", NormSystematic=0.026
 #W   : WJetsToLNu_NLO_ext_part* : 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kRed+2, Label="W (amc@NLO)", NormSystematic=0.026
 
-QCD_fakes: QCD_Pt* : xsec; FillColor=ROOT.kGray, Label="QCD (FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt"
-
 Z_fakes    : DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kAzure+2, NormSystematic=0.04, FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt", Label="Z (FR)"
 
 W_fakes    : WJetsToLNu_NLO_part1 + WJetsToLNu_NLO_part2 + WJetsToLNu_NLO_part3 + WJetsToLNu_NLO_ext_part1 + WJetsToLNu_NLO_ext_part2 + WJetsToLNu_NLO_ext_part3 : 20508.9*3 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kRed+2, NormSystematic=0.026, FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt", Label="W (FR)"
+
+QCD_fakes: QCD_Pt* : xsec; FillColor=ROOT.kGray, Label="QCD (FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt"
 
 # W    : WJetsToLNu_NLO_part2: 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kRed+2, NormSystematic=0.026, FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt", Label="W (FR)", PostFix='_fakes'
 # W    : WJetsToLNu_NLO_part3: 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kRed+2, NormSystematic=0.026, FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt", Label="W (FR)", PostFix='_fakes'
@@ -51,9 +51,9 @@ W_fakes    : WJetsToLNu_NLO_part1 + WJetsToLNu_NLO_part2 + WJetsToLNu_NLO_part3 
 ######################
 # full FR formula on QCD and main EWK components
 
-QCDandEWK_fullFR: WJetsToLNu_NLO_part1 + WJetsToLNu_NLO_part2 + WJetsToLNu_NLO_part3 + WJetsToLNu_NLO_ext_part1 + WJetsToLNu_NLO_ext_part2 + WJetsToLNu_NLO_ext_part3: 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kGreen+2, Label="QCD+EWK (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
-QCDandEWK_fullFR: DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kGreen+2, Label="QCD+EWK (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
-QCDandEWK_fullFR: QCD_Pt* : xsec; FillColor=ROOT.kGreen+2, Label="QCD+EWK (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
+QCDandEWK_fullFR: WJetsToLNu_NLO_part1 + WJetsToLNu_NLO_part2 + WJetsToLNu_NLO_part3 + WJetsToLNu_NLO_ext_part1 + WJetsToLNu_NLO_ext_part2 + WJetsToLNu_NLO_ext_part3: 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kGreen+2, Label="All (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
+QCDandEWK_fullFR: DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kGreen+2, Label="All (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
+QCDandEWK_fullFR: QCD_Pt* : xsec; FillColor=ROOT.kGreen+2, Label="All (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
 
 ######################
 ## other processes


### PR DESCRIPTION
Some fixes in fakeRate.cc:
avoid warnings when wrong flavour is being evaluated
Some fixes and polishing to global variables

mcPlots.py:
fix in setting Y axis range in special cases with huge error bars
Note: to have "CMS preliminary" not overlapping with exponential in Y axis, one should use --noCms option, or modifying the default behaviour of CMS_lumi imported from TTHAnalysis (which is used by default to polish the canvas)

Other fixes in some txt files used for FR tests