### PR TITLE
W charge asymmetry plot and new naming of parameters

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -193,14 +193,14 @@ if __name__ == "__main__":
         allValues = {}
         for pol in ['left','right', 'long']:
             cp = '{ch}_{pol}'.format(ch=charge,pol=pol)
-            MAXYFORNORM = ybins[cp][-2] # exclude the outermost bin which has huge error due to acceptance
+            MAXYFORNORM = ybins[cp][-3] # exclude the outermost 2 bins which has huge error due to acceptance
             normsigma = sum([xsec_nominal[pol][iy] for iy,y in enumerate(ybins[cp][:-1]) if abs(y)<MAXYFORNORM])
             print "total xsec up to |Y|<{maxy} = {sigma:.3f} (pb)".format(maxy=MAXYFORNORM,sigma=normsigma)
 
             tmp_val = valueClass('values_'+charge+'_'+pol)
 
             for iy,y in enumerate(ybinwidths['{ch}_{pol}'.format(ch=charge,pol=pol)]):
-                parname = 'W{charge}_{pol}_W{charge}_{pol}_{ch}_Ybin_{iy}'.format(charge=charge,pol=pol,ch=channel,iy=iy)
+                parname = 'W{charge}_{pol}_W{charge}_{pol}_{ch}_Ybin_{iy}_mu'.format(charge=charge,pol=pol,ch=channel,iy=iy)
 
                 tmp_val.val.append(xsec_nominal[pol][iy]/ybinwidths[cp][iy])
                 tmp_val.ehi.append(xsec_systematics[pol][iy]/ybinwidths[cp][iy])
@@ -232,7 +232,7 @@ if __name__ == "__main__":
                 if options.normxsec:
                     rfit = tuple([xs/xsec_nominal[pol][iy]*normsigma for xs in xsec_fit]) # rescale the fit xsec by the expected xsec in that bin
                 else:
-                    rfit = valuesAndErrors[parname] # r values: contain all the common norm uncertainties (lumi, eff...)
+                    rfit = valuesAndErrors[parname+'_mu'] # r values: contain all the common norm uncertainties (lumi, eff...)
 
                 tmp_val.relv_fit .append(rfit[0])
                 tmp_val.rello_fit.append(abs(rfit[0]-rfit[1]))
@@ -311,7 +311,7 @@ if __name__ == "__main__":
         padUp.SetLeftMargin(0.15)
         padUp.SetBottomMargin(0.10)
 
-        yaxtitle = '#frac{d#sigma/dy/#sigma_{tot}}{d#sigma^{exp}/dy/#sigma^{exp}_{tot}}' if options.normxsec else '#frac{dN/dy}{dN^{exp}/dy}'
+        yaxtitle = '#frac{d#sigma/dy/#sigma_{tot}}{d#sigma^{exp}/dy/#sigma^{exp}_{tot}}' if options.normxsec else '#frac{d#sigma/dy}{d#sigma^{exp}/dy}'
 
         allValues['left'].mg.Draw('Pa')
         allValues['left'].mg.GetXaxis().SetRangeUser(0., 3.)
@@ -352,7 +352,7 @@ if __name__ == "__main__":
         padDown.SetBottomMargin(0.15)
         allValues['long'].mg.Draw('pa')
         allValues['long'].mg.GetXaxis().SetRangeUser(0., 3.)
-        allValues['long'].mg.GetYaxis().SetRangeUser(0.85, 1.15)
+        allValues['long'].mg.GetYaxis().SetRangeUser(0.50, 1.50)
         allValues['long'].mg.GetXaxis().SetTitle('|Y_{W}|')
         allValues['long'].mg.GetXaxis().SetTitleSize(0.06)
         allValues['long'].mg.GetXaxis().SetLabelSize(0.06)

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -21,6 +21,8 @@ class valueClass:
 
         self.charge = 'plus' if 'plus' in name else 'minus'
         self.ch     = '+' if 'plus' in name else '-'
+        if 'asymmetry' in name:
+            self.charge = self.ch = ''
 
         self.color  = ROOT.kAzure+8 if self.isleft else ROOT.kOrange+7 if self.isright else ROOT.kGray+1
         self.colorf = ROOT.kAzure+3 if self.isleft else ROOT.kOrange+9 if self.isright else ROOT.kGray+3
