### PR TITLE
avoid qcd scale patterns to match with mu

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
      
          ## prepare the relevant files. only the datacards and the correct charge
          files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
-         files = ( f for f in files if charge in f and not re.match('.*_pdf.*|.*_mu.*',f) )
+         files = ( f for f in files if charge in f and not re.match('.*_pdf.*|.*_muR.*|.*_muF.*',f) )
          files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
          files = list( ( os.path.join(options.inputdir, f) for f in files ) )
          
@@ -179,7 +179,7 @@ if __name__ == "__main__":
                                                  if alt.GetName() not in plots:
                                                      plots[alt.GetName()] = alt.Clone()
                                                      plots[alt.GetName()].Write()
-                                         elif '_mu' in newname:
+                                         elif re.match('.*_muR.*|.*_muF.*',newname):
                                              tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); qcdscale = tokens[-1].replace('Dn','Down')
                                              newname = "{pfx}_{syst}".format(pfx=pfx,syst=qcdscale)
                                              if newname not in plots:
@@ -200,7 +200,7 @@ if __name__ == "__main__":
          tf = ROOT.TFile.Open(outfile)
          for e in tf.GetListOfKeys() :
              name=e.GetName()
-             if 'pdf' in name or '_mu' in name:
+             if re.match('.*_pdf.*|.*_muR.*|.*_muF.*',name):
                  if name.endswith("Up"): name = re.sub('Up$','',name)
                  if name.endswith("Down"): name = re.sub('Down$','',name)
                  syst = name.split('_')[-1]

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
      
          ## prepare the relevant files. only the datacards and the correct charge
          files = ( f for f in os.listdir(options.inputdir) if f.endswith('.card.txt') )
-         files = ( f for f in files if charge in f and not re.match('.*_pdf.*|.*_muR.*|.*_muF.*',f) )
+         files = ( f for f in files if charge in f and not re.match('.*_pdf.*|.*_muR.*|.*_muF.*|.*wptSlope.*',f) )
          files = sorted(files, key = lambda x: int(x.rstrip('.card.txt').split('_')[-1]) if not 'bkg'in x else -1) ## ugly but works
          files = list( ( os.path.join(options.inputdir, f) for f in files ) )
          
@@ -126,7 +126,7 @@ if __name__ == "__main__":
                          if len(l.split()) < 2: continue ## skip the second bin line if empty
                          bin = l.split()[1]
                          binn = int(bin.split('_')[-1]) if 'Ybin_' in bin else -1
-                     rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+|muR\S+|muF\S+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
+                     rootfiles_syst = filter(lambda x: re.match('{base}_(pdf\d+|muR\S+|muF\S+|wptSlope\S+)\.input\.root'.format(base=basename),x), os.listdir(options.inputdir))
                      rootfiles_syst = [dir+'/'+x for x in rootfiles_syst]
                      rootfiles_syst.sort()
                      if re.match('process\s+',l): 
@@ -170,7 +170,7 @@ if __name__ == "__main__":
                                              #print 'replacing old %s with %s' % (name,newname)
                                              plots[newname].Write()
                                      else:
-                                         if 'pdf' in newname:
+                                         if 'pdf' in newname: # these changes by default shape and normalization. Each variation should be symmetrized wrt nominal
                                              tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); pdf = tokens[-1]
                                              ipdf = int(pdf.split('pdf')[-1])
                                              newname = "{pfx}_pdf{ipdf}".format(pfx=pfx,ipdf=ipdf)
@@ -179,9 +179,11 @@ if __name__ == "__main__":
                                                  if alt.GetName() not in plots:
                                                      plots[alt.GetName()] = alt.Clone()
                                                      plots[alt.GetName()].Write()
