### PR TITLE
backport resubmission scripts from 94X. usage changes a bit:

### DIFF
--- a/Production/scripts/cmgListChunksToResub
+++ b/Production/scripts/cmgListChunksToResub
@@ -13,7 +13,7 @@ LSFL=false
 F=JSONAnalyzer/JSON.pck
 LOC=false
 P=false
-Q=8nh
+Q=""
 Z=false
 
 # evaluate parameters
@@ -25,7 +25,7 @@ while true; do
     -t )            F="$2"; shift 2 ;;
     -l )            LOC=true; shift ;;
     -p )            P=true; shift ;;
-    -q )            Q="$2"; shift 2 ;;
+    -q )            Q="-q $2"; shift 2 ;;
     -z )            Z=true; shift ;;
     -- )            shift; break ;;
     *  )            break ;;
@@ -40,10 +40,11 @@ function help {
     echo "The default queue is 8nh"
     echo "further options:"
     echo "-T  terse output"
-    echo "-d  check for a LSFJOB_ dir"
+    echo "-d  check for a LSFJOB_ dir or non-empty condor*.out"
     echo "-t <filename>  name of ROOT file to check for zombie (option -z)"
     echo "-l  print commands for local running instead of batch submission"
     echo "-p  check for null pck files"
+    echo "-q  queue to resubmit to (use HTCondor to resubmit to HTCondor instead of LSF)"
     echo "-z  check for zombie ROOT files"
     exit 1;
 }
@@ -54,7 +55,7 @@ if $HELP || [ "$1" == "" ]; then
 fi
 
 if $LSFL; then
-    $TERSE || echo "# Will check for a LSFJOB_ dir "
+    $TERSE || echo "# Will check for a LSFJOB_ dir or non-empty condor*.out "
 fi
 
 $TERSE || echo "# Will test for the presence of file $F"
@@ -86,13 +87,13 @@ for D in */; do
     # test if file to be tested for is present and whether bad pickle file flag has been set
     if test \! -s $D/$F || $PCKBAD; then
         # check for batch directory if requested or proceed to command printout
-        if [ "${LSFL}" = false ] || find $D -maxdepth 1 -type d -name 'LSFJOB_*' | grep -q LSFJ || test -f $D/submission_failed ; then
+        if [ "${LSFL}" = false ] || find $D -maxdepth 1 -type d -name 'LSFJOB_*'  -or -name 'condor_job*.out' -not -empty | grep -q . || test -f $D/submission_failed ; then
             if $LOC; then
                 # print local command
                 echo "cmgRunChunkLocally ${BASE}${D} ";
 	        else
                 # print batch command
-		        echo "cmgResubChunk -q $Q ${BASE}${D} ";
+		        echo "cmgResubChunk $Q ${BASE}${D} ";
             fi
         else
             $TERSE || echo "# Chunk ${BASE}${D} does not have a LSFJOB directory, maybe still running? ";
@@ -108,7 +109,7 @@ if $Z; then
             if $LOC; then
                 echo "cmgRunChunkLocally ${BASE}${D}     # zombie";
             else
-                echo "cmgResubChunk -q $Q ${BASE}${D}    # zombie";
+                echo "cmgResubChunk $Q ${BASE}${D}    # zombie";
             fi
         fi;
     done

--- a/Production/scripts/cmgListZombies
+++ b/Production/scripts/cmgListZombies
@@ -17,7 +17,7 @@ for f in sys.argv:
     for file in iglob(f):
         if not file.endswith(".root"): continue
         tfile = ROOT.TFile.Open(file)
-        if not tfile or tfile.IsZombie() or tfile.Recover()==1:
+        if not tfile or tfile.IsZombie():
             print file
         try:
             tfile.Close()

--- a/Production/scripts/cmgResubChunk
+++ b/Production/scripts/cmgResubChunk
@@ -1,16 +1,22 @@
 #!/bin/bash
+Q="8nh"; T="240"; HAST=false
 if [[ "$1" == "" || "$1" == "-h" || "$1" == "--help" ]]; then
-    echo "Usage: $0 [ -q <queue> ] <Component_ChunkXYZ> [ <JobName> ] "
-    echo " will resubmit the chunk <Component_ChunkXYZ> to the queue <queue> (default: 2nd)  "
+    echo "Usage: $0 [ -q <queue> | -t <time-in-minutes> ] <Component_ChunkXYZ> [ <JobName> ] "
+    echo " will resubmit the chunk <Component_ChunkXYZ> to the queue <queue> (default: $Q),  "
     echo " if no jobname is specified, the job name in LSF will be the chunk name."
+    echo " setting -q HTCondor will submit to HTCondor instead of LXF using the exising submit file"
+    echo " setting [ -q HTCondor ] -t time will submit to HTCondor with an alternate job length in minutes"
     echo " you can also run this command from within the Component_ChunkXYZ directory, in that case you can omit the chunk name"
     exit 1;
 fi
 
-Q=2nd
 if [[ "$1" == "-q" ]]; then
     Q=$2; shift; shift;
 fi;
+if [[ "$1" == "-t" ]]; then
+    Q="HTCondor"; T=$2; HAST=true; shift; shift;
+fi;
+
 if [[ "$1" != "" ]] && test -d $1 && test -f $1/batchScript.sh; then
     cd $1; shift;
 elif test \! -f batchScript.sh; then
@@ -19,5 +25,27 @@ elif test \! -f batchScript.sh; then
 fi
 LAB="$(basename $PWD)"; if [[ "$1" != "" ]]; then LAB=$1; fi;
 rename LSFJ OLD_LSFJ *; 
+rename condor_job OLD_condor_job *; 
+
 test -f submission_failed && rm submission_failed
-bsub -q $Q -J $LAB < batchScript.sh
+
+if [ "$Q" != "HTCondor" ]; then
+    echo "Resubmitting using LXBatch on queue $Q"
+    bsub -q $Q -J $LAB < batchScript.sh
+else 
+    if $HAST; then
+        if [ -f ../src.tar.gz ]; then
+            echo "Found ../src.tar.gz. Will resubmit with run_condor.sh"
+            run_condor.sh -t $T batchScript.sh
+        else
+            echo "Will resubmit with run_condor_simple.sh"
+            run_condor_simple.sh -t $T batchScript.sh
+        fi
+    else
+        if [ -f job_desc.cfg ]; then
+            condor_submit job_desc.cfg
+        else
+            echo "job_desc.cfg not found. please rerun with -t <time>"
+        fi;
+    fi;
+fi;


### PR DESCRIPTION
i run:
    cmgListChunksToResub  -q HTCondor >& .resub
which pipes all resub jobs into resub. however the default walltime
is tiny, so then afterwards i add -t 4000 to the commands:
     cmgResubChunk -q HTCondor -t 4000 <job>

seems to work fine, but please test @pfs and @emanueledimarco 