@@ -33,18 +35,21 @@ class valueClass:
         self.rap       = array.array('f', []); self.rlo       = array.array('f', []); self.rhi       = array.array('f', []);
 
     def makeGraphs(self):
-        self.graph = ROOT.TGraphAsymmErrors(len(self.val), self.rap, self.val, self.rlo, self.rhi, self.elo, self.ehi)
-        self.graph.SetName('graph'+self.pol)
-        self.graph_rel= ROOT.TGraphAsymmErrors(len(self.relv), self.rap, self.relv, self.rlo, self.rhi, self.rello, self.relhi)
-        self.graph_rel.SetName('graph'+self.pol+'_rel')
-
-        self.graph_fit = ROOT.TGraphAsymmErrors(len(self.val_fit), self.rap, self.val_fit, self.rlo, self.rhi, self.elo_fit, self.ehi_fit)
-        self.graph_fit.SetName('graph'+self.pol+'_fit')
-        self.graph_fit_rel = ROOT.TGraphAsymmErrors(len(self.relv_fit), self.rap, self.relv_fit, self.rlo, self.rhi, self.rello_fit, self.relhi_fit)
-        self.graph_fit_rel.SetName('graph'+self.pol+'_fit_rel')
-    
+        if len(self.val):
+            self.graph = ROOT.TGraphAsymmErrors(len(self.val), self.rap, self.val, self.rlo, self.rhi, self.elo, self.ehi)
+            self.graph.SetName('graph'+self.pol)
+        if len(self.relv): 
+            self.graph_rel= ROOT.TGraphAsymmErrors(len(self.relv), self.rap, self.relv, self.rlo, self.rhi, self.rello, self.relhi)
+            self.graph_rel.SetName('graph'+self.pol+'_rel')
+        if len(self.val_fit):
+            self.graph_fit = ROOT.TGraphAsymmErrors(len(self.val_fit), self.rap, self.val_fit, self.rlo, self.rhi, self.elo_fit, self.ehi_fit)
+            self.graph_fit.SetName('graph'+self.pol+'_fit')
+        if len(self.relv_fit):
+            self.graph_fit_rel = ROOT.TGraphAsymmErrors(len(self.relv_fit), self.rap, self.relv_fit, self.rlo, self.rhi, self.rello_fit, self.relhi_fit)
+            self.graph_fit_rel.SetName('graph'+self.pol+'_fit_rel')
+        
         self.graphStyle()
-        self.makeMultiGraphRel()
+        if len(self.relv) and len(self.relv_fit): self.makeMultiGraphRel()
 
     def makeMultiGraphRel(self):
         self.mg = ROOT.TMultiGraph()
@@ -53,23 +58,160 @@ class valueClass:
         self.mg.Add(self.graph_fit_rel)
 
     def graphStyle(self):
