### PR TITLE
MG5 default values for mass weights

### DIFF
--- a/WMass/python/postprocessing/examples/genFriendProducer.py
+++ b/WMass/python/postprocessing/examples/genFriendProducer.py
@@ -91,7 +91,7 @@ class GenQEDJetProducer(Module):
         self.pdfWeightOffset = 9 #index of first mc replica weight (careful, this should not be the nominal weight, which is repeated in some mc samples).  The majority of run2 LO madgraph_aMC@NLO samples with 5fs matrix element and pdf would use index 10, corresponding to pdf set 263001, the first alternate mc replica for the nominal pdf set 263000 used for these samples
         self.nMCReplicasWeights = 100 #number of input weights (100 for NNPDF 3.0)
         self.nHessianWeights = 60 #number of output weights
-        self.massWeights = range(80300, 80500, 5) #masses in MeV
+        self.massWeights = range(80300, 80505, 5) #masses in MeV
         if "PDFWeightsHelper_cc.so" not in ROOT.gSystem.GetLibraries():
             ROOT.gROOT.ProcessLine(".include /cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/eigen/3.2.2/include")
             ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/WMass/python/postprocessing/helpers/PDFWeightsHelper.cc+" % os.environ['CMSSW_BASE'])
@@ -162,7 +162,9 @@ class GenQEDJetProducer(Module):
         return idx_map[(mur,muf)]
 
     def bwWeight(self,genMass,imass):
-        (m0,gamma) = (80398.,2085.)
+        # default mass calculated from MG5 inputs
+        # width calculated with MG5_aMC_v2_6_3_2 loop_sm-ckm_no_b_mass for w+ > all all --> 2.05 ± 7.65e-06 (GeV)
+        (m0,gamma) = (80419.,2050.0) # MeV
         s_hat = pow(genMass,2)
         return (pow(s_hat - m0*m0,2) + pow(gamma*m0,2)) / (pow(s_hat - imass*imass,2) + pow(gamma*imass,2))
 


### PR DESCRIPTION
Determined default mass/width for MG5 sample