### PR TITLE
Changes to allow reduced tree size for MC samples

### DIFF
--- a/WMass/cfg/run_wmass_cfg.py
+++ b/WMass/cfg/run_wmass_cfg.py
@@ -28,10 +28,11 @@ isTest = getHeppyOption("test",None) != None and not re.match("^\d+$",getHeppyOp
 selectedEvents=getHeppyOption("selectEvents","")
 
 # save PDF information and do not skim. Do only for needed MC samples
-runOnSignal = False
+runOnSignal = True
 doTriggerMatching = True
-keepLHEweights = False
+keepLHEweights = True
 signalZ = False
+diLeptonSkim = False
 
 # Lepton Skimming
 ttHLepSkim.minLeptons = 1
@@ -39,12 +40,13 @@ ttHLepSkim.maxLeptons = 999
 #ttHLepSkim.idCut  = ""
 ttHLepSkim.ptCuts = [23]
 
-if doTriggerMatching:
+if diLeptonSkim:
     ttHLepSkim.minLeptons = 2
     ttHLepSkim.maxLeptons = 999
     #ttHLepSkim.idCut  = ""
     ttHLepSkim.ptCuts = [23, 23]
 
+if doTriggerMatching:
     print 'adding the trigger match analyzer'
     dmCoreSequence.insert(dmCoreSequence.index(triggerFlagsAna)+1, triggerMatchAnaEle )
     dmCoreSequence.insert(dmCoreSequence.index(triggerFlagsAna)+1, triggerMatchAnaMu  )
@@ -228,8 +230,8 @@ triggerFlagsAna.triggerBits = {
     'SingleEl'     : triggers_1e,
 }
 triggerFlagsAna.unrollbits = True
-triggerFlagsAna.saveIsUnprescaled = True
-triggerFlagsAna.checkL1Prescale = True
+triggerFlagsAna.saveIsUnprescaled = False
+triggerFlagsAna.checkL1Prescale = False
 
 ## do some trigger matching for the trigger efficiency studies
 
@@ -448,10 +450,18 @@ preprocessor = None
 #-------- HOW TO RUN -----------
 
 test = getHeppyOption('test')
-if test == 'testw' or test=='testz' or test=='testdata':
+if test.startswith('testw') or test.startswith('testz') or test=='testdata':
     if test=='testw':
         comp = WJetsToLNu_LO
         comp.files = ['/eos/user/m/mdunser/w-helicity-13TeV/testfiles/WJetsMG_test_0A85AA82-45BB-E611-8ACD-001E674FB063-9552f253c2fa2ae.root']
+    elif test=='testw_nnpdf31':
+        comp = WJetsToLNu
+        # comp.files = ['/eos/cms/store/mc/RunIISummer16MiniAODv2/WplusJToENuJ_scalesUpTo8_NNPDF31_plus_CMSPDF_TuneCP5_13TeV_powheg2-minlo-pythia/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/30000/34F84C69-917E-E811-BB1F-FA163EB2ABE6.root'] # we+
+        # comp.files = ['/eos/cms/store/mc/RunIISummer16MiniAODv2/WminusJToENuJ_scalesUpTo8_NNPDF31_plus_CMSPDF_TuneCP5_13TeV_powheg2-minlo-pythia/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/30000/2C26E10C-CE7F-E811-924B-FA163EE6807E.root'] # we-
+        comp.files = ['/eos/cms/store/mc/RunIISummer16MiniAODv2/WplusJToMuNuJ_scalesUpTo8_NNPDF31_plus_CMSPDF_TuneCP5_13TeV_powheg2-minlo-pythia/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v4/10000/04783B3A-B57D-E811-B421-FA163EF059FC.root'] # wm+
+    elif test=='testz_nnpdf31':
+        comp = DYJetsToLL_M50
+        comp.files = ['/eos/cms/store/mc/RunIISummer16MiniAODv2/ZJToEEJ_M-50_scalesUpTo8_NNPDF31_plus_CMSPDF_TuneCP5_13TeV_powheg2-minlo-pythia/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/70000/F22FBFAF-0179-E811-9038-FA163E54DF16.root']
     elif test=='testz':
         comp=DYJetsToLL_M50
         comp.files=['/eos/cms/store/cmst3/user/psilva/Wmass/DYJetsMG_test/FCDD4D28-12C4-E611-8BFC-C4346BC8F6D0.root']
@@ -505,13 +515,18 @@ elif test == '80X-MC':
         comp.files = [ tmpfil ]
         comp.splitFactor = 1
         if not getHeppyOption("single"): comp.fineSplitFactor = 4
-    elif what == "WJets":
-        WJetsToLNu = kreator.makeMCComponent("WJetsToLNu", "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM", "CMS", ".*root", 3* 20508.9)
+    elif what == "WJets" or what == "WJetsNNPDF31":
+        if what == "WJetsNNPDF31":
+            WJetsToLNu = kreator.makeMCComponent("WJetsToLNu_NNPDF31", "/WplusJToENuJ_scalesUpTo8_NNPDF31_plus_CMSPDF_TuneCP5_13TeV_powheg2-minlo-pythia/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/MINIAODSIM", "CMS", ".*root", 3* 20508.9)            
+            comp.files = [ '/store/mc/RunIISummer16MiniAODv2/WplusJToENuJ_scalesUpTo8_NNPDF31_plus_CMSPDF_TuneCP5_13TeV_powheg2-minlo-pythia/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/30000/B64A576F-7466-E811-8744-0025905A60B6.root' ]
+            tmpfil = os.path.expandvars("/tmp/$USER/B64A576F-7466-E811-8744-0025905A60B6.root")
+        else:
+            WJetsToLNu = kreator.makeMCComponent("WJetsToLNu", "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM", "CMS", ".*root", 3* 20508.9)
+            comp.files = [ '/store/mc/RunIISummer16MiniAODv2/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/160DFF65-E8BF-E611-A4AD-0CC47AC08C1A.root' ]
+            tmpfil = os.path.expandvars("/tmp/$USER/160DFF65-E8BF-E611-A4AD-0CC47AC08C1A.root")
         selectedComponents = [ WJetsToLNu ]
         comp = selectedComponents[0]
         comp.triggers = []
-        comp.files = [ '/store/mc/RunIISummer16MiniAODv2/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/160DFF65-E8BF-E611-A4AD-0CC47AC08C1A.root' ]
-        tmpfil = os.path.expandvars("/tmp/$USER/160DFF65-E8BF-E611-A4AD-0CC47AC08C1A.root")
         if not os.path.exists(tmpfil):
             os.system("xrdcp root://eoscms//eos/cms%s %s" % (comp.files[0],tmpfil))
         comp.files = [ tmpfil ]

--- a/WMass/python/analyzers/dmCore_modules_cff.py
+++ b/WMass/python/analyzers/dmCore_modules_cff.py
@@ -197,7 +197,8 @@ genHFAna = cfg.Analyzer(
 
 lheWeightAna = cfg.Analyzer(
     LHEWeightAnalyzer, name="LHEWeightAnalyzer",
-    useLumiInfo=False
+    useLumiInfo=False,
+    normLHEWeights=True
 )
 
 pdfwAna = cfg.Analyzer(

--- a/WMass/python/analyzers/ntupleTypes.py
+++ b/WMass/python/analyzers/ntupleTypes.py
@@ -46,3 +46,13 @@ leptonTypeWMass = NTupleObjectType("leptonWMass", baseObjectTypes = [ leptonType
     NTupleVariable("matchedTrgObjTkMuPt", lambda x: x.matchedTrgObjwmassTkMu.pt() if  x.matchedTrgObjwmassTkMu else -999.      , help="Matched trigger object (cone dR<0.3) pT to IsoTkMu24"),
     NTupleVariable("matchedTrgObjTkMuDR", lambda x: deltaR(x, x.matchedTrgObjwmassTkMu) if  x.matchedTrgObjwmassTkMu else -999., help="Matched trigger object (cone dR<0.3) dR to IsoTkMu24"),
 ])
+
+
+##------------------------------------------  
+## LHE weights with a reduced precision
+##------------------------------------------  
+lightWeightsInfoType = NTupleObjectType("LightWeightsInfo", mcOnly=True, variables = [
+#    NTupleVariable("id",   lambda x : x.id, int),
+    NTupleVariable("wgt",   lambda x : x.wgt, storageType="H"),
+])
+

--- a/WMass/python/analyzers/treeProducerWMass.py
+++ b/WMass/python/analyzers/treeProducerWMass.py
@@ -80,7 +80,7 @@ wmass_collections = {
             ##------------------------------------------------
             #"ivf"       : NTupleCollection("SV",     svType, 20, help="SVs from IVF"),
             ##------------------------------------------------
-            "LHE_weights"    : NTupleCollection("LHEweight",  weightsInfoType, 1000, mcOnly=True, help="LHE weight info"),
+            "LHE_weights"    : NTupleCollection("LHEweight",  lightWeightsInfoType, 1000, mcOnly=True, help="LHE weight info"),
             ##------------------------------------------------
             #"genleps"         : NTupleCollection("genLep",     genParticleWithLinksType, 10, help="Generated leptons (e/mu) from W/Z decays"),                                                                                                
             #"gentauleps"      : NTupleCollection("genLepFromTau", genParticleWithLinksType, 10, help="Generated leptons (e/mu) from decays of taus from W/Z/h decays"),                                                                       

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -140,34 +140,33 @@ class util:
      
         return -1
 
-    def getFromHessian(self, infile):
+    def getFromHessian(self, infile, keepGen=False):
         _dict = {}
         
         f = ROOT.TFile(infile, 'read')
         tree = f.Get('fitresults')
         lok  = tree.GetListOfLeaves()
-        
         for p in lok:
             if '_err'   in p.GetName(): continue
             if '_minos' in p.GetName(): continue
-            if '_gen'   in p.GetName(): continue
+            if '_gen'   in p.GetName() and not keepGen: continue
             if '_In'    in p.GetName(): continue
 
-            if not p.GetName()+'_err' in lok: continue
+            if not p.GetName()+'_err' in lok and not keepGen: continue
 
             if tree.GetEntries() > 1:
                 print 'YOUR INPUT FILE HAS MORE THAN ONE FIT INSIDE. THIS IS PROBABLY NOT A HESSIAN FILE!!!'
                 sys.exit()
             for ev in tree:
                 mean = getattr(ev, p.GetName())
-                err  = getattr(ev, p.GetName()+'_err')
+                err  = getattr(ev, p.GetName()+'_err') if hasattr(ev, p.GetName()+'_err') else 0
 
             _dict[p.GetName()] = (mean, mean+err, mean-err)
      
         return _dict
 
 
-    def getFromToys(self, infile):
+    def getFromToys(self, infile, keepGen=False):
         _dict = {}
         
         f = ROOT.TFile(infile, 'read')
@@ -177,7 +176,7 @@ class util:
         for p in lok:
             if '_err'   in p.GetName(): continue
             if '_minos' in p.GetName(): continue
-            if '_gen'   in p.GetName(): continue
+            if '_gen'   in p.GetName() and not keepGen: continue
             if '_In'    in p.GetName(): continue
             
             tmp_hist = ROOT.TH1F(p.GetName(),p.GetName(), 100000, -5000., 5000.)


### PR DESCRIPTION
Mostly by: 
- reducing the precision of LHE weights to 16bits floats (after making the ratios to the central weight)
- reducing the precision of GenParticles 4 momenta to 16bits floats
- removing the IDs of the LHE weights

seems to bring down the size to 2.7 kB/event (warning, missing LepGood because of the samples!)