### PR TITLE
overall simplification of fakes syst for electrons

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -272,12 +272,6 @@ if __name__ == "__main__":
                                                     print "Skipping %s " % newname
                                                     print "Will be recreated mirroring the Up component here"
                                                     continue
-                                                # this syst was made with alternateShape. However, the mirroring algorithm in makeShapeCards.py is different    
-                                                # and produces a strange result on the mirrored image (which it calls 'Down')                                         
-                                                # so here we take 'Up' and overwrite 'Down'                        
-                                                # the old 'Down' will not be written                                                                            
-                                                print "#####  CHECKPOINT  --> %s #####" % newname
-                                                # the syst might have been evaluated before the nominal, so nominals["x_data_fakes"] might not exist yet
                                                 pfx = 'x_data_fakes'
                                                 newname = newname[:-2] # remove Up from name                  
                                                 nominalFakes = 0
@@ -288,7 +282,7 @@ if __name__ == "__main__":
                                                     if not nominalFakes: 
                                                         print "Warning: couldn't read %s from file" % pfx
                                                         quit()
-                                                (alternate,mirror) = mirrorShape(nominalFakes,obj,newname,alternateShapeOnly=False,use2xNomiIfAltIsZero=True)             
+                                                (alternate,mirror) = mirrorShape(nominalFakes,obj,newname,alternateShapeOnly=True,use2xNomiIfAltIsZero=True)             
                                                 for alt in [alternate,mirror]:
                                                     if alt.GetName() not in plots:
                                                         plots[alt.GetName()] = alt.Clone()

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
@@ -34,18 +34,12 @@ Wminus_left_elescale_Dn  : WJetsToLNu_NLO* : 3.*20508.9   : genw_decayId == 12 &
 Wminus_right_elescale_Dn : WJetsToLNu_NLO* : 3.*20508.9   : genw_decayId == 12 && genw_charge<0 && LepGood1_mcMatchId*LepGood1_charge!=-24 ; FillColor=ROOT.kRed+2   , FakeRate="w-helicity-13TeV/wmass_e/fr-includes/reweighting_R_minus_lepDn.txt", Label="W- right lep scale Dn", SkipMe=True 
 
 # fake-lepton background systematics (shape systematics)
-# if fitting with pol1, account for change in slope
-incl_datafakes_FRe_pt_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptup.txt", SkipMe=True, PostFix='_fakes_FRe_pt_Up'
-incl_datafakes_FRe_pt_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptdown.txt", SkipMe=True, PostFix='_fakes_FRe_pt_Dn'
+incl_datafakes_FRe_slope_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptup.txt", SkipMe=True, PostFix='_fakes_FRe_slope_Up'
+incl_datafakes_FRe_slope_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptdown.txt", SkipMe=True, PostFix='_fakes_FRe_slope_Dn'
 
-# fake-lepton background systematics due to change of awayJet_pt from 30 (nominal) to 45 (just a random value we used)
-# it doesn't have an Up and Down variation, it will be made symmetric as we do for PDF  variations
+# fake-lepton background systematics due to change of awayJet_pt from 30 -> 45 GeV
 incl_datafakes_FRe_awayJetPt45 : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-jetpt_syst.txt", SkipMe=True, PostFix='_fakes_FRe_awayJetPt45'
 
 # norm vs eta and pt as shape
-incl_datafakes_FRe_norm_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-normup.txt", SkipMe=True, PostFix='_fakes_FRe_norm_Up'
-incl_datafakes_FRe_norm_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-normdown.txt", SkipMe=True, PostFix='_fakes_FRe_norm_Dn'
-
-# shape uncertainty (subtraction of EWK component scaled by 1sigma of cross section uncertainty, changes both shape and normalization)
-incl_datafakes_FRe_scaleEWK_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-EWKup.txt", SkipMe=True, PostFix='_fakes_FRe_scaleEWK_Up'
-incl_datafakes_FRe_scaleEWK_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-EWKdown.txt", SkipMe=True, PostFix='_fakes_FRe_scaleEWK_Dn'
+incl_datafakes_FRe_continuous_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-normup.txt", SkipMe=True, PostFix='_fakes_FRe_continuous_Up'
+incl_datafakes_FRe_continuous_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-normdown.txt", SkipMe=True, PostFix='_fakes_FRe_continuous_Dn'

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
@@ -28,17 +28,13 @@ CMS_We_elescale      :  W.*: .* : elescale         : templates
 # Fake rate uncertainties
 # 1+2) Measurement of the fake rate: normalization and shapes
 # ==================================================================
-# flat normalization uncertainty
-#CMS_We_FRe_norm      : data_fakes  : .* : 1.30
-# non-flat normalization uncertainty
-CMS_We_FRe_norm      : data_fakes  : .* : FRe_norm : templates
-# shape uncertainty (slope of FR with pt)
-CMS_We_FRe_pt        : data_fakes  : .* : FRe_pt   : templatesShapeOnly
-# shape uncertainty (subtraction of EWK component scaled by 1sigma of cross section uncertainty, changes both shape and normalization)
-CMS_We_FRe_scaleEWK        : data_fakes  : .* : FRe_scaleEWK : templates
-# the uncertainty from variation of awayJet pt from 30 to 45 does not have up and down
-# the field before the mode must be the full process name for mode=alternateShape (see makeShapeCards.py)
-CMS_We_FRe_awayJetPt45     : data_fakes  : .* : data_fakes_FRe_awayJetPt45 : alternateShape 
+# first is the normalization uncertainty
+#CMS_We_FRe_norm        : data_fakes  : .* : 1.30
+
+# shape uncertainties (slope of FR with pt up/down, and continuous variation in eta, and awayjet 45)
+CMS_We_FRe_slope         : data_fakes  : .* : FRe_slope       : templatesShapeOnly
+CMS_We_FRe_continuous    : data_fakes  : .* : FRe_continuous  : templates
+CMS_We_FRe_awayJetPt45   : data_fakes  : .* : data_fakes_FRe_awayJetPt45 : alternateShapeOnly
 
 # ==================================================================
 # Charge flips (uncertainty from T&P. Take the max(EB,EE) )


### PR DESCRIPTION
Simplification of fakes systematics:
- only one systematics modifying the normalization (eta-dependent 10->30%)
- 2 shape-only systematics (away jet pt and slope)
- removing EWK which is completely off 

Note: this still requires the override stuff in mergeCards, but the solution will be to simply make it 

`CMS_We_FRe_awayJetPt45   : data_fakes  : .* : data_fakes_FRe_awayJetPt45 : templateShapeOnly`
 
in systEnv and remove all the override stuff completely from the merger.
Use common names with muons to simplify combination.