### PR TITLE
Make fit by mu working again

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -41,7 +41,6 @@ if __name__ == "__main__":
     parser.add_option(     '--fix-YBins', dest='fixYBins', type='string', default='plusR=99;plusL=99;minusR=99;minusL=99', help='add here replacement of default rate-fixing. with format plusR=10,11,12;plusL=11,12;minusR=10,11,12;minusL=10,11 ')
     parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
     parser.add_option('-l','--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
-    parser.add_option(     '--absolute', dest='absoluteRates', default=False, action='store_true', help='Fit for absolute rates, not scale factors')
     parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
     parser.add_option(     '--lumiLnN'    , dest='lumiLnN'    , default=0.026, type='float', help='Log-uniform constraint to be added to all the fixed MC processes')
     parser.add_option(     '--wXsecLnN'   , dest='wLnN'       , default=0.038, type='float', help='Log-normal constraint to be added to all the fixed W processes')
@@ -153,6 +152,7 @@ if __name__ == "__main__":
                         for e in tf.GetListOfKeys() :
                             name=e.GetName()
                             obj=e.ReadObj()
+                            if name.endswith('data_obs') and 'data' not in basename: continue
                             if (not re.match('Wplus|Wminus',os.path.basename(f))) and 'data_obs' in name: obj.Clone().Write()
                             for p in processes:
                                 if p in name:
@@ -270,8 +270,6 @@ if __name__ == "__main__":
         
         os.system('rm {tmpcard}'.format(tmpcard=tmpcard))
         
-        if options.scaleFile: options.absoluteRates = True
-        
         kpatt = " %7s "
         if options.longLnN:
             combinedCard.write('norm_long_'+options.bin+'       lnN    ' + ' '.join([kpatt % (options.longLnN if 'long' in x else '-') for x in realprocesses])+'\n')
@@ -313,7 +311,7 @@ if __name__ == "__main__":
             for iy,helbin in enumerate(hel):
                 pol = helbin.split('_')[1]
                 index_procs = procs.index(helbin)
-                if options.absoluteRates:
+                if options.scaleFile:
                     lns = ' - '.join('' for i in range(index_procs+1))
                     lns += ' {effunc:.4f} '.format(effunc=1.+efferrors[pol][iy])
                     lns += ' - '.join('' for i in range(len(procs) - index_procs))
@@ -323,112 +321,96 @@ if __name__ == "__main__":
                 sfx = str(iy)
                 pol = helbin.split('_')[1]
                 rateNuis = tightConstraint
-                normPOI = 'norm_{n}'.format(n=helbin)
+                normPOI = '{norm}_{n}'.format(norm='norm' if options.scaleFile else 'r', n=helbin)
 
                 ## if we fit absolute rates, we need to get them from the process and plug them in below
-                if options.absoluteRates:
-    
-                    ## if we want to fit with the efficiency gen-reco, we need to add one efficiency parameter
-                    if options.scaleFile:
-                        tmp_eff = efficiencies[pol][iy]
-                        combinedCard.write('eff_{n}    rateParam * {n} \t {eff:.5f} [{dn:.5f},{up:.5f}]\n'.format(n=helbin,eff=tmp_eff,dn=(1-1E-04)*tmp_eff,up=(1+1E-04)*tmp_eff))
-                        expRate0 = float(ProcsAndRatesDict[helbin])/tmp_eff
-                        param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
-                        # remove the channel to allow ele/mu combination when fitting for GEN
-                        helbin_nochan = helbin.replace('_{channel}_Ybin'.format(channel=channel),'_Ybin')
-                        combinedCard.write('norm_{nc}  rateParam * {n} \t {pr}\n'.format(nc=helbin_nochan,n=helbin,pr=param_range_0))
-                        # combinedCard.write('lumi_13TeV_rp rateParam * {n} \t TMath::Power({lumiLnN},@0) gaussian_param \n'.format(n=helbin,lumiLnN=1.+optionslumiLnN)) #  this is to add manually a "lumi" lnN constraint on each process scaled by a rateParam
-    
-                    ## if we do not want to fit the gen-level thing, we want to just put the absolute reco rates here
-                    else:
-                        expRate0 = float(ProcsAndRatesDict[helbin])
-                        param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
-                        combinedCard.write('norm_{n}  rateParam * {n} \t {pr}\n'.format(n=helbin,pr=param_range_0))
-    
-                else:
-                    ## if not fitting full rates, we do the relative rateParams close to 1.
-                    ## this is now done with a physics model 
-                    pass
+                ## if we want to fit with the efficiency gen-reco, we need to add one efficiency parameter
+                if options.scaleFile:
+                    tmp_eff = efficiencies[pol][iy]
+                    combinedCard.write('eff_{n}    rateParam * {n} \t {eff:.5f} [{dn:.5f},{up:.5f}]\n'.format(n=helbin,eff=tmp_eff,dn=(1-1E-04)*tmp_eff,up=(1+1E-04)*tmp_eff))
+                    expRate0 = float(ProcsAndRatesDict[helbin])/tmp_eff
+                    param_range_0 = '{r:15.1f} [{dn:.1f},{up:.1f}]'.format(r=expRate0,dn=(1-rateNuis)*expRate0,up=(1+rateNuis)*expRate0)
+                    # remove the channel to allow ele/mu combination when fitting for GEN
+                    helbin_nochan = helbin.replace('_{channel}_Ybin'.format(channel=channel),'_Ybin')
+                    combinedCard.write('norm_{nc}  rateParam * {n} \t {pr}\n'.format(nc=helbin_nochan,n=helbin,pr=param_range_0))
                 POIs.append(normPOI)
         combinedCard.close()
 
-        if options.absoluteRates:
-            ProcsAndRatesUnity = []
-            for (p,r) in ProcsAndRates:
-                ProcsAndRatesUnity.append((p,'1') if ('left' in p or 'right' in p or 'long' in p) else (p,r))
+        ### Now write the final datacard
+        combinedCardNew = open(cardfile+"_new",'w')
+        combinedCard = open(cardfile,'r')
+
+        ProcsAndRatesUnity = [] # used in case of scaling to GEN
+        for (p,r) in ProcsAndRates:
+            ProcsAndRatesUnity.append((p,'1') if ('left' in p or 'right' in p or 'long' in p) else (p,r))
+        Wlong = [(p,r) for (p,r) in ProcsAndRates if re.match('W.*long',p)]
+        WLeftOrRight = [(p,r) for (p,r) in ProcsAndRates if ('left' in p or 'right' in p)]
+
+        for l in combinedCard.readlines():
+            if re.match("rate\s+",l):
+                if options.scaleFile: combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRatesUnity])+'\n')
+                else: combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRates])+'\n')
+            else: combinedCardNew.write(l)
+        if options.scaleFile:
+            eff_long = 1./getScales([ybins['left'][0],ybins['left'][-1]], charge, 'long', options.scaleFile)[0] # just take the eff on the total Y acceptance (should be 0,6)
+            eff_left = 1./getScales([ybins[pol][0],ybins[pol][-1]], charge, 'left', options.scaleFile)[0]
+            eff_right = 1./getScales([ybins[pol][0],ybins[pol][-1]], charge, 'right', options.scaleFile)[0]
+            normWLong = sum([float(r) for (p,r) in Wlong])/eff_long # there should be only 1 Wlong/charge
+            normWLeft = sum([float(r) for (p,r) in WLeftOrRight if 'left' in p])/eff_left
+            normWRight = sum([float(r) for (p,r) in WLeftOrRight if 'right' in p])/eff_right
+            combinedCardNew.write("eff_{nc}   rateParam * {n}    {eff:.5f} [{dn:.5f},{up:.5f}]\n".format(nc=Wlong[0][0].replace('_long','_%s_long' % channel),n=Wlong[0][0],
+                                                                                                         eff=eff_long,dn=(1-1E-04)*eff_long,up=(1+1E-04)*eff_long))
+            ## write the long yield here
+            nl = normWLong; tc = tightConstraint
+            combinedCardNew.write("norm_{n} rateParam * {n} {r:15.1f} [{dn:.1f},{up:.1f}]\n".format(n=Wlong[0][0],r=nl,dn=(1-tc)*nl,up=(1+tc)*nl))
+            POIs.append('norm_{n}'.format(n=Wlong[0][0].replace('_long','_%s_long' % channel))) # at this stage, norm POIs have still the channel inside
+        else:
+            POIs.append('r_{n}'.format(n=Wlong[0][0].replace('_long','_%s_long' % channel)))
     
