### PR TITLE
Propagate PDFs and QCD variations to Z

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -99,7 +99,7 @@ def writeQCDScaleSystsToMCA(mcafile,odir,syst="qcd",incl_mca='incl_sig',scales=[
             postfix = "_{proc}_{syst}{idir}".format(proc=incl_mca.split('_')[1],syst=scale,idir=idir)
             mcafile_syst = open(filename, 'a') if append else open("%s/mca%s.txt" % (odir,postfix), "w")
             if not scale == "wptSlope": ## alphaS and qcd scales are treated equally here. but they are different from the w-pT slope
-                mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="qcd'+postfix+'", PostFix="'+postfix+'" \n')
+                mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="qcd_'+scale+idir+'", PostFix="'+postfix+'" \n')
             else:
                 sign  =  1 if idir == 'Dn' else -1
                 asign = -1 if idir == 'Dn' else  1


### PR DESCRIPTION
- Propagate uncertainties on PDFs and QCD variations to Z completely correlated to the W
- by default, all the Y bins are now floating.
- a fix preventing all the cards with QCD variations having 0 yield (introduced by me when adding these systematics to the Z in make_helicity_cards.py)

@mdunser @cippy the command I have run is the usual one, e.g.: 

`python mergeCardComponentsAbsY.py -m -b Wel -C plus -i ../cards/helicity_2018_05_04_Zpdfs --sf ../../../data/efficiency/eff_el_PFMT40.root --absolute -p norm_Wplus_long`