-        if not self.graph:
-            print 'ERROR: this struct has no graphs!!!'
-            sys.exit()
-        self.graph.SetLineColor(self.color)
-        self.graph.SetFillColor(self.color)
-        self.graph.SetFillStyle(3002)
-    
-        self.graph_fit.SetLineWidth(2)
-        self.graph_fit.SetLineColor(self.colorf)
-    
-        self.graph_rel.SetLineWidth(5)
-        self.graph_rel.SetLineColor(self.color)
-        self.graph_rel.SetFillColor(self.color)
-        self.graph_rel.SetFillStyle(3002)
-        self.graph_fit_rel.SetLineWidth(2)
-        self.graph_fit_rel.SetLineColor(self.colorf)
-        
+        if hasattr(self,'graph'):
+            self.graph.SetLineColor(self.color)
+            self.graph.SetFillColor(self.color)
+            self.graph.SetFillStyle(3002)
+        if hasattr(self,'graph_fit'):
+            self.graph_fit.SetLineWidth(2)
+            self.graph_fit.SetLineColor(self.colorf)
+        if hasattr(self,'graph_rel'):
+            self.graph_rel.SetLineWidth(5)
+            self.graph_rel.SetLineColor(self.color)
+            self.graph_rel.SetFillColor(self.color)
+            self.graph_rel.SetFillStyle(3002)
+        if hasattr(self,'graph_fit_rel'):
+            self.graph_fit_rel.SetLineWidth(2)
+            self.graph_fit_rel.SetLineColor(self.colorf)
+
+def plotValues(values,charge,options):
+        c2 = ROOT.TCanvas('foo','', 800, 800)
+        c2.GetPad(0).SetTopMargin(0.05)
+        c2.GetPad(0).SetBottomMargin(0.15)
+        c2.GetPad(0).SetLeftMargin(0.16)
+
+        ch = '+' if charge == 'plus' else '-'
+        if charge == 'asymmetry': ch = ''
+        date = datetime.date.today().isoformat()
+        normstr = 'norm' if (options.normxsec and charge!='asymmetry') else ''
+
+        ## the four graphs exist now. now starting to draw them
+        ## ===========================================================
+        if sum(hasattr(values[pol],'graph') and hasattr(values[pol],'graph_fit') for pol in ['left','right','long'])==3:
+            leg = ROOT.TLegend(0.60, 0.60, 0.85, 0.90)
+            leg.SetFillStyle(0)
+            leg.SetBorderSize(0)
+            leg.AddEntry(values['left'] .graph     , 'W^{{{ch}}} left (PDF systs)' .format(ch=ch) , 'f')
+            leg.AddEntry(values['left'] .graph_fit , 'W^{{{ch}}} left (fit)' .format(ch=ch)       , 'pl')
+            leg.AddEntry(values['right'].graph     , 'W^{{{ch}}} right (PDF systs)'.format(ch=ch) , 'f')
+            leg.AddEntry(values['right'].graph_fit , 'W^{{{ch}}} right (fit)'.format(ch=ch)       , 'pl')
+            leg.AddEntry(values['long'] .graph     , 'W^{{{ch}}} long (PDF systs)'.format(ch=ch) , 'f')
+            leg.AddEntry(values['long'] .graph_fit , 'W^{{{ch}}} long (fit)'.format(ch=ch)       , 'pl')
+     
+            values['left'].graph.SetTitle('W {ch}: Y_{{W}}'.format(ch=ch))
+                
+            mg = ROOT.TMultiGraph()
+            mg.Add(values['left'] .graph,'P2')
+            mg.Add(values['right'].graph,'P2')
+            mg.Add(values['long'] .graph,'P2')
+            mg.Add(values['left'] .graph_fit)
+            mg.Add(values['right'].graph_fit)
+            mg.Add(values['long'] .graph_fit)
+     
+            mg.Draw('Pa')
+            mg.GetXaxis().SetRangeUser(0.,6.)
+            mg.GetXaxis().SetTitle('|Y_{W}|')
+            if options.normxsec: 
+                mg.GetYaxis().SetTitle('d#sigma/dy/#sigma_{tot}')
+            else: 
+                mg.GetYaxis().SetTitle('d#sigma/dy (pb)')
+            mg.GetXaxis().SetTitleSize(0.06)
+            mg.GetXaxis().SetLabelSize(0.04)
+            mg.GetYaxis().SetTitleSize(0.06)
+            mg.GetYaxis().SetLabelSize(0.04)
+            mg.GetYaxis().SetTitleOffset(1.2)
+     
+            leg.Draw('same')
+     
+            for ext in ['png', 'pdf']:
+                c2.SaveAs('{od}/genAbsY{norm}_pdfs_{date}_{ch}{suffix}_{t}.{ext}'.format(od=options.outdir, norm=normstr, date=date, ch=charge, suffix=options.suffix, ext=ext,t=options.type))
+
+        ## now make the relative error plot:
+        ## ======================================
+        if sum(hasattr(values[pol],'mg') for pol in ['left','right','long'])==3:
+            c2.Clear()
+            c2.Divide(1,3)
+     
+            line = ROOT.TF1("horiz_line","0" if charge=='asymmetry' else '1',0.0,3.0);
+            line.SetLineColor(ROOT.kBlack);
+            line.SetLineWidth(2);
+     
+            padUp = c2.cd(1)
+            padUp.SetTickx(1)
+            padUp.SetTicky(1)
+            padUp.SetGridy(1)
+            padUp.SetLeftMargin(0.15)
+            padUp.SetBottomMargin(0.10)
+     
+            yaxrange = {}
+            if charge=='asymmetry':
+                yaxtitle = 'W charge asymmetry'
+                yaxrange['left'] = (0, 0.4); yaxrange['right'] = (-0.4, 0.4); yaxrange['long'] = (-1, 1)
+            else:
+                yaxtitle = '#frac{d#sigma/dy/#sigma_{tot}}{d#sigma^{exp}/dy/#sigma^{exp}_{tot}}' if options.normxsec else '#frac{d#sigma/dy}{d#sigma^{exp}/dy}'
+                yaxrange['left'] = (0.85, 1.15); yaxrange['right'] = (0.85, 1.15); yaxrange['long'] = (0.5, 1.5)
+     
+            values['left'].mg.Draw('Pa')
+            values['left'].mg.GetXaxis().SetRangeUser(0., 3.)
+            values['left'].mg.GetYaxis().SetRangeUser(yaxrange['left'][0],yaxrange['left'][1])
+            values['left'].mg.GetXaxis().SetTitleSize(0.06)
+            values['left'].mg.GetXaxis().SetLabelSize(0.06)
+            values['left'].mg.GetYaxis().SetTitleSize(0.06)
+            values['left'].mg.GetYaxis().SetLabelSize(0.06)
+            values['left'].mg.GetYaxis().SetTitle(yaxtitle)
+
+            leg = ROOT.TLegend(0.20, 0.60, 0.45, 0.90)
+            leg.SetFillStyle(0)
+            leg.SetBorderSize(0)
+            leg.AddEntry(values['left'] .graph_rel     , 'W^{{{ch}}} left (PDF systs)' .format(ch=ch) , 'f')
+            leg.AddEntry(values['left'] .graph_fit_rel , 'W^{{{ch}}} left (fit)' .format(ch=ch)       , 'pl')
+            leg.AddEntry(values['right'].graph_rel     , 'W^{{{ch}}} right (PDF systs)'.format(ch=ch) , 'f')
+            leg.AddEntry(values['right'].graph_fit_rel , 'W^{{{ch}}} right (fit)'.format(ch=ch)       , 'pl')
+            leg.AddEntry(values['long'] .graph_rel     , 'W^{{{ch}}} long (PDF systs)'.format(ch=ch) , 'f')
+            leg.AddEntry(values['long'] .graph_fit_rel , 'W^{{{ch}}} long (fit)'.format(ch=ch)       , 'pl')
+     
+            leg.Draw('same')
+            line.Draw("Lsame");
+            padUp.RedrawAxis("sameaxis");
+     
+            padMiddle = c2.cd(2)
+            padMiddle.SetTickx(1)
+            padMiddle.SetTicky(1)
+            padMiddle.SetGridy(1)
+            padMiddle.SetLeftMargin(0.15)
+            padMiddle.SetBottomMargin(0.15)
+            values['right'].mg.Draw('pa')
+            values['right'].mg.GetXaxis().SetRangeUser(0., 3.)
+            values['right'].mg.GetYaxis().SetRangeUser(yaxrange['right'][0],yaxrange['right'][1])
+            values['right'].mg.GetXaxis().SetTitle('|Y_{W}|')
+            values['right'].mg.GetXaxis().SetTitleSize(0.06)
+            values['right'].mg.GetXaxis().SetLabelSize(0.06)
+            values['right'].mg.GetYaxis().SetTitleSize(0.06)
+            values['right'].mg.GetYaxis().SetLabelSize(0.06)
+            values['right'].mg.GetYaxis().SetTitle(yaxtitle)
+            line.Draw("Lsame");
+            padMiddle.RedrawAxis("sameaxis");
+     
+            padDown = c2.cd(3)
+            padDown.SetTickx(1)
+            padDown.SetTicky(1)
+            padDown.SetGridy(1)
+            padDown.SetLeftMargin(0.15)
+            padDown.SetBottomMargin(0.15)
+            values['long'].mg.Draw('pa')
+            values['long'].mg.GetXaxis().SetRangeUser(0., 3.)
+            values['long'].mg.GetYaxis().SetRangeUser(yaxrange['long'][0],yaxrange['long'][1])
+            values['long'].mg.GetXaxis().SetTitle('|Y_{W}|')
+            values['long'].mg.GetXaxis().SetTitleSize(0.06)
+            values['long'].mg.GetXaxis().SetLabelSize(0.06)
+            values['long'].mg.GetYaxis().SetTitleSize(0.06)
+            values['long'].mg.GetYaxis().SetLabelSize(0.06)
+            values['long'].mg.GetYaxis().SetTitle(yaxtitle)
+            line.Draw("Lsame");
+            padDown.RedrawAxis("sameaxis");
+     
+            for ext in ['png', 'pdf']:
+                c2.SaveAs('{od}/genAbsY{norm}_pdfs_{date}_{ch}{suffix}_relative_{t}.{ext}'.format(od=options.outdir, norm=normstr, date=date, ch=charge, suffix=options.suffix, ext=ext,t=options.type))
 
 NPDFs = 60
 