-            combinedCardNew = open(cardfile+"_new",'w')
-            combinedCard = open(cardfile,'r')
-            for l in combinedCard.readlines():
-                if re.match("rate\s+",l):
-                    combinedCardNew.write('rate            %s \n' % ' '.join([kpatt % r for (p,r) in ProcsAndRatesUnity])+'\n')
-                else: combinedCardNew.write(l)
-            Wlong = [(p,r) for (p,r) in ProcsAndRates if re.match('W.*long',p)]
-            WLeftOrRight = [(p,r) for (p,r) in ProcsAndRates if ('left' in p or 'right' in p)]
-            if options.scaleFile:
-                eff_long = 1./getScales([ybins['left'][0],ybins['left'][-1]], charge, 'long', options.scaleFile)[0] # just take the eff on the total Y acceptance (should be 0,6)
-                eff_left = 1./getScales([ybins[pol][0],ybins[pol][-1]], charge, 'left', options.scaleFile)[0]
-                eff_right = 1./getScales([ybins[pol][0],ybins[pol][-1]], charge, 'right', options.scaleFile)[0]
-                normWLong = sum([float(r) for (p,r) in Wlong])/eff_long # there should be only 1 Wlong/charge
-                normWLeft = sum([float(r) for (p,r) in WLeftOrRight if 'left' in p])/eff_left
-                normWRight = sum([float(r) for (p,r) in WLeftOrRight if 'right' in p])/eff_right
-                normWLeftOrRight = normWLeft + normWRight
-                combinedCardNew.write("eff_{nc}   rateParam * {n}    {eff:.5f} [{dn:.5f},{up:.5f}]\n".format(nc=Wlong[0][0].replace('_long','_%s_long' % channel),n=Wlong[0][0],
-                                                                                                             eff=eff_long,dn=(1-1E-04)*eff_long,up=(1+1E-04)*eff_long))
-                ## write the long yield here
-                nl = normWLong; tc = tightConstraint
-                combinedCardNew.write("norm_{n} rateParam * {n} {r:15.1f} [{dn:.1f},{up:.1f}]\n".format(n=Wlong[0][0],r=nl,dn=(1-tc)*nl,up=(1+tc)*nl))
-                POIs.append('norm_{n}'.format(n=Wlong[0][0].replace('_long','_%s_long' % channel))) # at this stage, norm POIs have still the channel inside
-    
-            ## if we do not scale gen-reco, then we go back to before...
-            else:
-                normWLong = sum([float(r) for (p,r) in Wlong]) # there should be only 1 Wlong/charge
-                normWLeftOrRight = sum([float(r) for (p,r) in WLeftOrRight])
-                combinedCardNew.write("norm_%-50s   rateParam * %-5s  %15.1f [%.0f,%.0f]\n" % (Wlong[0][0],Wlong[0][0],normWLong,(1-tightConstraint)*normWLong,(1+tightConstraint)*normWLong))
-    
-            ## make an efficiency nuisance group
+        if options.scaleFile: ## make an efficiency nuisance group
             combinedCardNew.write('\nefficiencies group = '+' '.join([p.replace('norm','eff') for p in POIs])+'\n\n' )
 
