### PR TITLE
Use TXNetFile and AsyncReading to open the ROOT file to pick the counter histo

### DIFF
--- a/WMass/python/plotter/archiveTreeDirOnAFS.py
+++ b/WMass/python/plotter/archiveTreeDirOnAFS.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# USAGE: python archiveTreeDirOnAFS.py EOSDIR AFSDIR
+
+import os, subprocess
+from optparse import OptionParser
+
+if __name__ == "__main__":
+
+    usage="%prog [options] eosdir afsdir"
+    
+    parser = OptionParser(usage=usage)
+    parser.add_option("-t", dest="treeproducername", type='string', default="treeProducerWMass", help='Name of the tree producer module')
+    parser.add_option("-f", dest="friendtreedir", type='string', default="friends", help='String identifying friend trees directory')
+    parser.add_option("-T", dest="treename", type='string', default="tree.root", help='Name of the tree file')
+    (options, args) = parser.parse_args()
+    if len(args)<2: raise RuntimeError, 'Expecting at least two arguments'
+    
+    eosdir = args[0]
+    afsdir = args[1]
+    
+    treedir = os.path.basename(eosdir)
+    if not os.path.isdir(eosdir):
+            rsync = "rsync -avz --exclude '*.root' {source} {destination}".format(source=eosdir,destination=afsdir)
+            print "Giving rsync command: ",rsync
+            os.system(rsync)
+    
+    alldsets = os.listdir(eosdir)
+    dsets = [d for d in alldsets if options.friendtreedir not in d and '.txt' not in d]
+    friends = os.listdir(eosdir+'/'+options.friendtreedir)
+    
+    for d in dsets:
+            url = "root://eoscms.cern.ch/{eosdir}/{dataset}/{treeproducername}/{treename}\n".format(eosdir=eosdir,dataset=d,treeproducername=options.treeproducername,treename=options.treename)
+            furl = open('{afsdir}/{treedir}/{dataset}/{treeproducername}/{treename}.url'.format(afsdir=afsdir,treedir=treedir,dataset=d,treeproducername=options.treeproducername,treename=options.treename),'w')
+            furl.write(url)
+            furl.close()
+    for f in friends:
+            friendurl = 'root://eoscms.cern.ch/{eosdir}/{frienddir}/{friendfile}\n'.format(eosdir=eosdir,frienddir=options.friendtreedir,friendfile=f)
+            furl = open('{afsdir}/{treedir}/{frienddir}/{friendfile}.url'.format(afsdir=afsdir,treedir=treedir,frienddir=options.friendtreedir,friendfile=f),'w')
+            furl.write(friendurl)
+            furl.close()
+            
+    print "AFS tree structure in {afsdir}/{treedir}".format(afsdir=afsdir,treedir=treedir)

--- a/WMass/python/plotter/mcAnalysis.py
+++ b/WMass/python/plotter/mcAnalysis.py
@@ -196,7 +196,8 @@ class MCAnalysis:
                 else                     : self._allData[pname] =     [tty]
                 if "data" not in pname:
                     ## get the counts from the histograms instead of pickle file
-                    tmp_rootfile = ROOT.TFile.Open(rootfile, 'READ')
+                    ROOT.gEnv.SetValue("TFile.AsyncReading", 1);
+                    tmp_rootfile = ROOT.TXNetFile(rootfile+"?readaheadsz=65535")
                     histo_count        = tmp_rootfile.Get('Count')
                     histo_sumgenweight = tmp_rootfile.Get('SumGenWeights')
                     n_count        = histo_count       .GetBinContent(1)

--- a/WMass/python/plotter/tree2yield.py
+++ b/WMass/python/plotter/tree2yield.py
@@ -237,7 +237,7 @@ class TreeToYield:
 #            ROOT.gEnv.SetValue("XNet.Debug", -1); # suppress output about opening connections
             #self._tfile = ROOT.TFile.Open(self._fname+"?readaheadsz=200000") # worse than 65k
             #self._tfile = ROOT.TFile.Open(self._fname+"?readaheadsz=32768") # worse than 65k
-            self._tfile = ROOT.TFile.Open(self._fname+"?readaheadsz=65535") # good
+            self._tfile = ROOT.TXNetFile(self._fname+"?readaheadsz=65535") # good
             #self._tfile = ROOT.TFile.Open(self._fname+"?readaheadsz=0") #worse than 65k
         else:
             self._tfile = ROOT.TFile.Open(self._fname)


### PR DESCRIPTION
also using TXNetFile instead of TFile.Open in tree2yield. 
**no comments please**

Also, adding a script to recreate the directory structure in AFS substituting both the main tree and the friend with the .url files. Should help when mcAnalysis looks for the parts of a component with listdir. 
Usage:

`python archiveTreeDirOnAFS.py EOSDIR AFSDIR   `