@@ -84,7 +226,7 @@ if __name__ == "__main__":
     parser.add_option(      '--toyfile'     , dest='toyfile'  , default=''            , type='string', help='file that has the toys')
     parser.add_option(      '--scandir'     , dest='scandir'  , default=''            , type='string', help='directory with all the scans')
     parser.add_option(      '--hessfile'    , dest='hessfile' , default=''            , type='string', help='file that contains the hessian errors in a dictionary')
-    parser.add_option(      '--xsecfile'    , dest='xsecfile' , default=None          , type='string', help='file that contains the expected x sections with variations')
+    parser.add_option(      '--xsecfiles'    , dest='xsecfiles' , default=None          , type='string', help='files that contains the expected x sections with variations (one per charge,comma separated in the same order of the charges) ')
     parser.add_option('-C', '--charge'      , dest='charge'   , default='plus,minus'  , type='string', help='process given charge. default is both')
     parser.add_option('-o', '--outdir'      , dest='outdir'   , default='.'           , type='string', help='outdput directory to save the plots')
     parser.add_option(      '--suffix'      , dest='suffix'   , default=''            , type='string', help='suffix for the correlation matrix')
@@ -136,14 +278,17 @@ if __name__ == "__main__":
 
 
     charges = options.charge.split(',')
-    for charge in charges:
+    xsecfiles = options.xsecfiles.split(',')
+    xsec_nominal_allCharges = {}; xsec_systematics_allCharges = {}
+    for ic,charge in enumerate(charges):
 
         ##file_pdfs = os.environ['CMSSW_BASE']+'/src/CMGTools/WMass/data/pdfs_prefit/pdf_variations_prefit.root'
         base = "/afs/cern.ch/work/e/emanuele/wmass/heppy/CMSSW_8_0_25/"
         file_pdfs = base+'/src/CMGTools/WMass/data/pdfs_prefit/pdf_variations_prefit.root'
         ## this gets the pdf central variation binned in the correct format
         nominal = utilities.getRebinned(ybins,charge,file_pdfs, 0)