-            ## remove all the POIs that we want to fix
-            # remove the channel to allow ele/mu combination when fitting for GEN
-            POIs = [poi.replace('_{channel}_'.format(channel=channel),'_') for poi in  POIs]
-            for poi in POIs:
-                if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
-                    fixedPOIs.append(poi)
-                if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
-                    fixedPOIs.append(poi)
-            floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
-            allPOIs = fixedPOIs+floatPOIs
-            ## define the combine POIs, i.e. the subset on which to run MINOS
-            minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
+        ## remove all the POIs that we want to fix
+        # remove the channel to allow ele/mu combination when fitting for GEN
+        POIs = [poi.replace('_{channel}_'.format(channel=channel),'_') for poi in  POIs]
+        for poi in POIs:
+            if 'right' in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'R']):
+                fixedPOIs.append(poi)
+            if 'left'  in poi and any('Ybin_'+str(i) in poi for i in fixedYBins[charge+'L']):
+                fixedPOIs.append(poi)
+        floatPOIs = list(poi for poi in POIs if not poi in fixedPOIs)
+        allPOIs = fixedPOIs+floatPOIs
+        ## define the combine POIs, i.e. the subset on which to run MINOS
+        minosPOIs = allPOIs if not options.POIsToMinos else options.POIsToMinos.split(',')
 
-            ## make a group for the fixed rate parameters.
+        ## make a group for the fixed rate parameters. ## this is maybe obsolete, and restricted only to absolute rate fitting
+        if options.scaleFile:
             print 'adding a nuisance group for the fixed rateParams'
             if len(fixedPOIs): combinedCardNew.write('\nfixedY group = {fixed} '.format(fixed=' '.join(i.strip() for i in fixedPOIs)))
             combinedCardNew.write('\nallY group = {all} \n'.format(all=' '.join([i for i in allPOIs])))
-            combinedCardNew.close() ## for some reason this is really necessary
-            os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
+        combinedCardNew.close() ## for some reason this is really necessary
+        os.system("mv {cardfile}_new {cardfile}".format(cardfile=cardfile))
         
