### PR TITLE
fully functioning friends submission script with condor

### DIFF
--- a/WMass/python/postprocessing/condorMerging/friendsScript.sh
+++ b/WMass/python/postprocessing/condorMerging/friendsScript.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+## make local directory
+echo 'i am in this directory'
+echo $PWD
+
+echo ls of this directory:
+ls ./
+
+export localMergeDir=${PWD}/friends_${3}_chunk${4}
+echo making directory ${localMergeDir}
+mkdir -p ${localMergeDir}
+
+
+echo moving to cmssw directory ${1}
+
+cd $1
+## do cmsenv and go back
+eval `scramv1 runtime -sh`
+
+echo 'moving back to localMergingDirectory'
+cd ${localMergeDir}
+
+echo 'will run the copy and running of friend trees'
+eos cp -r ${2}/ .
+
+echo done copying, this is the content of the localMergeDir:
+ls ./
+
+
+## run the actual command
+export localOutDir=tmp_friends_out
+
+echo running command: python ${1}/src/CMGTools/WMass/python/postprocessing/postproc_batch.py ./ ${localOutDir} -d ${3} -N ${5} -c ${4} --friend
+
+
+mkdir -p ${localOutDir}
+python ${1}/src/CMGTools/WMass/python/postprocessing/postproc_batch.py ./ ${localOutDir} -d ${3} -N ${5} -c ${4} --friend
+
+echo 'making output directory (if it does not exist)'
+echo eos mkdir -p ${6}
+eos mkdir ${6}
+
+echo this is in ${localOutDir}
+ls  ${localOutDir}
+eos cp ${PWD}/${localOutDir}/tree_Friend_${3}.chunk${4}.root ${6}/
+
+echo i think i am done...
+

--- a/WMass/python/postprocessing/condorMerging/mergeTrees.py
+++ b/WMass/python/postprocessing/condorMerging/mergeTrees.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
             tmp_f = open(options.directory+'/'+sd+'/treeProducerWMass/tree.root.url','r')
             tmp_root = tmp_f.readlines()[0].replace('\n','')
             dss[dsname]['files'  ] .append(tmp_root)
-            dss[dsname]['chunks' ] .append(options.directory+'/'+sd)
+            dss[dsname]['chunks' ] .append(os.path.abspath(options.directory+'/'+sd))
             if dss[dsname]['avgsize'][1] < 100: ## only calculate avg on the first 100
                 newavgsize = getAverageFileSize('/'.join(tmp_root.split('/')[3:]), dss[dsname]['avgsize'])
                 dss[dsname]['avgsize'] = newavgsize

--- a/WMass/python/postprocessing/condorMerging/submitFriendsCondor.py
+++ b/WMass/python/postprocessing/condorMerging/submitFriendsCondor.py
@@ -1,0 +1,94 @@
+import ROOT, commands, os, sys, optparse, datetime
+
+
+## USAGE:
+## ====================================
+## python submitFriendsCondor.py -d <inputDirMainTrees> -o <outputDirFriends>
+
+## the input directory must have all the main trees in it
+## the output directory on eos does not necessarily have to exist
+
+if __name__ == '__main__':
+
+    parser = optparse.OptionParser(usage='usage: python %prog -d dirWithTrees -o targetDirForFriends ', version='%prog 1.0')
+    parser.add_option('-d', '--directory' , type=str, default=''     , help='directory with the main trees inside. has to be given')
+    parser.add_option('-N', '--nperjob'   , type=int, default=250000 , help='number of entries to process per job (default: %default)')
+    parser.add_option('-o', '--targetdir' , type=str, default=''     , help='target directory for the output. has to be given')
+    (options, args) = parser.parse_args()
+
+    if not options.targetdir:
+        print 'no target directory given... exiting'
+        sys.exit(0)
+    if not options.directory:
+        print 'no source directory given... exiting'
+        sys.exit(0)
+
+    cmsenv = os.environ['CMSSW_BASE']
+
+    dss = {}
+
+    for isd,sd in enumerate(os.listdir(options.directory)):
+        fp = options.directory+'/'+sd
+        tmp_f = fp+'/treeProducerWMass/tree.root'
+        
+        ## a few checks to do to avoid random files in the directory
+        if not os.path.isdir(fp): 
+            continue
+        if not os.path.isfile(tmp_f): 
+            continue
+
+        try:
+            ## get the number of entries for each dataset
+            tmp_f = ROOT.TFile(tmp_f, 'READ')
+            tmp_t = tmp_f.Get('tree')
+            tmp_n = tmp_t.GetEntries()
+
+            dss[sd] = tmp_n
+
+            tmp_f.Close()
+        except:
+            print 'something went wrong trying to get the number of events for sample', sd
+            print 'i\'m moving on...'
+            continue
+
+    date = datetime.date.today().isoformat()
+    condorSubmitCommands = []
+    totalNumberOfJobs = 0
+    for ds,nds in dss.items():
+        n_chunks = int(nds/options.nperjob + (nds%options.nperjob > 1) ) ## this should definitely work, right?
+        print 'for dataset {d} i will submit {n} chunks'.format(d=ds,n=n_chunks)
+        tmp_condor_filename = 'logs/condor_friends_{ds}_{d}.condor'.format(ds=ds,d=date)
+        tmp_condor = open(tmp_condor_filename,'w')
+        tmp_condor.write('''Executable = friendsScript.sh
+use_x509userproxy = $ENV(X509_USER_PROXY)
+Log        = logs/log_condor_{ds}.log
+Output     = logs/log_condor_{ds}.out
+Error      = logs/log_condor_{ds}.error
+getenv      = True
+
+environment = "LS_SUBCWD={here}"
+request_memory = 4000
++MaxRuntime = 43200 \n\n'''.format(ds=ds, here=os.environ['PWD']))
+        while n_chunks:
+            totalNumberOfJobs += 1
+            n_chunks -= 1 ## otherwise over counting...
+            tmp_condor.write('arguments = {cmssw} {treedir} {ds} {chunk} {n} {td}\n'.format(cmssw=cmsenv,
+                             treedir=os.path.abspath(options.directory+'/'+ds), 
+                             ds=ds, 
+                             chunk=n_chunks, 
+                             n=options.nperjob,
+                             td=options.targetdir)  )
+            tmp_condor.write('queue 1\n\n')
+        tmp_condor.close()
+        condorSubmitCommands.append('condor_submit {cf}'.format(cf=tmp_condor_filename))
+
+    print 'this will result in a total of {n} jobs'.format(n=len(totalNumberOfJobs))
+    print 'submitting to condor...'
+    for sc in condorSubmitCommands:
+        print sc
+        os.system(sc)
+    print '...done'
+
+        
+
+


### PR DESCRIPTION
this script copies all the files locally to the node and then runs the postproc_batch.py locally. then it copies the output friend tree to the specified path.

also beneficial is the fact that it does not make hundreds of jobs that clog the condor_q, but spawns the jobs.

also a small update in the main tree merger, which allows now to give relative paths for where the directories are.