-        xsec_nominal = utilities.getXSecFromShapes(ybins,charge,options.xsecfile,channel, 0)
+        xsec_nominal = utilities.getXSecFromShapes(ybins,charge,xsecfiles[ic],channel, 0)
+        xsec_nominal_allCharges[charge] = xsec_nominal
 
         shape_syst = {}
         value_syst = {}
@@ -154,7 +299,7 @@ if __name__ == "__main__":
                 # print "Loading polarization %s, histograms for pdf %d" % (pol,ip)
                 ## this gets the pdf variations after correctly rebinning the YW
                 pdf = utilities.getRebinned(ybins,charge,file_pdfs,ip)
-                xsec_pdf = utilities.getXSecFromShapes(ybins,charge,options.xsecfile,channel,ip)
+                xsec_pdf = utilities.getXSecFromShapes(ybins,charge,xsecfiles[ic],channel,ip)
                 histos.append(pdf[pol])
                 values.append(xsec_pdf[pol])
             shape_syst[pol] = histos
@@ -189,6 +334,7 @@ if __name__ == "__main__":
                 xsec_systs.append(xsec_totUp)
             systematics[pol]=systs
             xsec_systematics[pol]=xsec_systs
+        xsec_systematics_allCharges[charge] = xsec_systematics
 
         allValues = {}
         for pol in ['left','right', 'long']:
@@ -242,125 +388,41 @@ if __name__ == "__main__":
                 tmp_val.rlo.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
                 tmp_val.rhi.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
 
-                tmp_val.makeGraphs()
+            tmp_val.makeGraphs()
 
-                allValues[pol] = tmp_val
+            allValues[pol] = tmp_val
 
