### PR TITLE
Include recoil variables in next version of trees

### DIFF
--- a/WMass/cfg/run_wmass_cfg.py
+++ b/WMass/cfg/run_wmass_cfg.py
@@ -54,18 +54,6 @@ if doTriggerMatching:
     dmCoreSequence.insert(dmCoreSequence.index(triggerFlagsAna)+1, triggerMatchAnaMu  )
     dmCoreSequence.insert(dmCoreSequence.index(triggerFlagsAna)+1, triggerMatchAnaTkMu)
 
-if doRecoilVariables:
-    print 'adding recoil variables'
-    from CMGTools.WMass.analyzers.eventRecoilProducer import *
-    eventRecoilProducer = cfg.Analyzer(EventRecoilProducer,
-                                       name='eventRecoilProducer',
-                                       pf='packedPFCandidates',
-                                       pfType='std::vector<pat::PackedCandidate>',
-                                       gen='packedGenParticles',
-                                       genType='std::vector<pat::PackedGenParticle>')
-    dmCoreSequence.insert(dmCoreSequence.index(treeProducer)-1,eventRecoilProducer)
-    treeProducer.globalVariables += wmass_recoilVariables
-
 # Run miniIso
 lepAna.doMiniIsolation = True
 lepAna.packedCandidates = 'packedPFCandidates'
@@ -487,6 +475,19 @@ if selectedEvents!="":
         toSelect = events
         )
     dmCoreSequence.insert(dmCoreSequence.index(lheWeightAna), eventSelector)
+
+if doRecoilVariables:
+    print 'adding recoil variables'
+    from CMGTools.WMass.analyzers.eventRecoilProducer import *
+    eventRecoilProducer = cfg.Analyzer(EventRecoilProducer,
+                                       name='eventRecoilProducer',
+                                       pf='packedPFCandidates',
+                                       pfType='std::vector<pat::PackedCandidate>',
+                                       gen='packedGenParticles',
+                                       genType='std::vector<pat::PackedGenParticle>')
+    dmCoreSequence.append(eventRecoilProducer)
+    treeProducer.globalVariables += wmass_recoilVariables
+
 
 #-------- SEQUENCE -----------
 

--- a/WMass/cfg/run_wmass_cfg.py
+++ b/WMass/cfg/run_wmass_cfg.py
@@ -34,6 +34,7 @@ keepLHEweights = True
 signalZ = False
 diLeptonSkim = False
 useBasicRECOLeptons = False
+doRecoilVariables = True
 
 # Lepton Skimming
 ttHLepSkim.minLeptons = 1
@@ -53,6 +54,17 @@ if doTriggerMatching:
     dmCoreSequence.insert(dmCoreSequence.index(triggerFlagsAna)+1, triggerMatchAnaMu  )
     dmCoreSequence.insert(dmCoreSequence.index(triggerFlagsAna)+1, triggerMatchAnaTkMu)
 
+if doRecoilVariables:
+    print 'adding recoil variables'
+    from CMGTools.WMass.analyzers.eventRecoilProducer import *
+    eventRecoilProducer = cfg.Analyzer(EventRecoilProducer,
+                                       name='eventRecoilProducer',
+                                       pf='packedPFCandidates',
+                                       pfType='std::vector<pat::PackedCandidate>',
+                                       gen='packedGenParticles',
+                                       genType='std::vector<pat::PackedGenParticle>')
+    dmCoreSequence.insert(dmCoreSequence.index(treeProducer)-1,eventRecoilProducer)
+    treeProducer.globalVariables += wmass_recoilVariables
 
 # Run miniIso
 lepAna.doMiniIsolation = True

--- a/WMass/python/analyzers/eventRecoilProducer.py
+++ b/WMass/python/analyzers/eventRecoilProducer.py
@@ -250,22 +250,21 @@ class EventRecoilProducer(Analyzer):
             setattr(event,'%s_recoil_scalar_sphericity'%m,float(scalar_sphericity))
             setattr(event,'%s_dphi2tkmet'%m,float(dphi2tkmet))
 
