### PR TITLE
Strict check feature

### DIFF
--- a/WMass/cfg/run_wmass_cfg.py
+++ b/WMass/cfg/run_wmass_cfg.py
@@ -312,7 +312,7 @@ if scaleProdToLumi>0: # select only a subset of a sample, corresponding to a giv
         c.fineSplitFactor = 1
 
 
-if runData: # and not isTest: # For running on data
+if runData != False: # and not isTest: # For running on data
 
     is50ns = False
     dataChunks = []
@@ -320,9 +320,14 @@ if runData: # and not isTest: # For running on data
     json = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt' # 36.5/fb
 
     run_ranges = []; useAAA=False;
-    processing = "Run2016B-07Aug17_ver2-v1"; short = "Run2016B"; dataChunks.append((json,processing,short,run_ranges,useAAA))
-    for era in 'CDEFGH':
-        processing = "Run2016%s-07Aug17-v1" % era; short = "Run2016%s" % era; dataChunks.append((json,processing,short,run_ranges,useAAA))
+    eras='BCDEFGH'
+    if runData in eras:
+        eras=runData    
+    for era in eras:
+        if era=='B':
+            processing = "Run2016B-07Aug17_ver2-v1"; short = "Run2016B"; dataChunks.append((json,processing,short,run_ranges,useAAA))
+        else:
+            processing = "Run2016%s-07Aug17-v1" % era; short = "Run2016%s" % era; dataChunks.append((json,processing,short,run_ranges,useAAA))
     
     DatasetsAndTriggers = []
     selectedComponents = [];
@@ -366,7 +371,8 @@ if runData: # and not isTest: # For running on data
                     from CMGTools.Production.promptRecoRunRangeFilter import filterComponent
                     filterComponent(comp, verbose=1)
                 print "Will process %s (%d files)" % (comp.name, len(comp.files))
-                comp.splitFactor = len(comp.files)/3
+                #comp.splitFactor = len(comp.files)/3
+                comp.splitFactor = len(comp.files)/2
                 comp.fineSplitFactor = 1
                 selectedComponents.append( comp )
             if exclusiveDatasets: vetos += triggers

--- a/WMass/python/postprocessing/condorMerging/fullMergeTrees.py
+++ b/WMass/python/postprocessing/condorMerging/fullMergeTrees.py
@@ -15,7 +15,7 @@ print 'STATUS: copying the directory structure onto worker node'
 for d in dirsToCopy:
     os.system('cp -r {d} . '.format(d=d))
 
-if not opt.skipCheck:
+if not options.skipCheck:
 
     ## running cmgListChunks to check for incomplete directories
     print 'STATUS: checking for failed directories with cmgListChunksToResub'

--- a/WMass/python/postprocessing/condorMerging/mergeScript.sh
+++ b/WMass/python/postprocessing/condorMerging/mergeScript.sh
@@ -26,5 +26,11 @@ echo mkdir -p $4
 ##mkdir -p $4
 eos mkdir $4
 
+
+skipCheckOPT=""
+if [ "$5" == "True" ]; then
+    skipCheckOPT="--skipCheck"
+fi
+
 echo 'will run the full merge python script'
-python ../fullMergeTrees.py -p $2 -d $3 -o $4
+python ../fullMergeTrees.py -p $2 -d $3 -o $4 ${skipCheckOPT}

--- a/WMass/python/postprocessing/condorMerging/mergeTrees.py
+++ b/WMass/python/postprocessing/condorMerging/mergeTrees.py
@@ -16,12 +16,28 @@ def getAverageFileSize(p, thing):
     retval = [newavg, n+1]
     return retval
 
+def checkIntegrity(url):
+    """check if file is not corrupted"""
+    f=ROOT.TFile.Open(url)
+    try:
+        if f.IsZombie():    
+            raise UserWarning(url,'is probably corrupted')
+        if f.TestBit(ROOT.TFile.kRecovered):
+            raise UserWarning(url,'is in fishy state, was recovered')
+        if f.GetListOfKeys().GetSize()==0:
+            raise UserWarning(url,'has no keys...fishy...')
+    except:
+        raise UserWarning(url,'is unusable at all')
+    f.Close()
+
 if __name__ == '__main__':
 
     parser = optparse.OptionParser(usage='usage: %prog [opts] ', version='%prog 1.0')
