### PR TITLE
Changing Z cross section in mca files and polishing scripts for electron FR

### DIFF
--- a/WMass/python/plotter/runfakerateElectron.sh
+++ b/WMass/python/plotter/runfakerateElectron.sh
@@ -14,22 +14,12 @@ lumi_2016BF="19.7"  # to be checked, but we will never use it probably
 ######################
 #--------------------------
 # choose the dataset to use (2016 B to F or 2016 B to H)
-makeTH3_eta_pt_passID="y"  # special option to make the code create only TH3D histograms |eta| vs pt vs passID. It overrides other options
 useSignedEta="y" # distinguish bins of positive and negative rapidity (if passing binning with just positive values below, it will just skip the negative, so you are actually using half statistics)
 useFull2016dataset="y"
 useJson="n"
 useSkimmedTrees="y" 
-skipStackPlots="y" # skip stack plots made by make_fake_rates_data.py
-skipMCGO="y"  # if "y", will just run print MCEFF, which is the command to create the root file with TH3D only
-onlypack="n" # just pack an already existing fake-rate (obsolete: if you run this script with makeTH3_eta_pt_passID="y", then that part is not needed)
-# if onlypack='n', the packing might still be done at the end of FR computation, see options below
-# else, if onlypack='y', it overrides the packFRfromTest option below
 #--------------------------
-#etaRange="0.0,1.0,1.479,2.1,2.5"
-etaRange="0.0,0.3,0.6,0.9,1.2,1.479,1.7,1.9,2.1,2.3,2.5"  # if makeTH3_eta_pt_passID="y", it is ignored, it will make single TH3D histograms (pt vs eta vs passID, the eta binning is in make_fake_rates_xvars.txt)
-#etaRange="0.0,1.0,1.479,2.1,2.5"
-mtRanges="0,25,25,120"  # can stay as it is, was used with the 2-mT-region method
-mtDefinition="pfmtfix"  # trkmtfix, trkmt, pfmtfix, pfmt: even though we no longer use the 2-mT-regions method, I think pfmt should be better because trkmt is correlated with ID variables
+mtRanges="0,25,25,120"  # can stay as it is, was used with the 2-mT-region method, unless I change the fake rate script, leave it as it is: it is a dummy option
 ptDefinition="pt_granular"  # pt_coarse, pt_granular (first is mainly for QCD MC)
 #ptDefinition="pt_coarse"
 #-------------------------
@@ -46,19 +36,7 @@ fi
 
 istest="y"
 # following option testdir is used only if istest is 'y'
-testdir="SRtrees_new/fakeRate_${mtDefinition}_${ptDefinition}_mT40_${lumi/./p}fb_signedEta_pt65_subtrAllMC_newTrigSF_fitpol2_testTrigSF"
-if [[ "${makeTH3_eta_pt_passID}" == "y" ]]; then
-    #if [[ "${useSignedEta}" == "y" ]]; then
-	testdir="${testdir/${mtDefinition}/eta}"
-    #else
-	#testdir="${testdir/${mtDefinition}/abseta}"
-    #fi
-fi
-# by default, if this is a test we do not pack to avoid overwriting something when we just do tests
-# you can override this feature setting this flag to 'y'
-# even if you don't pack, the command you would use is printed in stdout
-packFRfromTest="n" 
-# anyway, the packing uses the FR made with the 2-mt-regions method, which is not good. Unless I modify the script, it is not needed (also because we have to smooth the FR)
+testdir="SRtrees_new/fakeRate_eta_${ptDefinition}_mT40_${lumi/./p}fb_signedEta_pt65_subtrAllMC_newTrigSF_fitpol2_testTrigSF"
 ######################
 ######################
 # additional options to be passed to w-helicity-13TeV/make_fake_rates_data.py
@@ -90,10 +68,8 @@ host=`echo "$HOSTNAME"`
 srtreeoption=""
 frGraphDir="el"
 
-packdir="${frGraphDir}"
 if [[ "${istest}" == "y" ]]; then
     testoption=" --test ${testdir}/ "
-    packdir="test/${testdir}/${frGraphDir}"
 fi
 
 cmdComputeFR="python ${plotterPath}/w-helicity-13TeV/make_fake_rates_data.py --qcdmc --mt ${mtDefinition} ${testoption} --fqcd-ranges ${mtRanges} --pt ${ptDefinition} --lumi ${lumi}"