-            #thrust variables (if no PF candidates -1 is assigned)
+            #thrust variables and event shapes (if no PF candidates -1 is assigned)
             try:
                 Thrust3D=self.doPCA(momList=selPF[:,[0,1,2]])
                 Thrust2D=self.doPCA(momList=selPF[:,[0,1]])            
+                sphericity,aplanarity,C,D,detST=self.analyzeMomentumTensor(momList=selPF[:,[0,1,2]],r=1)
             except:
                 Thrust3D=[-1,-1,-1]
                 Thrust2D=[-1,-1]
+                sphericity,aplanarity,C,D,detST=-1,-1,-1,-1,-1
             setattr(event,"%s_thrust"%m, float(Thrust3D[2]))
             setattr(event,"%s_thrustMajor"%m, float(Thrust3D[1]))
             setattr(event,"%s_thrustMinor"%m, float(Thrust3D[0]))
             setattr(event,"%s_oblateness"%m, float(Thrust3D[1]-Thrust3D[0]))            
             setattr(event,"%s_thrustTransverse"%m, float(Thrust2D[1]))
             setattr(event,"%s_thrustTransverseMinor"%m, float(Thrust2D[0]))
-
-            #event shapes
-            sphericity,aplanarity,C,D,detST=self.analyzeMomentumTensor(momList=selPF[:,[0,1,2]],r=1)
             setattr(event,"%s_sphericity"%m, float(sphericity))
             setattr(event,"%s_aplanarity"%m, float(aplanarity))
             setattr(event,"%s_C"%m, float(C))

--- a/WMass/python/analyzers/eventRecoilProducer.py
+++ b/WMass/python/analyzers/eventRecoilProducer.py
@@ -218,7 +218,7 @@ class EventRecoilProducer(Analyzer):
                 wgtSum=1.0
                 if 'puppi' in m:
                     selPF_w=pfWeights[mfilter]  
-                    if 'invpuppi' in m: selPF_w=1.0-selPF_w
+                    if 'invpuppi' in m: selPF_w=abs(1.0-selPF_w)
                     selPF=selPF*selPF_w
                             
             #basic kinematics
@@ -250,9 +250,13 @@ class EventRecoilProducer(Analyzer):
             setattr(event,'%s_recoil_scalar_sphericity'%m,float(scalar_sphericity))
             setattr(event,'%s_dphi2tkmet'%m,float(dphi2tkmet))
 
-            #thrust variables
-            Thrust3D=self.doPCA(momList=selPF[:,[0,1,2]])
-            Thrust2D=self.doPCA(momList=selPF[:,[0,1]])            
+            #thrust variables (if no PF candidates -1 is assigned)
+            try:
+                Thrust3D=self.doPCA(momList=selPF[:,[0,1,2]])
+                Thrust2D=self.doPCA(momList=selPF[:,[0,1]])            
+            except:
+                Thrust3D=[-1,-1,-1]
+                Thrust2D=[-1,-1]
             setattr(event,"%s_thrust"%m, float(Thrust3D[2]))
             setattr(event,"%s_thrustMajor"%m, float(Thrust3D[1]))
             setattr(event,"%s_thrustMinor"%m, float(Thrust3D[0]))