-            combinedCard = open(cardfile,'a+')
-            ## add the PDF systematics 
-            for sys,procs in theosyst.iteritems():
-                # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
-                combinedCard.write('%-15s   shape %s\n' % (sys,(" ".join(['1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
-            combinedCard.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
-            combinedCard.write('\nscales group = '+' '.join([sys for sys,procs in qcdsyst.iteritems()])+'\n')
-            combinedCard.write('\nalphaS group = '+' '.join([sys for sys,procs in alssyst.iteritems()])+'\n')
-            combinedCard.write('\nwpt group = '+' '.join([sys for sys,procs in wptsyst.iteritems()])+'\n')
+        combinedCard = open(cardfile,'a+')
+        ## add the PDF systematics 
+        for sys,procs in theosyst.iteritems():
+            # there should be 2 occurrences of the same proc in procs (Up/Down). This check should be useless if all the syst jobs are DONE
+            combinedCard.write('%-15s   shape %s\n' % (sys,(" ".join(['1.0' if p in procs and procs.count(p)==2 else '  -  ' for p,r in ProcsAndRates]))) )
+        combinedCard.write('\npdfs group = '+' '.join([sys for sys,procs in pdfsyst.iteritems()])+'\n')
+        combinedCard.write('\nscales group = '+' '.join([sys for sys,procs in qcdsyst.iteritems()])+'\n')
+        combinedCard.write('\nalphaS group = '+' '.join([sys for sys,procs in alssyst.iteritems()])+'\n')
+        combinedCard.write('\nwpt group = '+' '.join([sys for sys,procs in wptsyst.iteritems()])+'\n')
 
-            ## now assign a uniform luminosity uncertainty to all the MC processes
-            combinedCard.write('\nCMS_lumi_13TeV   lnN %s\n' % (" ".join(['-' if 'data' in p else '%.3f'%(1+options.lumiLnN) for p,r in ProcsAndRates])) )
-            ## not needed as  far as we float all the Y bins
-            # combinedCard.write('CMS_W   lnN %s\n' % (" ".join(['%.3f' % (1+options.wLnN) if (p=='TauDecaysW' or re.match('W{charge}'.format(charge=charge),p)) else '-' for p,r in ProcsAndRates])) )
-            combinedCard.close() 
+        ## now assign a uniform luminosity uncertainty to all the MC processes
+        combinedCard.write('\nCMS_lumi_13TeV   lnN %s\n' % (" ".join(['-' if 'data' in p else '%.3f'%(1+options.lumiLnN) for p,r in ProcsAndRates])) )
+        ## not needed as  far as we float all the Y bins
+        # combinedCard.write('CMS_W   lnN %s\n' % (" ".join(['%.3f' % (1+options.wLnN) if (p=='TauDecaysW' or re.match('W{charge}'.format(charge=charge),p)) else '-' for p,r in ProcsAndRates])) )
+        combinedCard.close() 
 
         print "merged datacard in ",cardfile
         
         ws = cardfile.replace('_card.txt', '_ws.root')
-        if options.absoluteRates:
+        if options.scaleFile:
             txt2wsCmd = 'text2workspace.py {cf} -o {ws} --X-allow-no-signal --X-no-check-norm '.format(cf=cardfile, ws=ws)
             combineCmd = 'combine {ws} -M MultiDimFit    -t -1 --expectSignal=1 -m 999 --saveFitResult --cminInitialHesse 1 --cminFinalHesse 1 --cminPreFit 1       --redefineSignalPOIs {pois}            --floatOtherPOIs=0 --freezeNuisanceGroups efficiencies,fixedY{pdfs}{scales}{alphas} -v 9'.format(ws=ws, pois=','.join(minosPOIs), pdfs=(',pdfs' if len(pdfsyst) else ''), scales=(',scales' if len(qcdsyst) else ''),alphas=(',alphaS' if len(alssyst) else ''))
         else: 


### PR DESCRIPTION
When not passing the scale file, the fit is by mu, w/o rescaling by the GEN=>RECO eff. 
The new POIs in the workspace are called r_<W...> instead of norm_<W...> and are inside a range [0,10].

Commands examples:
- Fit by mu:
`./mergeCardComponentsAbsY.py [-m] -b Wel -C plus -i cards_el`
@bendavid this is the trivial step discussed today
- Fit (as so far) rescaling by the efficiency:
`./mergeCardComponentsAbsY.py [-m] -b Wel -C plus -i cards_el --sf efficiency.root`
(just to have what we used so far still working)

also, fixing the fact that the signal was added to data_obs.