@@ -105,48 +81,17 @@ if [[ "${useSkimmedTrees}" == "y" ]]; then
     cmdComputeFR="${cmdComputeFR} --useSkim "
 fi
 
-if [[ "${skipStackPlots}" == "y" ]]; then
-    cmdComputeFR="${cmdComputeFR} --skipStack "
-fi
-
-if [[ "${skipMCGO}" == "y" ]]; then
-    cmdComputeFR="${cmdComputeFR} --skipMCGO "
-fi
-
-if [[ "${makeTH3_eta_pt_passID}" == "y" ]]; then
-    cmdComputeFR="${cmdComputeFR} --makeTH3-eta-pt-passID "
-fi
-
 if [[ "${useSignedEta}" == "y" ]]; then
     cmdComputeFR="${cmdComputeFR} --useSignedEta "
-fi
-
-if [[ "X${etaRange}" != "X" ]]; then
-    cmdComputeFR="${cmdComputeFR} --etaRange \"${etaRange}\" "
 fi
 
 if [[ "X${addOption}" != "X" ]]; then
     cmdComputeFR="${cmdComputeFR} --addOpts \"${addOption}\" "
 fi
 
-if [[ "${onlypack}" == "y" ]]; then
-    echo "onlypack=='y': will not run fake-rate script, but just pack."
-    echo "Packing from ${plotterPath}/plots/fake-rate/${packdir}/comb/"
-else
-    echo "Running: ${cmdComputeFR}"
-    echo "${cmdComputeFR} | grep python > commands4fakeRate.sh" | bash
-    #echo "${cmdComputeFR} > commands4fakeRate.sh" | bash
-    echo "The commands used for fake-rate are stored in commands4fakeRate.sh"
-    cat commands4fakeRate.sh | bash  # here we really run the commands saved in commands4fakeRate.sh
-fi
-
-# now we pack the FR histograms
-cmdPackFR="python ${plotterPath}/w-helicity-13TeV/pack_fake_rates_data.py ${CMSSW_BASE}/src/CMGTools/WMass/data/fakerate/FR_data_el.root --lep-flavour el --input-path ${plotterPath}/plots/fake-rate/${packdir}/comb/"
-if [[ "${packFRfromTest}" == "y" ]] || [[ "${istest}" != "y" ]] || [[ "${onlypack}" == "y" ]]; then
-    echo "${cmdPackFR}" | bash
-else
-    echo "Not packing FR because istest='y'. You can force the packing setting packFRfromTest='y'."
-    echo "Anyway, the command to pack is reported below"
-    echo "${cmdPackFR}"
-fi
+echo "Running: ${cmdComputeFR}"
+echo "${cmdComputeFR} | grep python > commands4fakeRate.sh" | bash
+#echo "${cmdComputeFR} > commands4fakeRate.sh" | bash
+echo "The commands used for fake-rate are stored in commands4fakeRate.sh"
+cat commands4fakeRate.sh | bash  # here we really run the commands saved in commands4fakeRate.sh
 

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-qcdClosureTest.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-qcdClosureTest.txt
@@ -34,7 +34,7 @@ QCD: QCD_Pt* : xsec; FillColor=ROOT.kBlack, Label="QCD", NormSystematic=1.00
 #W   : WJetsToLNu_NLO_part* : 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kRed+2, Label="W (amc@NLO)", NormSystematic=0.026
 #W   : WJetsToLNu_NLO_ext_part* : 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kRed+2, Label="W (amc@NLO)", NormSystematic=0.026
 
-Z_fakes    : DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kAzure+2, NormSystematic=0.04, FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt", Label="Z (FR)"
+Z_fakes    : DYJetsToLL_M50_part* : 2008.4*3; FillColor=ROOT.kAzure+2, NormSystematic=0.04, FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt", Label="Z (FR)"
 
 W_fakes    : WJetsToLNu_NLO_part1 + WJetsToLNu_NLO_part2 + WJetsToLNu_NLO_part3 + WJetsToLNu_NLO_ext_part1 + WJetsToLNu_NLO_ext_part2 + WJetsToLNu_NLO_ext_part3 : 20508.9*3 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kRed+2, NormSystematic=0.026, FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc.txt", Label="W (FR)"
 