--- a/WMass/python/analyzers/eventRecoilProducer.py
+++ b/WMass/python/analyzers/eventRecoilProducer.py
@@ -1,0 +1,292 @@
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
+from PhysicsTools.HeppyCore.utils.deltar import * 
+import PhysicsTools.HeppyCore.framework.config as cfg
+import copy
+import ROOT
+import os
+from math import hypot
+from copy import deepcopy
+from sklearn.decomposition import PCA
+import numpy as np
+
+class EventRecoilProducer(Analyzer):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(EventRecoilProducer,self).__init__(cfg_ana,cfg_comp,looperName)
+
+        self.metFlavours=['tkmet','npv_tkmet','closest_tkmet','puppimet','invpuppimet','gen']
+
+        #added by me
+        if "FastJetAnalysis_cc.so" not in ROOT.gSystem.GetLibraries():
+            print "Compile Event shape script"
+            ROOT.gSystem.Load("/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.1.0/lib/libfastjet.so")
+            ROOT.gSystem.AddIncludePath("-I/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/fastjet/3.1.0/include")
+            ROOT.gSystem.Load("/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.020/lib/libfastjetcontribfragile.so")
+            ROOT.gSystem.AddIncludePath("-I/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/fastjet-contrib/1.020/include")
+            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/WMass/python/postprocessing/helpers/FastJetAnalysis.cc+" % os.environ['CMSSW_BASE'])
+        else:
+            print "FastJetAnalysis_cc.so found in ROOT libraries"
+        #
+
+        self._worker = ROOT.FastJetAnalysis()
+
+    def declareHandles(self):
+        super(EventRecoilProducer, self).declareHandles()
+        self.handles['cmgCand'] = AutoHandle( self.cfg_ana.pf, self.cfg_ana.pfType )
+        self.mchandles['packedGen'] = AutoHandle( self.cfg_ana.gen, self.cfg_ana.genType )
+
+
+    def beginLoop(self, setup):
+        super(EventRecoilProducer,self).beginLoop(setup)
+
+
+    def doPCA(self,momList):
+
+        """perform a principal component analysis and returns the thrust vectors"""
+
+        if len(momList)<2: return np.zeros(3)
+
+        n_components=momList.shape[1]
+        pcaAnalysis = PCA(n_components=n_components)
+        pcaAnalysis.fit(momList)
+        
+        #project along the thrust axis and sort
+        thrust = [ np.sum( np.absolute(np.dot(momList,pcaAnalysis.components_[i])) ) for i in xrange(0,n_components) ]
+        total_sum = np.sum( np.sqrt( np.sum( momList**2, axis=1) ) )
+        thrust = thrust/total_sum
+        thrust = np.sort(thrust)
+
+        return thrust
+    
+    def analyzeMomentumTensor(self,momList,r=1):
+
+        """compute the momentum tensor and its eigenvalues"""
+        
+        toReturn=[-1,-1,-1,-1,-1]
+        if len(momList)<2: return toReturn
+
+        #momentum tensor
+        momTensor=np.zeros((3,3))
+        norm=0
+        tmomTensor=np.zeros((2,2))
+        normT=0        
+        for i in xrange(0,len(momList)):
+
+            X,Y,Z=momList[i]
+            p3=np.sqrt(X**2+Y**2+Z**2)
+            if p3>0:
+                coeff = np.power(p3,r-2 )
+                norm += np.power(p3,r)
+                momTensor[0][0] += coeff*X*X
+                momTensor[0][1] += coeff*X*Y
+                momTensor[0][2] += coeff*X*Z
+                momTensor[1][0] += coeff*Y*X
+                momTensor[1][1] += coeff*Y*Y
+                momTensor[1][2] += coeff*Y*Z
+                momTensor[2][0] += coeff*Z*X
+                momTensor[2][1] += coeff*Z*Y
+                momTensor[2][2] += coeff*Z*Z
+
+            p2 = np.sqrt(X*X+Y*Y)
+            if p2>0:
+                coeff = np.power(p2,r-2)
+                normT += np.power(p2,r)
+                tmomTensor[0][0] += coeff*X*X
+                tmomTensor[0][1] += coeff*X*Y
+                tmomTensor[1][0] += coeff*Y*X
+                tmomTensor[1][1] += coeff*Y*Y
+                
+        momTensor=momTensor/norm
+        tmomTensor=tmomTensor/normT
+
+        #eigenvalues
+        w,_=np.linalg.eig(momTensor)
+        w=np.sort(w)        
+        toReturn[0]=1.5*(w[0]+w[1])                    #sphericity
+        toReturn[1]=1.5*w[0]                           #aplanarity
+        toReturn[2]=3.*(w[2]*w[1]+w[2]*w[1]+w[1]*w[0]) #C
+        toReturn[3]=27.*w[0]*w[1]*w[2]                 #D
+        toReturn[4]=np.linalg.det(tmomTensor)          #detST
+
+        return toReturn
+
+    def processGen(self,event):
+
+        """makes a charged-based gen recoil estimator"""
+
+        #loop over final state particles
+        pMom=[]
+        try:
+            nlep=0
+            for p in self.mchandles['packedGen'].product():
+                if p.charge() == 0: continue
+                if p.status() != 1: continue
+                if p.pt()<0.5 or abs(p.eta())>2.4 : continue
+
+                #veto up to two high pT central, leptons
+                if abs(p.pdgId()) in [11,13] and p.pt()>20 and abs(p.eta())<2.4:
+                    nlep+=1
+                    if nlep<=2 : continue
+
+                pMom.append( [p.px(),p.py(),p.pz(),p.pt(),p.energy()] )
+        except:
+            pass
+
+        return np.array(pMom)
+
+    def process(self, event):
+
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+
+        self.readCollections(event.input)
+
+        #gen level
+        genMom=self.processGen(event)
+
+        #vertex analysis
+        mindz=9999.
+        next2pv=-1
+        for ivtx in xrange(1,len(event.goodVertices)):            
+            dz=event.goodVertices[ivtx].position().z()-event.goodVertices[0].position().z()
+            if abs(dz)>abs(mindz): continue
+            mindz=dz
+            next2pv=ivtx
+        setattr(event,'mindz',mindz)
+        setattr(event,'vx',event.goodVertices[ivtx].position().x())
+        setattr(event,'vy',event.goodVertices[ivtx].position().y())
+        setattr(event,'vz',event.goodVertices[ivtx].position().z())
+
+        #pre-select leptons
+        vetoCands=[]
+        for l in event.selectedLeptons:
+            if l.pt()<20 or abs(l.eta())>2.4 : continue
+            if l.associatedVertex.position()!=event.vertices[0].position() : continue
+            vetoCands.append(l)
+    
+        #select pf candidates
+        pfTags,pfMom,pfWeights=[],[],[]
+        pfcands = self.handles['cmgCand'].product()
+        for pfcand in pfcands:
+
+            p=pfcand.p4()
+            if p.pt()<0.5 : continue
+
+            #veto up to two leptons
+            veto=False
+            if pfcand.charge()!=0:
+                for ic in xrange(0,min(2,len(vetoCands))):
+                    if vetoCands[ic].associatedVertex.position()!=pfcand.vertex() : continue
+                    if deltaR(vetoCands[ic].p4(),p)>0.05: continue
+                    veto=True
+            if veto: 
+                print 'Vetoed',pfcand.pdgId(),pfcand.pt(),pfcand.eta()
+                continue
+
+            #flags to be used in the different met flavours
+            isCharged=True if pfcand.charge()!=0 else False
+            isCentral=True if abs(p.eta())<2.4 else False
+            isFromPV=True if pfcand.fromPV(0)>1 else False
+            isFromNext2PV=True if not isFromPV and next2pv>0 and pfcand.fromPV(next2pv) else False
+            use_tkmet         = (isCharged and isCentral and isFromPV)
+            use_npv_tkmet     = (isCharged and isCentral and not isFromPV)
+            use_closest_tkmet = (isCharged and isCentral and isFromNext2PV)
+            use_puppimet      = True
+            use_invpuppimet   = True
+
+            #add to list
+            pfTags.append( [use_tkmet,use_npv_tkmet,use_closest_tkmet,use_puppimet,use_invpuppimet] )
+            pfMom.append( [pfcand.px(),pfcand.py(),pfcand.pz(),pfcand.pt(),pfcand.energy()] )
+            pfWeights.append( [pfcand.puppiWeightNoLep()] )
+            
+        #convert to numpy arrays for filtering and other operations
+        pfTags=np.array(pfTags)
+        pfMom=np.array(pfMom)
+        pfWeights=np.array(pfWeights)
+
+        #produce the observables for each met flavour
+        tkmet_phi=None
+        for im in xrange(0,len(self.metFlavours)):            
+
+            m=self.metFlavours[im]
+            
+            selPF=[]
+            if m=='gen':
+                selPF=genMom
+            else:
+                mfilter=(pfTags[:,im]==True)
+                selPF=pfMom[mfilter] 
+                wgtSum=1.0
+                if 'puppi' in m:
+                    selPF_w=pfWeights[mfilter]  
+                    if 'invpuppi' in m: selPF_w=1.0-selPF_w
+                    selPF=selPF*selPF_w
+                            
+            #basic kinematics
+            if len(selPF)>0:
+                recx,recy,recz,ht,_=np.sum(selPF,axis=0,dtype=np.float32)
+                recpt=np.hypot(recx,recy)
+                recphi=np.arctan2(recy,recx)
+                leadmom=selPF[np.argmax(selPF[:,3])]
+                leadpt=leadmom[3]
+                leadphi=np.arctan2(leadmom[1],leadmom[0])
+                scalar_sphericity=recpt/ht
+            else:
+                recpt=0
+                recphi=0
+                leadpt=0
+                leadphi=0
+                ht=0
+                scalar_sphericity=0
+
+            if im==0: tkmet_phi=recphi
+            dphi2tkmet=ROOT.TVector2.Phi_mpi_pi(recphi-tkmet_phi)
+
+            setattr(event,'%s_n'%m,len(selPF))
+            setattr(event,'%s_recoil_pt'%m,float(recpt))
+            setattr(event,'%s_recoil_phi'%m,float(recphi))
+            setattr(event,'%s_leadpt'%m,float(leadpt))
+            setattr(event,'%s_leadphi'%m,float(leadphi))
+            setattr(event,'%s_recoil_scalar_ht'%m,float(ht))
+            setattr(event,'%s_recoil_scalar_sphericity'%m,float(scalar_sphericity))
+            setattr(event,'%s_dphi2tkmet'%m,float(dphi2tkmet))
+
+            #thrust variables
+            Thrust3D=self.doPCA(momList=selPF[:,[0,1,2]])
+            Thrust2D=self.doPCA(momList=selPF[:,[0,1]])            
+            setattr(event,"%s_thrust"%m, float(Thrust3D[2]))
+            setattr(event,"%s_thrustMajor"%m, float(Thrust3D[1]))
+            setattr(event,"%s_thrustMinor"%m, float(Thrust3D[0]))
+            setattr(event,"%s_oblateness"%m, float(Thrust3D[1]-Thrust3D[0]))            
+            setattr(event,"%s_thrustTransverse"%m, float(Thrust2D[1]))
+            setattr(event,"%s_thrustTransverseMinor"%m, float(Thrust2D[0]))
+
+            #event shapes
+            sphericity,aplanarity,C,D,detST=self.analyzeMomentumTensor(momList=selPF[:,[0,1,2]],r=1)
+            setattr(event,"%s_sphericity"%m, float(sphericity))
+            setattr(event,"%s_aplanarity"%m, float(aplanarity))
+            setattr(event,"%s_C"%m, float(C))
+            setattr(event,"%s_D"%m, float(D))
+            setattr(event,"%s_detST"%m, float(detST))
+
+            #N-jetttiness and rho
+            self._worker.reset()
+            for i in xrange(0,len(selPF)):
+                px,py,pz,pt,en=selPF[i]
+                self._worker.add(px,py,pz,en)
+            self._worker.run()
+            setattr(event,"%s_rho"%m, self._worker.rho())
+            for i in xrange(1,5):
+                setattr(event,"%s_tau%d"%(m,i), self._worker.tau(i))
+
+
+        return True
+
+
+setattr(EventRecoilProducer,
+        "defaultConfig", 
+        cfg.Analyzer(class_object = EventRecoilProducer,
+                     pf='packedPFCandidates',
+                     pfType='std::vector<pat::PackedCandidate>',
+                     gen='packedGenParticles', 
+                     genType='std::vector<pat::PackedGenParticle>')
+        )