+        plotValues(allValues,charge,options)
 
-        c2 = ROOT.TCanvas('foo','', 800, 800)
-        c2.GetPad(0).SetTopMargin(0.05)
-        c2.GetPad(0).SetBottomMargin(0.15)
-        c2.GetPad(0).SetLeftMargin(0.16)
+    if len(charges)>1:
+        print "Making charge asymmetry plots now..."
+        asymmetryValues = {}
+        
+        for pol in ['left','right', 'long']:
+            cp = 'plus_'+pol
+            tmp_val = valueClass('asymmetry_'+pol)
+            for iy,y in enumerate(ybinwidths[cp]):
+                
+                ch_sum  = xsec_nominal_allCharges['plus'][pol][iy] + xsec_nominal_allCharges['minus'][pol][iy]
+                ch_diff = xsec_nominal_allCharges['plus'][pol][iy] - xsec_nominal_allCharges['minus'][pol][iy]
+                asy_val = ch_diff / ch_sum
+                # the following is not completely correct, since it doesn't account correlations in exp. uncertainties
+                err_sum = math.hypot(xsec_systematics_allCharges['plus'][pol][iy],xsec_systematics_allCharges['minus'][pol][iy])
+                asy_err = asy_val * math.hypot(err_sum/ch_sum,err_sum/ch_diff)
+                tmp_val.relv .append(asy_val)
+                tmp_val.relhi.append(asy_err)
+                tmp_val.rello.append(asy_err)
 
-        ## the four graphs exist now. now starting to draw them
-        ## ===========================================================
-        leg = ROOT.TLegend(0.60, 0.60, 0.85, 0.90)
-        leg.SetFillStyle(0)
-        leg.SetBorderSize(0)
-        leg.AddEntry(allValues['left'] .graph     , 'W^{{{ch}}} left (PDF systs)' .format(ch='+' if charge == 'plus' else '-') , 'f')
-        leg.AddEntry(allValues['left'] .graph_fit , 'W^{{{ch}}} left (fit)' .format(ch='+' if charge == 'plus' else '-')       , 'pl')
-        leg.AddEntry(allValues['right'].graph     , 'W^{{{ch}}} right (PDF systs)'.format(ch='+' if charge == 'plus' else '-') , 'f')
-        leg.AddEntry(allValues['right'].graph_fit , 'W^{{{ch}}} right (fit)'.format(ch='+' if charge == 'plus' else '-')       , 'pl')
-        leg.AddEntry(allValues['long'] .graph     , 'W^{{{ch}}} long (PDF systs)'.format(ch='+' if charge == 'plus' else '-') , 'f')
-        leg.AddEntry(allValues['long'] .graph_fit , 'W^{{{ch}}} long (fit)'.format(ch='+' if charge == 'plus' else '-')       , 'pl')
+                asy_fit = utilities.getAsymmetryFromToys(pol,channel,iy,options.infile)
+                tmp_val.relv_fit .append(asy_fit[0])
+                tmp_val.rello_fit.append(abs(asy_fit[0]-asy_fit[1]))
+                tmp_val.relhi_fit.append(abs(asy_fit[0]-asy_fit[2]))
 
-        allValues['left'].graph.SetTitle('W {ch}: Y_{{W}}'.format(ch=charge))
-            
-        mg = ROOT.TMultiGraph()
-        mg.Add(allValues['left'] .graph,'P2')
-        mg.Add(allValues['right'].graph,'P2')
-        mg.Add(allValues['long'] .graph,'P2')
-        mg.Add(allValues['left'] .graph_fit)
-        mg.Add(allValues['right'].graph_fit)
-        mg.Add(allValues['long'] .graph_fit)
- 
-        mg.Draw('Pa')
-        mg.GetXaxis().SetRangeUser(0.,6.)
-        mg.GetXaxis().SetTitle('|Y_{W}|')
-        if options.normxsec: 
-            mg.GetYaxis().SetTitle('d#sigma/dy/#sigma_{tot}')
-        else: 
-            mg.GetYaxis().SetTitle('d#sigma/dy (pb)')
-        mg.GetXaxis().SetTitleSize(0.06)
-        mg.GetXaxis().SetLabelSize(0.04)
-        mg.GetYaxis().SetTitleSize(0.06)
-        mg.GetYaxis().SetLabelSize(0.04)
-        mg.GetYaxis().SetTitleOffset(1.2)
- 
-        leg.Draw('same')
+                tmp_val.rap.append((ybins[cp][iy]+ybins[cp][iy+1])/2.)
+                tmp_val.rlo.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+                tmp_val.rhi.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
 