@@ -55,7 +55,7 @@ QCD_fakes: QCD_Pt* : xsec; FillColor=ROOT.kGray, Label="QCD (FR)", FakeRate="w-h
 # full FR formula on QCD and main EWK components
 
 QCDandEWK_fullFR: WJetsToLNu_NLO_part1 + WJetsToLNu_NLO_part2 + WJetsToLNu_NLO_part3 + WJetsToLNu_NLO_ext_part1 + WJetsToLNu_NLO_ext_part2 + WJetsToLNu_NLO_ext_part3: 3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kGreen+2, Label="All (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
-QCDandEWK_fullFR: DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kGreen+2, Label="All (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
+QCDandEWK_fullFR: DYJetsToLL_M50_part* : 2008.4*3; FillColor=ROOT.kGreen+2, Label="All (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
 QCDandEWK_fullFR: QCD_Pt* : xsec; FillColor=ROOT.kGreen+2, Label="All (PR+FR)", FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frqcdmc_fullFormula.txt"
 
 ######################

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-skims.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-skims.txt
@@ -1,6 +1,6 @@
 # signal from the weighted uncut sample should not be skimmed
 W    : WJetsToLNu_* : 3.*20508.9  ; FillColor=ROOT.kGray+1   , Label="W"
-Z    : DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
+Z    : DYJetsToLL_M50_part* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
 Top  : TTJets_SingleLeptonFromT_part* :  xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
 Top  : TTJets_SingleLeptonFromTbar_part* :  xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
 Top  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.04

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5.txt
@@ -28,7 +28,7 @@ W_LO   : WJetsToLNu_LO* :  3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId
 data_fakes: SingleElectron_07Aug17_Run2016* : 1 ; FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frdata_smooth.txt", Label="Fakes (data)", FillColor=ROOT.kGray, NormSystematic
 =0.30
 
-Z    : DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
+Z    : DYJetsToLL_M50_part* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
 Z_LO : DYJetsToLL_M50_LO_* : 5765.40 ; FillColor=ROOT.kAzure+2, Label="Z (Madgraph)", NormSystematic=0.04
 
 Top  : TTJets_SingleLeptonFromT_part* :  xsec; FillColor=ROOT.kGreen+2, Label="Top", NormSystematic=0.09

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5_FRskim.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5_FRskim.txt
@@ -52,5 +52,5 @@ WFlips  : WJetsToLNu_NLO* : 3.*20508.9    : genw_decayId == 12 && LepGood1_mcMat
 
 data: SingleElectron_07Aug17_Run2016*
 
-WandZ   : WJetsToLNu_NLO* :  3.*20508.9 ; FillColor=ROOT.kRed+2, Label="W (amc@NLO)", NormSystematic=0.026
-WandZ   : DYJetsToLL_M50_* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
+#WandZ   : WJetsToLNu_NLO* :  3.*20508.9 ; FillColor=ROOT.kRed+2, Label="W (amc@NLO)", NormSystematic=0.026
+#WandZ   : DYJetsToLL_M50_* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5_FRskim.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5_FRskim.txt
@@ -29,7 +29,7 @@ W_LO   : WJetsToLNu_LO* :  3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId
 data_fakes: SingleElectron_07Aug17_Run2016* : 1 ; FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frdata_smooth.txt", Label="Fakes (data)", FillColor=ROOT.kGray, NormSystematic
 =0.30
 
-Z    : DYJetsToLL_M50_* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
+Z    : DYJetsToLL_M50_* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
 
 Z_LO : DYJetsToLL_M50_LO_* : 5765.40 ; FillColor=ROOT.kAzure+2, Label="Z (Madgraph)", NormSystematic=0.04
 

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5_TINY.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5_TINY.txt
@@ -29,7 +29,7 @@ W_LO   : WJetsToLNu_LO* :  3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId
 data_fakes: SingleElectron_07Aug17_Run2016* : 1 ; FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frdata_smooth.txt", Label="Fakes (data)", FillColor=ROOT.kGray, NormSystematic
 =0.30
 
