### PR TITLE
Update to use the correlated xsec stat error from TF fit

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -120,9 +120,9 @@ def combCharges(options):
         os.system(txt2hdf5Cmd)
         ## print out the command to run in combine
         if options.freezePOIs:
-            combineCmd = 'combinetf.py --POIMode none -t -1 {metafile}'.format(metafile=combinedCard.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
+            combineCmd = 'combinetf.py --POIMode none -t -1 --binByBinStat --correlateXsecStat {metafile}'.format(metafile=combinedCard.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
         else:
-            combineCmd = 'combinetf.py -t -1 {metafile}'.format(metafile=combinedCard.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
+            combineCmd = 'combinetf.py -t -1 --binByBinStat --correlateXsecStat {metafile}'.format(metafile=combinedCard.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
         print combineCmd
 
 if __name__ == "__main__":
@@ -660,9 +660,9 @@ if __name__ == "__main__":
         os.system(txt2hdf5Cmd)
         ## print out the command to run in combine
         if options.freezePOIs:
-            combineCmd = 'combinetf.py --POIMode none -t -1 {metafile}'.format(metafile=cardfile_xsec.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
+            combineCmd = 'combinetf.py --POIMode none -t -1 --binByBinStat --correlateXsecStat {metafile}'.format(metafile=cardfile_xsec.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
         else:
-            combineCmd = 'combinetf.py -t -1 {metafile}'.format(metafile=cardfile_xsec.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
+            combineCmd = 'combinetf.py -t -1 --binByBinStat --correlateXsecStat {metafile}'.format(metafile=cardfile_xsec.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
         print combineCmd
     # end of loop over charges
 

--- a/WMass/python/plotter/w-helicity-13TeV/submitToys.py
+++ b/WMass/python/plotter/w-helicity-13TeV/submitToys.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
 
         tmp_filecont = jobstring_tf
         #cmd = 'text2tf.py -t {n} --seed {j}{jn} {dc}'.format(n=int(options.nTj),dc=os.path.abspath(workspace),j=j*int(options.nTj)+1,jn=(j+1)*int(options.nTj)+1)
-        cmd = 'combinetf.py -t {n} --seed {j}{jn} {dc} --nThreads {nthr}'.format(n=int(options.nTj),dc=os.path.abspath(workspace),j=j*int(options.nTj)+1,jn=(j+1)*int(options.nTj)+1,nthr=options.nThreads)
+        cmd = 'combinetf.py -t {n} --seed {j}{jn} {dc} --nThreads {nthr} --binByBinStat --correlateXsecStat'.format(n=int(options.nTj),dc=os.path.abspath(workspace),j=j*int(options.nTj)+1,jn=(j+1)*int(options.nTj)+1,nthr=options.nThreads)
         if fixPOIs: cmd += ' --POIMode none '
         tmp_filecont = tmp_filecont.replace('COMBINESTRING', cmd)
         tmp_filecont = tmp_filecont.replace('CMSSWBASE', os.environ['CMSSW_BASE']+'/src/')


### PR DESCRIPTION
Trivial change to put GEN yields in place of xsec in pb in the masked channel datacards, to make use of the correlated statistical uncertainty from MC implemented by @bendavid in https://github.com/WMass/HiggsAnalysis-CombinedLimit/pull/18 .

This is the default now. To revert to the previous behaviour, use "--xsecMaskedYields" option.

With the new default, one should use 

`combinetf.py card.hdf5 -t -1 --binByBinStat --correlateXsecStat`

to include the partial correlation of stat uncertainties, as from Josh prescription... 