--- a/WMass/python/analyzers/treeProducerWMass.py
+++ b/WMass/python/analyzers/treeProducerWMass.py
@@ -88,7 +88,8 @@ wmass_collections = {
             "generatorSummary" : NTupleCollection("GenPart", genParticleWithLinksType, 50 , mcOnly=True, help="Hard scattering particles, with ancestry and links"),
 }
 
-wmass_recoilVariables=[ NTupleVariable(x, lambda ev : getattr(ev,x), float, mcOnly=False,  help=x) for x in ['vz','vy','vz','mindz']]
+wmass_recoilVariables=[ NTupleVariable(x, lambda ev : getattr(ev,x), float, mcOnly=False,  help=x, storageType='H') 
+                        for x in ['vz','vy','vz','mindz']]
 for m in ['tkmet','npv_tkmet','closest_tkmet','puppimet','invpuppimet','gen']:
     for v in ['n','recoil_pt','recoil_phi','scalar_sphericity','scalar_ht','dphi2tkmet','leadpt','leadphi'
               'thrustMinor','thrustMajor','thrust','oblateness','thrustTransverse','thrustTransverseMinor',

--- a/WMass/python/analyzers/treeProducerWMass.py
+++ b/WMass/python/analyzers/treeProducerWMass.py
@@ -88,12 +88,17 @@ wmass_collections = {
             "generatorSummary" : NTupleCollection("GenPart", genParticleWithLinksType, 50 , mcOnly=True, help="Hard scattering particles, with ancestry and links"),
 }
 
-wmass_vertexVariables=[
-    NTupleVariable("vx",    lambda ev: ev.goodVertices[0].x() if len(ev.goodVertices)>0 else 0, mcOnly=False, help="PV position x"),
-    NTupleVariable("vy",    lambda ev: ev.goodVertices[0].y() if len(ev.goodVertices)>0 else 0, mcOnly=False, help="PV position y"),
-    NTupleVariable("vz",    lambda ev: ev.goodVertices[0].z() if len(ev.goodVertices)>0 else 0, mcOnly=False, help="PV position z"),
-    NTupleVariable("mindz", 
-                   lambda ev: min([abs(ev.goodVertices[0].z()-ev.goodVertices[i].z()) for i in xrange(1,len(ev.goodVertices))]) if len(ev.goodVertices)>1 else 0, 
-                   mcOnly=False, 
-                   help="closest to PV in z")
-]
+wmass_recoilVariables=[ NTupleVariable(x, lambda ev : getattr(ev,x), float, mcOnly=False,  help=x) for x in ['vz','vy','vz','mindz']]
+for m in ['tkmet','npv_tkmet','closest_tkmet','puppimet','invpuppimet','gen']:
+    for v in ['n','recoil_pt','recoil_phi','scalar_sphericity','scalar_ht','dphi2tkmet','leadpt','leadphi'
+              'thrustMinor','thrustMajor','thrust','oblateness','thrustTransverse','thrustTransverseMinor',
+              'sphericity','aplanarity','C','D','detST',
+              'rho','tau1','tau2','tau3','tau4']:
+        wmass_recoilVariables.append(
+            NTupleVariable('{0}_{1}'.format(m,v), 
+                           lambda ev : getattr(ev,'{0}_{1}'.format(m,v)),  
+                           float,
+                           mcOnly=True if m=='gen' else False,
+                           help='{0} {1}'.format(m,v),
+                           storageType='H') #16 bit should be enough
+            )

--- a/WMass/python/postprocessing/helpers/FastJetAnalysis.cc
+++ b/WMass/python/postprocessing/helpers/FastJetAnalysis.cc
@@ -28,7 +28,8 @@ public:
   void reset() { 
     pList_.clear(); 
     for(size_t i=0; i<taus_.size(); i++) 
-      taus_[i]=0; rho_=0;
+      taus_[i]=-1; 
+    rho_=-1;
   }
 
   void add(float px, float py, float pz, float en) {
@@ -55,8 +56,8 @@ public:
     rho_=bge.rho();
   }
 
-  const float & tau(int i) { return taus_[i-1]; }
-  const float &rho() { return rho_; }
+  const float &tau(int i) { return taus_[i-1]; }
+  const float &rho()      { return rho_; }
  
 private:
   std::vector<fastjet::PseudoJet> pList_;

--- a/WMass/python/postprocessing/helpers/FastJetAnalysis.cc
+++ b/WMass/python/postprocessing/helpers/FastJetAnalysis.cc
@@ -1,0 +1,68 @@
+#ifndef CMGTools_WMassTools_FastJetAnalysis_h
+#define CMGTools_WMassTools_FastJetAnalysis_h
+
+#include <iostream>
+#include <vector>
+#include <TTreeReaderValue.h>
+#include <TTreeReaderArray.h>
+#include <TLorentzVector.h>
+
+// system include files
+#include <memory>
+#include "TLorentzVector.h"
+#include "TVector3.h"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/contrib/Njettiness.hh"
+#include "fastjet/tools/JetMedianBackgroundEstimator.hh"
+#include <DataFormats/Math/interface/deltaR.h>
+
+using namespace fastjet;
+
+class FastJetAnalysis {
+
+public:
+
+  FastJetAnalysis(int ntaus=4) { taus_.resize(ntaus); reset(); };
+  ~FastJetAnalysis() {};
+
+  void reset() { 
+    pList_.clear(); 
+    for(size_t i=0; i<taus_.size(); i++) 
+      taus_[i]=0; rho_=0;
+  }
+
+  void add(float px, float py, float pz, float en) {
+    fastjet::PseudoJet p4(px,py,pz,en);
+    pList_.push_back(p4);
+  }
+
+  void run(float rapmax=2.5){
+
+    if(pList_.size()==0) return;
+
+    //n-jettiness
+    fastjet::contrib::NormalizedMeasure normalizedMeasure(1.0,0.4);
+    fastjet::contrib::Njettiness routine(fastjet::contrib::Njettiness::onepass_kt_axes,normalizedMeasure);
+    for(size_t i=0; i<taus_.size(); i++)
+      taus_[i]=routine.getTau(float(i+1),pList_);
+
+    //rho    
+    Selector sel_rapmax = SelectorAbsRapMax(rapmax);
+    JetDefinition jet_def_for_rho(kt_algorithm,0.5);
+    AreaDefinition area_def(active_area,GhostedAreaSpec(rapmax + 1.));
+    JetMedianBackgroundEstimator bge(sel_rapmax, jet_def_for_rho, area_def);
+    bge.set_particles(pList_);
+    rho_=bge.rho();
+  }
+
+  const float & tau(int i) { return taus_[i-1]; }
+  const float &rho() { return rho_; }
+ 
+private:
+  std::vector<fastjet::PseudoJet> pList_;
+  std::vector<float> taus_;
+  float rho_;
+
+};
+
+#endif


### PR DESCRIPTION
adding event recoil variable producer + C helper and variables to be included in the trees
*do not merge yet* - i'm getting some errors running with the latest 80X setup which don't let me run as before:

1. https://github.com/WMass/cmg-cmssw/blob/heppy_80X/PhysicsTools/HeppyCore/python/statistics/tree.py#L117 changing np to numpy seems missing

2. after fixing 1. i get AttributeError: 'pat::Electron' object has no attribute 'matchedTrgObjwmassEle'
    should something else be run in the cfg to set this attribute?

@pgunnell - follow this as this contains the new version of the variables you started