-        date = datetime.date.today().isoformat()
-        normstr = 'norm' if options.normxsec else ''
-        for ext in ['png', 'pdf']:
-            c2.SaveAs('{od}/genAbsY{norm}_pdfs_{date}_{ch}{suffix}_{t}.{ext}'.format(od=options.outdir, norm=normstr, date=date, ch=charge, suffix=options.suffix, ext=ext,t=options.type))
-
-        ## now make the relative error plot:
-        ## ======================================
-
-        c2.Clear()
-        c2.Divide(1,3)
-
-        line = ROOT.TF1("horiz_line","1",0.0,3.0);
-        line.SetLineColor(ROOT.kBlack);
-        line.SetLineWidth(2);
-
-        padUp = c2.cd(1)
-        padUp.SetTickx(1)
-        padUp.SetTicky(1)
-        padUp.SetGridy(1)
-        padUp.SetLeftMargin(0.15)
-        padUp.SetBottomMargin(0.10)
-
-        yaxtitle = '#frac{d#sigma/dy/#sigma_{tot}}{d#sigma^{exp}/dy/#sigma^{exp}_{tot}}' if options.normxsec else '#frac{d#sigma/dy}{d#sigma^{exp}/dy}'
-
-        allValues['left'].mg.Draw('Pa')
-        allValues['left'].mg.GetXaxis().SetRangeUser(0., 3.)
-        allValues['left'].mg.GetYaxis().SetRangeUser(0.85, 1.15)
-        allValues['left'].mg.GetXaxis().SetTitleSize(0.06)
-        allValues['left'].mg.GetXaxis().SetLabelSize(0.06)
-        allValues['left'].mg.GetYaxis().SetTitleSize(0.06)
-        allValues['left'].mg.GetYaxis().SetLabelSize(0.06)
-        allValues['left'].mg.GetYaxis().SetTitle(yaxtitle)
-
-        leg.Draw('same')
-        line.Draw("Lsame");
-        padUp.RedrawAxis("sameaxis");
-
-        padMiddle = c2.cd(2)
-        padMiddle.SetTickx(1)
-        padMiddle.SetTicky(1)
-        padMiddle.SetGridy(1)
-        padMiddle.SetLeftMargin(0.15)
-        padMiddle.SetBottomMargin(0.15)
-        allValues['right'].mg.Draw('pa')
-        allValues['right'].mg.GetXaxis().SetRangeUser(0., 3.)
-        allValues['right'].mg.GetYaxis().SetRangeUser(0.85, 1.15)
-        allValues['right'].mg.GetXaxis().SetTitle('|Y_{W}|')
-        allValues['right'].mg.GetXaxis().SetTitleSize(0.06)
-        allValues['right'].mg.GetXaxis().SetLabelSize(0.06)
-        allValues['right'].mg.GetYaxis().SetTitleSize(0.06)
-        allValues['right'].mg.GetYaxis().SetLabelSize(0.06)
-        allValues['right'].mg.GetYaxis().SetTitle(yaxtitle)
-        line.Draw("Lsame");
-        padMiddle.RedrawAxis("sameaxis");
-
-        padDown = c2.cd(3)
-        padDown.SetTickx(1)
-        padDown.SetTicky(1)
-        padDown.SetGridy(1)
-        padDown.SetLeftMargin(0.15)
-        padDown.SetBottomMargin(0.15)
-        allValues['long'].mg.Draw('pa')
-        allValues['long'].mg.GetXaxis().SetRangeUser(0., 3.)
-        allValues['long'].mg.GetYaxis().SetRangeUser(0.50, 1.50)
-        allValues['long'].mg.GetXaxis().SetTitle('|Y_{W}|')
-        allValues['long'].mg.GetXaxis().SetTitleSize(0.06)
-        allValues['long'].mg.GetXaxis().SetLabelSize(0.06)
-        allValues['long'].mg.GetYaxis().SetTitleSize(0.06)
-        allValues['long'].mg.GetYaxis().SetLabelSize(0.06)
-        allValues['long'].mg.GetYaxis().SetTitle(yaxtitle)
-        line.Draw("Lsame");
-        padDown.RedrawAxis("sameaxis");
-
-        for ext in ['png', 'pdf']:
-            c2.SaveAs('{od}/genAbsY{norm}_pdfs_{date}_{ch}{suffix}_relative_{t}.{ext}'.format(od=options.outdir, norm=normstr, date=date, ch=charge, suffix=options.suffix, ext=ext,t=options.type))
+            tmp_val.makeGraphs()
+            asymmetryValues[pol] = tmp_val
+        
+        plotValues(asymmetryValues,'asymmetry',options)

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -1,5 +1,8 @@
 #!/bin/env python
