### PR TITLE
adding mW uncertainty to the cards. +- 50 MeV

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -127,14 +127,18 @@ def writeQCDScaleSystsToMCA(mcafile,odir,syst="qcd",incl_mca='incl_sig',scales=[
         for idir in ['Up','Dn']:
             postfix = "_{proc}_{syst}{idir}".format(proc=incl_mca.split('_')[1],syst=scale,idir=idir)
             mcafile_syst = open(filename, 'a') if append else open("%s/mca%s.txt" % (odir,postfix), "w")
-            if not scale == "wptSlope": ## alphaS and qcd scales are treated equally here. but they are different from the w-pT slope
-                mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="qcd_'+scale+idir+'", PostFix="'+postfix+'" \n')
-            else:
+            if scale == "wptSlope":
                 sign  =  1 if idir == 'Dn' else -1
                 asign = -1 if idir == 'Dn' else  1
                 offset = 0.05; slope = 0.005;
                 fstring = "wpt_slope_weight(genw_pt\,{off:.3f}\,{slo:.3f})".format(off=1.+asign*offset, slo=sign*slope)
                 mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="'+fstring+'", PostFix="'+postfix+'" \n')
+            elif scale == "mW":
+                ## central mass is 80419 MeV, the closest we have to that is 80420. will scale +- 50 MeV, i.e. 80470 for Up and 80370 for Dn
+                fstring = "mass_80470" if idir == 'Up' else "mass_80370"
+                mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="'+fstring+'", PostFix="'+postfix+'" \n')
+            else: ## alphaS and qcd scales are treated equally here. but they are different from the w-pT slope
+                mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="qcd_'+scale+idir+'", PostFix="'+postfix+'" \n')
             qcdsysts.append(postfix)
     print "written ",syst," systematics relative to ",incl_mca
 
@@ -273,7 +277,7 @@ if options.addPdfSyst:
     # SYSTFILEALL = writePdfSystsToSystFile(SYSTFILE)
 if options.addQCDSyst:
     scales = ['muR','muF',"muRmuF", "alphaS"]
-    writeQCDScaleSystsToMCA(MCA,outdir+"/mca",scales=scales+["wptSlope"])
+    writeQCDScaleSystsToMCA(MCA,outdir+"/mca",scales=scales+["wptSlope", "mW"])
     writeQCDScaleSystsToMCA(MCA,outdir+"/mca",scales=scales,incl_mca='incl_dy')
 
 writeEfficiencyStatErrorSystsToMCA(MCA,outdir+"/mca",options.channel)


### PR DESCRIPTION
comment: the central mass of the generator is 80419 MeV. the closest mass we have to that is 80420 MeV, and so the Up / Down variations are to 80370 MeV and 80470 MeV.

this means we have to save at least those two weights when skimming the friends. we can save the other ones though, i don't think we need them for the helicity (and there's many).