-Z    : DYJetsToLL_M50_* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
+Z    : DYJetsToLL_M50_* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
 Z_LO : DYJetsToLL_M50_LO_* : 5765.40 ; FillColor=ROOT.kAzure+2, Label="Z (Madgraph)", NormSystematic=0.04
 
 Top  : TTJets_SingleLeptonFromT_part* :  xsec; FillColor=ROOT.kGreen+2, Label="Top", NormSystematic=0.09

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5_Whel.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_V5_Whel.txt
@@ -38,7 +38,7 @@ W_LO   : WJetsToLNu_LO* :  3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId
 data_fakes: SingleElectron_07Aug17_Run2016* : 1 ; FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frdata_smooth.txt", Label="Fakes (data)", FillColor=ROOT.kGray, NormSystematic
 =0.30
 
-Z    : DYJetsToLL_M50_part* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
+Z    : DYJetsToLL_M50_part* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
 Z_LO : DYJetsToLL_M50_LO_* : 5765.40 ; FillColor=ROOT.kAzure+2, Label="Z (Madgraph)", NormSystematic=0.04
 
 Top  : TTJets_SingleLeptonFromT_part* :  xsec; FillColor=ROOT.kGreen+2, Label="Top", NormSystematic=0.09

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_forPlots.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_forPlots.txt
@@ -29,7 +29,7 @@ W_LO   : WJetsToLNu_LO* :  3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId
 data_fakes: SingleElectron_07Aug17_Run2016* : 1 ; FakeRate="w-helicity-13TeV/wmass_e/fakeRate-frdata_smooth.txt", Label="Fakes (data)", FillColor=ROOT.kGray, NormSystematic
 =0.30
 
-Z    : DYJetsToLL_M50_* : 1921.8*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
+Z    : DYJetsToLL_M50_* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z (amc@NLO)", NormSystematic=0.04
 Z_LO : DYJetsToLL_M50_LO_* : 5765.40 ; FillColor=ROOT.kAzure+2, Label="Z (Madgraph)", NormSystematic=0.04
 
 Top  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kGreen+2, Label="Top", NormSystematic=0.09

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/dy/mca.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/dy/mca.txt
@@ -1,3 +1,3 @@
-Z        : DYJetsToLL_M50_*                                           : 1921.8*3.     ; FillColor=ROOT.kAzure+2  , Label="Z"        , NormSystematic=0.04
+Z        : DYJetsToLL_M50_*                                           : 2008.4*3.     ; FillColor=ROOT.kAzure+2  , Label="Z"        , NormSystematic=0.04
 
 data: SingleMuon_Run2016*

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-bkgmc.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-bkgmc.txt
@@ -1,4 +1,4 @@
-#Z           : DYJetsToLL_M50_*                    : 1921.8*3                                              ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04
+#Z           : DYJetsToLL_M50_*                    : 2008.4*3                                              ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04
 
 Top         : TTJets_SingleLeptonFromT_part*      : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.09
 Top         : TTJets_SingleLeptonFromTbar_part*   : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.09

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-dy.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-dy.txt
@@ -1,1 +1,1 @@
-Z  : DYJetsToLL_M50_*    : 1921.8*3   ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04
+Z  : DYJetsToLL_M50_*    : 2008.4*3   ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-wmu-helicity-systs.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-wmu-helicity-systs.txt
@@ -20,7 +20,7 @@ Wminus_right : WJetsToLNu_LO_* : 3.*20508.9    : genw_decayId == 14 && genw_char
 
 ##TauDecaysW : WJetsToLNu_NoSkim_part* : 3.*20508.9   : (genw_decayId != 12 && genw_decayId != 14)  ; FillColor=ROOT.kPink   , Label="W to tau"
 TauDecaysW : WJetsToLNu_LO_* : 3.*20508.9   : (genw_decayId != 12 && genw_decayId != 14)  ; FillColor=ROOT.kPink   , Label="W to tau"
-Z          : DYJetsToLL_M50_part*                                                      : 1921.8*3 ; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
+Z          : DYJetsToLL_M50_part*                                                      : 2008.4*3 ; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
 Top        : TTJets_SingleLeptonFromT_ext_part* + TTJets_SingleLeptonFromT_part*       : xsec     ; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
 Top        : TTJets_SingleLeptonFromTbar_ext_part* + TTJets_SingleLeptonFromTbar_part* : xsec     ; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
 Top        : TToLeptons_sch_amcatnlo                                                   : xsec     ; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.04


### PR DESCRIPTION
Z cross section for aMC@NLO changed to 2008.4 pb (was 1921.8), for both muons and electrons.

Removing obsolete options and snippet for electron fake-rate scripts.