-# USAGE: python plotYW.py --type toys --infile toys_wplus.root -y cards_el/binningYW.txt -C plus -o plots --xsecfile Wel_plus_shapes_xsec.root [--normxsec]
+# USAGE: python plotYW.py --type toys --infile toys_wplus.root -y cards_el/binningYW.txt -C plus -o plots --xsecfiles Wel_plus_shapes_xsec.root [--normxsec]
+#
+# When run on the W+ W- combined fit it also makes charge asymmetry plot:
+# python plotYW.py --type toys --infile toys_wboth.root -y cards_el/binningYW.txt -C plus,minus -o plots --xsecfiles Wel_plus_shapes_xsec.root,Wel_minus_shapes_xsec.root
 
 import ROOT, datetime, array, os, math, re
 ROOT.gROOT.SetBatch(True)

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -204,6 +204,11 @@ class util:
         ret = self.getExprFromToys(charge+pol+channel+str(iy),'{num}/{den}'.format(num=num,den=den),infile)
         return ret
 
+    def getAsymmetryFromToys(self, pol, channel, iy, infile):
+        expr = '(Wplus_{pol}_Wplus_{pol}_{ch}_Ybin_{iy}_mu_pmaskedexp - Wminus_{pol}_Wminus_{pol}_{ch}_Ybin_{iy}_mu_pmaskedexp)/(Wplus_{pol}_Wplus_{pol}_{ch}_Ybin_{iy}_mu_pmaskedexp + Wminus_{pol}_Wminus_{pol}_{ch}_Ybin_{iy}_mu_pmaskedexp)'.format(pol=pol,ch=channel,iy=iy)
+        ret = self.getExprFromToys('chargeAsym',expr,infile)
+        return ret
+
     def getFromScans(self, indir):
         _dict = {}
         

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -198,8 +198,8 @@ class util:
         ybins_expr = []
         for iv, val in enumerate(ybins[cp][:-1]):
             if abs(val)<absYmax:
-                ybins_expr.append('W{charge}_{pol}_W{charge}_{pol}_{ch}_Ybin_{iy}_pmaskedexp'.format(charge=charge,pol=pol,ch=channel,iy=iv))
-        num = 'W{charge}_{pol}_W{charge}_{pol}_{ch}_Ybin_{iy}_pmaskedexp'.format(charge=charge,pol=pol,ch=channel,iy=iy)
+                ybins_expr.append('W{charge}_{pol}_W{charge}_{pol}_{ch}_Ybin_{iy}_mu_pmaskedexp'.format(charge=charge,pol=pol,ch=channel,iy=iv))
+        num = 'W{charge}_{pol}_W{charge}_{pol}_{ch}_Ybin_{iy}_mu_pmaskedexp'.format(charge=charge,pol=pol,ch=channel,iy=iy)
         den = '('+'+'.join(ybins_expr)+')'        
         ret = self.getExprFromToys(charge+pol+channel+str(iy),'{num}/{den}'.format(num=num,den=den),infile)
         return ret


### PR DESCRIPTION
When running on the combined fit, make also the charge asymmetry plot from toys. To run it, pass the list of charges, and the list of the two x-sec files in the same order:

 python plotYW.py --type toys --infile toys_wboth.root -y cards_el/binningYW.txt -C plus,minus -o plots --xsecfiles Wel_plus_shapes_xsec.root,Wel_minus_shapes_xsec.root

Caveat: the estimated uncertainty for the theory expected is probably wrong, since it doesn't account for the correlation in the w+ and w- rates (while the fit does it correctly).
@bendavid @cippy @mdunser 