### PR TITLE
Small fixes to mergeCards after cleanup. Update toys to GSL minimizer

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/submitToys.py
+++ b/WMass/python/plotter/w-helicity-13TeV/submitToys.py
@@ -1,3 +1,5 @@
+#!/bin/env python
+
 # usage: python submitToys.py ../cards/helicity_2018_03_09_testpdfsymm/Wel_plus_ws.root 1000 plus -n 10
 
 import ROOT, random, array, os
@@ -18,9 +20,11 @@ if __name__ == "__main__":
     
     print "Submitting {nt} toys with workspace {ws} and prefix {pfx}...".format(nt=ntoys,ws=workspace,pfx=prefix)
 
-    trackPars = "'\"''rgx{norm_.*|pdf.*}''\"'"
+    trackPars = "'\"''rgx{norm_.*|pdf.*|scales.*|alphaS.*|wpt.*|CMS.*|eff_unc.*}''\"'"
     raiseNormPars = "'\"''rgx{norm_.*}=1,100000000''\"'"
-    cmdBase = "combineTool.py -d {ws} -M MultiDimFit -t {nt} --expectSignal=1 -m 999 {savefr} --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1 --redefineSignalPOIs norm_W%s_long --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY%s --toysNoSystematics -n _{pfx} -s {seed} --trackParameters {track} --setParameterRanges {norm} --job-mode lxbatch --task-name {taskname} --sub-opts='-q 8nh' %s" % (charge, ',pdfs' if options.normonly else '', '--dry-run' if options.dryRun else '')
+    ## the following is to have a reasonable result with MINUIT
+    #cmdBase = "combineTool.py -d {ws} -M MultiDimFit -t {nt} --expectSignal=1 -m 999 {savefr} --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1 --redefineSignalPOIs norm_W%s_long --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies%s --toysNoSystematics -n _{pfx} -s {seed} --trackParameters {track} --setParameterRanges {norm} --job-mode lxbatch --task-name {taskname} --sub-opts='-q 8nh' %s" % (charge, ',pdfs,scales,alphaS,wpt' if options.normonly else '', '--dry-run' if options.dryRun else '')
+    cmdBase = "combineTool.py -d {ws} -M MultiDimFit -t {nt} -m 999 {savefr} --keepFailures --cminDefaultMinimizerType GSLMultiMin --cminDefaultMinimizerAlgo BFGS2 --cminDefaultMinimizerTolerance=0.001 --toysFrequentist --bypassFrequentistFit --redefineSignalPOIs norm_Wplus_left_Wplus_left_Ybin_0,norm_Wplus_left_Wplus_left_Ybin_1,norm_Wplus_left_Wplus_left_Ybin_2,norm_Wplus_left_Wplus_left_Ybin_3,norm_Wplus_left_Wplus_left_Ybin_4,norm_Wplus_left_Wplus_left_Ybin_5,norm_Wplus_left_Wplus_left_Ybin_6,norm_Wplus_left_Wplus_left_Ybin_7,norm_Wplus_left_Wplus_left_Ybin_8,norm_Wplus_left_Wplus_left_Ybin_9,norm_Wplus_left_Wplus_left_Ybin_10,norm_Wplus_left_Wplus_left_Ybin_11,norm_Wplus_left_Wplus_left_Ybin_12,norm_Wplus_left_Wplus_left_Ybin_13,norm_Wplus_left_Wplus_left_Ybin_14,norm_Wplus_left_Wplus_left_Ybin_15,norm_Wplus_left_Wplus_left_Ybin_16,norm_Wplus_left_Wplus_left_Ybin_17,norm_Wplus_right_Wplus_right_Ybin_0,norm_Wplus_right_Wplus_right_Ybin_1,norm_Wplus_right_Wplus_right_Ybin_2,norm_Wplus_right_Wplus_right_Ybin_3,norm_Wplus_right_Wplus_right_Ybin_4,norm_Wplus_right_Wplus_right_Ybin_5,norm_Wplus_right_Wplus_right_Ybin_6,norm_Wplus_right_Wplus_right_Ybin_7,norm_Wplus_right_Wplus_right_Ybin_8,norm_Wplus_right_Wplus_right_Ybin_9,norm_Wplus_right_Wplus_right_Ybin_10,norm_Wplus_right_Wplus_right_Ybin_11,norm_Wplus_right_Wplus_right_Ybin_12,norm_Wplus_right_Wplus_right_Ybin_13,norm_Wplus_right_Wplus_right_Ybin_14,norm_Wplus_right_Wplus_right_Ybin_15,norm_Wplus_right_Wplus_right_Ybin_16,norm_Wplus_long  --floatOtherPOIs=1 --freezeNuisanceGroups efficiencies%s -n _{pfx} -s {seed} --trackParameters {track} --job-mode lxbatch --task-name {taskname} --sub-opts='-q 8nh' %s" % (',pdfs,scales,alphaS,wpt' if options.normonly else '', '--dry-run' if options.dryRun else '')
 
     if options.nTj==None or ntoys<options.nTj:
         cmd = cmdBase.format(nt=ntoys,ws=workspace,pfx=prefix,seed=12345,taskname='toys_'+prefix,track=trackPars,norm=raiseNormPars,savefr='--saveFitResult')


### PR DESCRIPTION
- mergeCardComponentsAbsY.py:
   - fix some fixedY, allY groups after the cleanup
   - add the lumi lnN to all the Ws (i.e. all MC components, fixed and floating, as should be)
   - update the combine command to GSL

- submitToys.py
  - update to GSL, run frequentist toys skipping the prefit to data
