### PR TITLE
Fix the mirroring in makeShapeCards to math the one we have in the merger

### DIFF
--- a/WMass/python/plotter/makeShapeCards.py
+++ b/WMass/python/plotter/makeShapeCards.py
@@ -446,7 +446,7 @@ for name in systsEnv.keys():
                 if (y0 > 0 and yA > 0):
                     yM = y0*y0/yA
                 elif yA == 0:
-                    yM = 2*y0
+                    yM = 0
                 mirror.SetBinContent(b, yM)
             if mode == "alternateShapeOnly":
                 # keep same normalization

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
@@ -36,7 +36,8 @@ CMS_We_FRe_norm      : data_fakes  : .* : FRe_norm : templates
 CMS_We_FRe_pt        : data_fakes  : .* : FRe_pt   : templatesShapeOnly
 # shape uncertainty (subtraction of EWK component scaled by 1sigma of cross section uncertainty, changes both shape and normalization)
 CMS_We_FRe_scaleEWK        : data_fakes  : .* : FRe_scaleEWK : templates
-# the uncertainty from variation of awayJet pt from 30 to 45 does not have up and down, so it is symmetrized around the nominal template when merging cards
+# variation of the away jet pT
+CMS_We_FRe_awayJetPt45     : data_fakes  : .* : data_fakes_FRe_awayJetPt45 : alternateShape
 
 # ==================================================================
 # Charge flips (uncertainty from T&P. Take the max(EB,EE) )


### PR DESCRIPTION
After conversation with @cippy, this is the easiest solution for the jetpt shape

1) the mirroring in makeShapeCards now matches the one in the merger
2) add an alternateShape syst for the jet pt in the systEnv.txt (done for ele, @mdunser do it for muons) like:

`+CMS_We_FRe_awayJetPt45     : data_fakes  : .* : data_fakes_FRe_awayJetPt45 : alternateShape`

3) the Up and Down in the root file is already good to use (no change needed downstream)
Tested on ele and Up and Down make sense