-                                         elif re.match('.*_muR.*|.*_muF.*',newname):
-                                             tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); qcdscale = tokens[-1].replace('Dn','Down')
-                                             newname = "{pfx}_{syst}".format(pfx=pfx,syst=qcdscale)
+                                         elif re.match('.*_muR.*|.*_muF.*|.*wptSlope.*',newname): # these changes by default shape and normalization
+                                             tokens = newname.split("_"); pfx = '_'.join(tokens[:-1]); syst = tokens[-1].replace('Dn','Down')
+                                             newname = "{pfx}_{syst}".format(pfx=pfx,syst=syst)
+                                             if 'wptSlope' in newname: # this needs to be scaled not to change normalization
+                                                 obj.Scale(nominals[pfx].Integral()/obj.Integral())
                                              if newname not in plots:
                                                  plots[newname] = obj.Clone(newname)
                                                  plots[newname].Write()
@@ -200,7 +202,7 @@ if __name__ == "__main__":
          tf = ROOT.TFile.Open(outfile)
          for e in tf.GetListOfKeys() :
              name=e.GetName()
-             if re.match('.*_pdf.*|.*_muR.*|.*_muF.*',name):
+             if re.match('.*_pdf.*|.*_muR.*|.*_muF.*|.*wptSlope.*',name):
                  if name.endswith("Up"): name = re.sub('Up$','',name)
                  if name.endswith("Down"): name = re.sub('Down$','',name)
                  syst = name.split('_')[-1]
@@ -211,6 +213,7 @@ if __name__ == "__main__":
          else: print "You are running w/o theory systematics. Lucky you!"
          pdfsyst = {k:v for k,v in theosyst.iteritems() if 'pdf' in k}
          qcdsyst = {k:v for k,v in theosyst.iteritems() if 'muR' in k or 'muF' in k}
+         wptsyst = {k:v for k,v in theosyst.iteritems() if 'wptSlope' in k}
      
          combineCmd="combineCards.py "
          for f in files:
@@ -370,7 +373,7 @@ if __name__ == "__main__":
                          rates = (l.rstrip().split())[1:]
                      if len(procs) and len(rates): break
                  ProcsAndRates = zip(procs,rates)
-     
+
                  combinedCard = open(cardfile,'r')
                  ProcsAndRatesUnity = []
                  for (p,r) in ProcsAndRates:
@@ -444,6 +447,7 @@ if __name__ == "__main__":
                      combinedCardNew.write('%-15s   shape %s\n' % (sys,(" ".join([kpatt % '1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
                  combinedCardNew.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
                  combinedCardNew.write('\nscales group = '+' '.join([sys for sys,procs in qcdsyst.iteritems()])+'\n')
+                 combinedCardNew.write('\nwpt group = '+' '.join([sys for sys,procs in wptsyst.iteritems()])+'\n')
 
                  ## now assign a uniform luminosity uncertainty to all the fixed processes, to avoid constraining 
                  channel = 'mu' if 'mu' in helbin else 'el'
@@ -474,7 +478,7 @@ if __name__ == "__main__":
          print txt2wsCmd
          os.system(txt2wsCmd)
              
-         combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs}{scales} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''), scales=(',scaless' if len(qcdsyst) else ''))
+         combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs}{scales} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''), scales=(',scales' if len(qcdsyst) else ''))
          print combineCmd
 
      datacards = [os.path.abspath(options.inputdir)+"/"+options.bin+'_{ch}_card.txt'.format(ch=charge) for charge in ['plus','minus']]
@@ -490,6 +494,6 @@ if __name__ == "__main__":
          t2w = 'text2workspace.py {cf} -o {ws} --X-allow-no-signal --X-no-check-norm '.format(cf=combinedCard, ws=ws)
          print "combined t2w command: ",t2w
          os.system(t2w)
-         combineCmdTwoCharges = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs}{scales} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''), scales=(',scaless' if len(qcdsyst) else ''))
+         combineCmdTwoCharges = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs}{scales} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''), scales=(',scales' if len(qcdsyst) else ''))
          print combineCmdTwoCharges
          print "DONE. ENJOY FITTING !"


### PR DESCRIPTION
- avoid qcd scale patterns to match with mu (fix)
- add the wptSlope systematic in the merged card. The systematic is hardcoded to be shapeOnly