-    parser.add_option('-d', '--directory', type=str, default='', help='directory with the output directories')
-    parser.add_option('-m', '--maxsize'  , type=int, default=6 , help='maximum size of the output parts. default 6 gb')
-    parser.add_option('-o', '--targetdir', type=str, default='', help='target directory for the output')
+    parser.add_option('-d', '--directory', type=str, default='',    help='directory with the output directories [%default]')
+    parser.add_option(      '--strict',              default=False, help='perform a strict check on the integrity of the root files [%default]', action='store_true')
+    parser.add_option(      '--dryRun',              default=False, help='dry run (do not submit to condor) [%default]', action='store_true')
+    parser.add_option('-m', '--maxsize'  , type=int, default=6 ,    help='maximum size of the output parts. [%default] gb')
+    parser.add_option('-o', '--targetdir', type=str, default='',    help='target directory for the output [%default]')
     (options, args) = parser.parse_args()
 
     if not options.targetdir:
@@ -30,12 +46,16 @@ if __name__ == '__main__':
     if not options.directory:
         print 'no source directory given... exiting'
         sys.exit(0)
-
+    if options.strict:
+        print 'Will perform a strict integrity check on every single file'
+        print 'Submitted jobs won\'t perform check'
+        
     cmsenv = os.environ['CMSSW_BASE']
 
     datasets = set()
     dss = {}
 
+    badChunksList=[]
     for isd,sd in enumerate(os.listdir(options.directory)):
         if not 'Chunk' in sd: continue
         if not os.path.isdir(options.directory+'/'+sd): continue
@@ -50,13 +70,18 @@ if __name__ == '__main__':
             ## this is basically already a check for processed chunks
             tmp_f = open(options.directory+'/'+sd+'/treeProducerWMass/tree.root.url','r')
             tmp_root = tmp_f.readlines()[0].replace('\n','')
+            if options.strict:
+                checkIntegrity(tmp_root)
             dss[dsname]['files'  ] .append(tmp_root)
             dss[dsname]['chunks' ] .append(options.directory+'/'+sd)
             if dss[dsname]['avgsize'][1] < 100: ## only calculate avg on the first 100
                 newavgsize = getAverageFileSize('/'.join(tmp_root.split('/')[3:]), dss[dsname]['avgsize'])
                 dss[dsname]['avgsize'] = newavgsize
             tmp_f.close()
-        except:
+        except UserWarning as uw:
+            badChunksList.append(options.directory+'/'+sd)
+            continue
+        except Exception:
             continue
 
     date = datetime.date.today().isoformat()
@@ -81,7 +106,7 @@ request_memory = 4000
         n_part = 1
         while len(dss[ds]['chunks']):
             chunks = ','.join(dss[ds]['chunks'][:n_chunksPerPart])
-            tmp_condor.write('arguments = {cmssw} {n} {chunks} {td}\n'.format(cmssw=cmsenv,n=n_part,chunks=chunks,td=options.targetdir))
+            tmp_condor.write('arguments = {cmssw} {n} {chunks} {td} {strict}\n'.format(cmssw=cmsenv,n=n_part,chunks=chunks,td=options.targetdir,strict=options.strict))
             tmp_condor.write('queue 1\n\n')
             ## now remove the chunks from the list that are in this job:
             dss[ds]['chunks'] = dss[ds]['chunks'][n_chunksPerPart:]
@@ -89,10 +114,20 @@ request_memory = 4000
         tmp_condor.close()
         condorSubmitCommands.append('condor_submit {cf}'.format(cf=tmp_condor_filename))
 
-    print 'submitting to condor...'
-    for sc in condorSubmitCommands:
-        print sc
-        os.system(sc)
+    if options.dryRun:
+        print 'this was just a dry run...'
+    else:
+        print 'submitting to condor...'
+        for sc in condorSubmitCommands:
+            print sc
+            os.system(sc)
+
+    #list files to resubmit
+    print 'Listing files to resubmit below'
+    for f in badChunksList:
+        print 'cmgResubChunk -q HTCondor -t 4000 %s'%f
+
+
     print '...done'
 
         


### PR DESCRIPTION
If you run python mergeTrees.py blabla --strict
it will now try to open every single file and check if it is zombie, if has the recovered bit on, no keys or fails to open completely, and prints out at the end a list in style of cmgListChunksToResub
If --strict is passed the check is disabled in the nodes when fullMergeTrees.py is called
This is because the only thing cmgListChunksToResub does is to check the JSON files but sometimes, even if they are not there the ROOT file is just fine