### PR TITLE
setting the offset for the pdf lhe weights to 9

### DIFF
--- a/WMass/python/plotter/lheHeadersWJets.txt
+++ b/WMass/python/plotter/lheHeadersWJets.txt
@@ -8,19 +8,18 @@ launch
 initrwgt
 
 <weightgroup combine="envelope" type="scale_variation">
-      <weight id="1001"> muR=0.10000E+01 muF=0.10000E+01 </weight>
-      <weight id="1002"> muR=0.10000E+01 muF=0.20000E+01 </weight>
-      <weight id="1003"> muR=0.10000E+01 muF=0.50000E+00 </weight>
-      <weight id="1004"> muR=0.20000E+01 muF=0.10000E+01 </weight>
-      <weight id="1005"> muR=0.20000E+01 muF=0.20000E+01 </weight>
-      <weight id="1006"> muR=0.20000E+01 muF=0.50000E+00 </weight>
-      <weight id="1007"> muR=0.50000E+00 muF=0.10000E+01 </weight>
-      <weight id="1008"> muR=0.50000E+00 muF=0.20000E+01 </weight>
-      <weight id="1009"> muR=0.50000E+00 muF=0.50000E+00 </weight>
-    </weightgroup>
-    <weightgroup combine="gaussian" type="PDF_variation">
-      <weight id="2001"> pdfset=292201 </weight>
-      <weight id="2002"> pdfset=292202 </weight>
+0     <weight id="1001"> muR=0.10000E+01 muF=0.10000E+01 </weight> ## this is the central weight. it is (almost) equivalent to genWeight.
+1     <weight id="1002"> muR=0.10000E+01 muF=0.20000E+01 </weight>
+2     <weight id="1003"> muR=0.10000E+01 muF=0.50000E+00 </weight>
+3     <weight id="1004"> muR=0.20000E+01 muF=0.10000E+01 </weight>
+4     <weight id="1005"> muR=0.20000E+01 muF=0.20000E+01 </weight>
+5     <weight id="1006"> muR=0.20000E+01 muF=0.50000E+00 </weight>
+6     <weight id="1007"> muR=0.50000E+00 muF=0.10000E+01 </weight>
+7     <weight id="1008"> muR=0.50000E+00 muF=0.20000E+01 </weight>
+8     <weight id="1009"> muR=0.50000E+00 muF=0.50000E+00 </weight>
+
+9     <weight id="2001"> pdfset=292201 </weight>
+10    <weight id="2002"> pdfset=292202 </weight>
       <weight id="2003"> pdfset=292203 </weight>
       <weight id="2004"> pdfset=292204 </weight>
       <weight id="2005"> pdfset=292205 </weight>
@@ -117,10 +116,10 @@ initrwgt
       <weight id="2096"> pdfset=292296 </weight>
       <weight id="2097"> pdfset=292297 </weight>
       <weight id="2098"> pdfset=292298 </weight>
-      <weight id="2099"> pdfset=292299 </weight>
-      <weight id="2100"> pdfset=292300 </weight>
-      <weight id="2101"> pdfset=292301 </weight>
-      <weight id="2102"> pdfset=292302 </weight>
+107   <weight id="2099"> pdfset=292299 </weight>
+108   <weight id="2100"> pdfset=292300 </weight>
+109   <weight id="2101"> pdfset=292301 </weight>
+110   <weight id="2102"> pdfset=292302 </weight>
     </weightgroup>
 scalesfunctionalform
 


### PR DESCRIPTION
included a small check to see if the first pdf-related LHE weight is actually the first replica, and not the second or not the central replica.

it gives a print warning, it does not stop the module.

updated the lheHeadersWJets.txt file to have the numbering.