### PR TITLE
Updates and fixes: largely speeding up running on tree with toys

### DIFF
--- a/WMass/python/plotter/runplotsElectron.sh
+++ b/WMass/python/plotter/runplotsElectron.sh
@@ -94,7 +94,7 @@ fi
 #useHLTpt27="y" # already in selection txt file
 runBatch="y"
 queueForBatch="cmscaf1nd"
-nameTag="_FRpol2" 
+nameTag="_testTreeAFS" 
 #nameTag="_varStudy"
 useLessMC="n"
 useSkimmedTrees="y" # skimmed samples are on both pccmsrm28 and eos 
@@ -229,7 +229,7 @@ regionKey["FRcheckRegion"]="FRcheckRegion"
 runRegion["FRcheckRegion"]="y"
 regionName["FRcheckRegion"]="FR_check_region"
 #skimTreeDir["FRcheckRegion"]="TREES_electrons_1l_V6_TINY"
-skimTreeDir["FRcheckRegion"]="TREES_1LEP_80X_V3_WSKIM_NEW"
+skimTreeDir["FRcheckRegion"]="TREE_4_XSEC_AFS"
 outputDir["FRcheckRegion"]="full2016data_${today}"
 regionCuts["FRcheckRegion"]=" -X nJet30 ${FRnumSel} ${fiducial} ${ptMax/XX/45} ${mtMax/XX/30}"
 #processManager["FRcheckRegion"]=" --xp W,WFlips,TauDecaysW "
@@ -273,12 +273,15 @@ scaleMCdata["WmassSignalRegion"]="--fitData"
 regionKey["WhelicitySignalRegion"]="WhelicitySignalRegion"
 runRegion["WhelicitySignalRegion"]="y"
 regionName["WhelicitySignalRegion"]="whelicity_signal_region"
-#skimTreeDir["WhelicitySignalRegion"]="TREES_1LEP_80X_V3_WENUSKIM_V5_TINY" ## ADD _TINY, uness you want trkmet variables
-skimTreeDir["WhelicitySignalRegion"]="TREES_1LEP_80X_V3_WSKIM_NEW" 
+#skimTreeDir["WhelicitySignalRegion"]="TREES_1LEP_80X_V3_WSKIM_NEW" 
+#skimTreeDir["WhelicitySignalRegion"]="TREES_electrons_1l_V6_TINY" 
+skimTreeDir["WhelicitySignalRegion"]="TREE_4_XSEC_AFS" 
 outputDir["WhelicitySignalRegion"]="full2016data_${today}"
 regionCuts["WhelicitySignalRegion"]=" -X nJet30  ${fiducial} ${ptMax/XX/45} ${FRnumSel} ${mtMin/XX/40}" # "${WselAllPt} ${WselFull}" "${mtMinSmear/XX/40}"
 qcdFromFR["WhelicitySignalRegion"]="y"
 scaleMCdata["WhelicitySignalRegion"]=" -p data,W,data_fakes,Z,TauDecaysW,Top,DiBosons,WFlips  "
+#scaleMCdata["WhelicitySignalRegion"]=" -p data_fakes  "
+#scaleMCdata["WhelicitySignalRegion"]=" -p W  "
 #--noLegendRatioPlot --canvasSize 3000 750 --setTitleYoffset 0.3" #--scaleSigToData --sp data_fakes " # --pg 'EWK := Wincl,Z,Top,Dibosons'
 #
 # data_fakes,Z,TauDecaysW,Top,DiBosons,WFlips
@@ -428,7 +431,7 @@ fi
 # otherwise the parsing of the option parameters is not done correctly
 
 
-commonCommand="python ${plotterPath}/mcPlots.py -f -l ${luminosity} --s2v --tree treeProducerWMass --obj tree --lspam '#bf{CMS} #it{Preliminary}' --legendWidth 0.25 --legendFontSize 0.05 ${plotterPath}/w-helicity-13TeV/wmass_e/${mcafile} ${plotterPath}/w-helicity-13TeV/wmass_e/${cutfile} ${plotterPath}/w-helicity-13TeV/wmass_e/${plotfile} ${dataOption} ${plottingMode} --noCms"
+commonCommand="python ${plotterPath}/mcPlots.py -f -l ${luminosity} --s2v --tree treeProducerWMass --obj tree --lspam '#bf{CMS} #it{Preliminary}' --legendWidth 0.25 --legendFontSize 0.05 ${plotterPath}/w-helicity-13TeV/wmass_e/${mcafile} ${plotterPath}/w-helicity-13TeV/wmass_e/${cutfile} ${plotterPath}/w-helicity-13TeV/wmass_e/${plotfile} ${dataOption} ${plottingMode} --noCms "
 
 # if [[ "X${scaleAllMCtoData}" != "X" ]]; then
 #     commonCommand="${commonCommand} ${scaleAllMCtoData} "
@@ -522,10 +525,17 @@ do
 	    treepath="/eos/cms/store/cmst3/group/wmass/mciprian/"
 	fi
 
+	if [[ "${treedir}" == "TREES_1LEP_80X_V3_SIGSKIM_WENU_FULLSEL_NOMT" ]]; then		
+	    treepath="/eos/cms/store/cmst3/group/wmass/mciprian/"
+	fi
+
 	if [[ "${treedir}" == "TREES_electrons_1l_V6_TINY" ]]; then		
 	    treepath="/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/"
 	fi
 
+	if [[ "${treedir}" == "TREE_4_XSEC_AFS" ]]; then		
+	    treepath="/afs/cern.ch/work/m/mciprian/w_mass_analysis/heppy/CMSSW_8_0_25/src/CMGTools/WMass/python/plotter/"
+	fi
 
 
 	#treeAndFriend=" -P ${treepath}/${treedir}/ -F Friends ${treepath}/${treedir}/friends/tree_Friend_{cname}.root -F Friends ${treepath}/${treedir}/friends/tree_FRFriend_{cname}.root --FMC Friends ${treepath}/${treedir}/friends/tree_TrgFriend_{cname}.root "

--- a/WMass/python/plotter/w-helicity-13TeV/makeNewBranchToyTree.py
+++ b/WMass/python/plotter/w-helicity-13TeV/makeNewBranchToyTree.py
@@ -1,0 +1,113 @@
+#!/bin/env python
+
+# python w-helicity-13TeV/makeNewBranchToyTree.py -i toys/diffXsec_mu_2018_09_25_group10_legacySF/comb_WchargeAsymmetry/toys_comb_WchargeAsymmetry.root -c mu
+
+
+import ROOT, os, sys, re, array, math
+from array import array
+
+from make_diff_xsec_cards import getDiffXsecBinning
+from make_diff_xsec_cards import templateBinning
+
+sys.path.append(os.getcwd() + "/plotUtils/")
+from utility import *
+
+ROOT.gROOT.SetBatch(True)
+
+import utilities
+utilities = utilities.util()
+
+if __name__ == "__main__":
+
+
+    from optparse import OptionParser
+    parser = OptionParser(usage='%prog [options]')
+    parser.add_option('-i','--inputfile', dest='infile', default='', type='string', help='input root file with toys')
+    parser.add_option('-o','--outdir', dest='outdir', default='SAME', type='string', help='output directory to save things (same folder as input toy file if SAME')
+    parser.add_option('-t','--tree', dest='tree', default='fitresults', type='string', help='name of tree inside file')
+    #parser.add_option('-c','--channel', dest='channel', default='', type='string', help='name of the channel (mu or el)')
+    parser.add_option('-n','--name', dest='name', default='toyFriend.root', type='string', help='name of output file')
+    #parser.add_option('-v','--verbose', dest='verbose', default=False, action="store_true", type='string', help='Verbose mode, will print event number')
+    (options, args) = parser.parse_args()
+
+    ROOT.TH1.SetDefaultSumw2()
+    
+    # channel = options.channel
+    # if channel not in ["el","mu"]:
+    #     print "Error: unknown channel %s (select 'el' or 'mu')" % channel
+    #     quit()
+
+    if options.outdir:
+        outname = options.outdir
+        if outname == "SAME":
+            outname = os.path.dirname(options.infile) + "/"
+        else:
+            addStringToEnd(outname,"/",notAddIfEndswithMatch=True)        
+            createPlotDirAndCopyPhp(outname)
+    else:
+        print "Error: you should specify an output folder using option -o <name>. Exit"
+        quit()
+
+    if not options.infile:
+        print "Error: you should specify a file containing the toys using option -i <name>. Exit"
+        quit()
+
+
+    fin = ROOT.TFile(options.infile, 'read')
+    tree = fin.Get(options.tree)
+    if not tree:
+        print "Error: could not read tree in file"
+        quit()
+    lok  = tree.GetListOfLeaves()
+
+
+    fout = ROOT.TFile( outname+options.name, 'recreate' )    
+    t = ROOT.TTree( 'toyFriend', 'friend tree for toys' )
+    totxsec_plus  = array( 'f', [ 0. ] )
+    totxsec_minus = array( 'f', [ 0. ] )
+
+    t.Branch( 'totxsec_plus' , totxsec_plus , 'totxsec_plus/F' )
+    t.Branch( 'totxsec_minus', totxsec_minus, 'totxsec_minus/F' )
+
+    # for i in range(tree.GetEntries()):
+    #     totxsec_plus[0]  = -1. * i
+    #     totxsec_minus[0] = i
+    #     #print "%.1f  %.1f" % (totxsec_plus[0], totxsec_minus[0])
+    #     fillStatus = t.Fill()
+    #     #print "fillStatus = %d" % fillStatus
+
+    lok_pruned = []
+    for p in lok:
+        pname = p.GetName()
+        if not pname.endswith("_pmaskedexp"): continue
+        if "outliers" in pname: continue  # use only bins inside acceptance for the total xsec (it only exists for diff.xsec in pt-|eta|)              
+        lok_pruned.append(p)
+
+    print "I filtered {fin} elements out of {init}".format(fin=str(len(lok_pruned)),init=str(len(lok)))
+
+    nEvents = tree.GetEntries()
+    for i,ev in enumerate(tree):
+
+        sum_plus = 0
+        sum_minus = 0
+        sys.stdout.write('Event {num}/{tot}   \r'.format(num=i,tot=nEvents))
+        sys.stdout.flush()
+
+        # loop on leaves (branches)
+        for p in lok_pruned:  
+            pname = p.GetName()
+            #if not pname.endswith("_pmaskedexp"): continue
+            #if "outliers" in pname: continue  # use only bins inside acceptance for the total xsec (it only exists for diff.xsec in pt-|eta|)
+            #print "pname = %s" % pname
+            if "plus"    in pname: sum_plus += getattr(ev, pname)
+            elif "minus" in pname: sum_minus += getattr(ev, pname)
+            #Wplus_{ch}_ieta_{ieta}_ipt_{ipt}_Wplus_{ch}_group_{ig}_pmaskedexp example for POI's name for diff.xsec
+        totxsec_plus[0] = sum_plus
+        totxsec_minus[0] = sum_minus
+        t.Fill()
+
+    # fout.Write()
+    t.Write()    
+    fout.Close()
+
+    fin.Close()

--- a/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
@@ -1,0 +1,329 @@
+#!/bin/env python
+
+# python w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py -i cards/diffXsec_mu_2018_07_11_group10_coarseBin/ -o plots/diffXsec/chargeAsymmetry/muon/ -c mu -t toys/diffXsec_mu_2018_07_11_group10_coarseBin/toys_comb_WchargeAsymmetry.root -n
+
+import ROOT, os, sys, re, array, math
+
+from make_diff_xsec_cards import getDiffXsecBinning
+from make_diff_xsec_cards import templateBinning
+
+sys.path.append(os.getcwd() + "/plotUtils/")
+from utility import *
+
+ROOT.gROOT.SetBatch(True)
+
+import utilities
+utilities = utilities.util()
+
+
+def getTH1fromTH2(h2D,h2Derr=0,unrollAlongX=True):  # unrollAlongX=True --> select rows, i.e. takes a stripe from x1 to xn at same y, then go to next stripe at next y
+    nX = h2D.GetNbinsX()
+    nY = h2D.GetNbinsY()
+    nbins = nX * nY
+    name = h2D.GetName() + "_unrollTo1D" 
+    newh = ROOT.TH1D(name,h2D.GetTitle(),nbins,0.5,nbins+0.5)
+    if 'TH2' not in h2D.ClassName(): raise RuntimeError, "Calling getTH1fromTH2 on something that is not TH2"
+    for i in xrange(nX):
+        for j in xrange(nY):
+            if unrollAlongX:
+                bin = 1 + i + j * nX
+            else:
+                bin = 1 + j + i * nY
+            newh.SetBinContent(bin,h2D.GetBinContent(i+1,j+1))
+            if h2Derr: newh.SetBinError(bin,h2Derr.GetBinContent(i+1,j+1))
+            else:      newh.SetBinError(bin,h2D.GetBinError(i+1,j+1))
+    return newh
+
+
+
+if __name__ == "__main__":
+
+
+    from optparse import OptionParser
+    parser = OptionParser(usage='%prog [options]')
+    parser.add_option('-i','--input', dest='inputdir', default='', type='string', help='input directory with all the cards inside. It is used to get other information')
+    parser.add_option('-o','--outdir', dest='outdir', default='', type='string', help='output directory to save things')
+    parser.add_option('-t','--toyfile', dest='toyfile', default='.', type='string', help='Root file with toys.')
+    parser.add_option('-c','--channel', dest='channel', default='', type='string', help='name of the channel (mu or el)')
+    parser.add_option('-f','--friend', dest='friend', default='', type='string', help='Root file with friend tree containing total xsec (it does not include the outliers). Tree name is assumed to be "toyFriend"')
+    parser.add_option('-n','--norm-width', dest='normWidth' , default=False , action='store_true',   help='Normalize cross section histograms dividing by bin width')
+    parser.add_option(     '--hessian', dest='hessian' , default=False , action='store_true',   help='The file passed with -t is interpreted as hessian: will provide the central value of charge asymmetry but not the uncertainty, and will not plot the differential cross section')
+    (options, args) = parser.parse_args()
+
+    ROOT.TH1.SetDefaultSumw2()
+    
+    channel = options.channel
+    if channel not in ["el","mu"]:
+        print "Error: unknown channel %s (select 'el' or 'mu')" % channel
+        quit()
+
+    if options.outdir:
+        outname = options.outdir
+        addStringToEnd(outname,"/",notAddIfEndswithMatch=True)
+        if options.hessian: outname = outname + "/hessian/"
+        else              : outname = outname + "/toys/"
+        createPlotDirAndCopyPhp(outname)
+    else:
+        print "Error: you should specify an output folder using option -o <name>. Exit"
+        quit()
+
+    if not options.toyfile:
+        print "Error: you should specify a file containing the toys using option -t <name>. Exit"
+        quit()
+
+
+    if options.inputdir:
+        if not options.inputdir.endswith("/"): options.inputdir += "/"
+        basedir = os.path.basename(os.path.normpath(options.inputdir))
+        binfile = options.inputdir + "binningPtEta.txt"
+        if "_group" in basedir:
+            tokens = basedir.split("_")
+            for x in tokens:
+                if "group" in x:
+                    #ngroup = int("".join(str(s) for s in x if s.isdigit()))
+                    ngroup = int(x.split("group")[1])
+        else:
+            ngroup = 1 
+    else:
+        print "Error: you should specify an input folder containing all the cards using option -i <name>. Exit"
+        quit()
+
+    etaPtBinningVec = getDiffXsecBinning(binfile, "gen")
+    genBins  = templateBinning(etaPtBinningVec[0],etaPtBinningVec[1])
+    netabins = genBins.Neta
+    nptbins  = genBins.Npt
+
+    lepton = "electron" if channel == "el" else "muon"
+    Wchannel = "W #rightarrow %s#nu" % ("e" if channel == "el" else "#mu")
+
+    hChAsymm = ROOT.TH2F("hChAsymm_{lep}".format(lep=lepton),"Charge asymmetry: {Wch}".format(Wch=Wchannel),
+                         genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
+    hChAsymmErr = ROOT.TH2F("hChAsymmErr_{lep}".format(lep=lepton),"Charge asymmetry uncertainty: {Wch}".format(Wch=Wchannel),
+                            genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
+    
+
+    nbins = genBins.Neta * genBins.Npt
+    binCount = 1        
+    print "Now filling histograms with charge asymmetry"
+
+    f = ROOT.TFile(options.toyfile, 'read')
+    tree = f.Get('fitresults')
+    if options.friend != "":
+        tree.AddFriend('toyFriend',options.friend)
+
+    for ieta in range(1,genBins.Neta+1):
+        for ipt in range(1,genBins.Npt+1):
+            #print "\rBin {num}/{tot}".format(num=binCount,tot=nbins),
+            sys.stdout.write('Bin {num}/{tot}   \r'.format(num=binCount,tot=nbins))
+            sys.stdout.flush()
+            binCount += 1
+
+            if options.hessian: 
+                central = utilities.getDiffXsecAsymmetryFromHessian(channel,ieta-1,ipt-1,genBins.Neta,ngroup,options.toyfile)
+            else:                
+                central,up,down = utilities.getDiffXsecAsymmetryFromToysFast(channel,ieta-1,ipt-1,genBins.Neta,ngroup,
+                                                                             nHistBins=2000, minHist=0., maxHist=1.0, tree=tree)
+                #central,up,down = utilities.getDiffXsecAsymmetryFromToys(channel,ieta-1,ipt-1,genBins.Neta,ngroup,options.toyfile)
+                error = up - central
+                hChAsymm.SetBinError(ieta,ipt,error)         
+                hChAsymmErr.SetBinContent(ieta,ipt,error)
+            hChAsymm.SetBinContent(ieta,ipt,central)        
+            
+
+
+    setTDRStyle()
+
+    canvas = ROOT.TCanvas("canvas","",800,700)
+
+    xaxisTitle = 'gen %s |#eta|' % lepton
+    yaxisTitle = 'gen %s p_{T} [GeV]' % lepton
+    #zaxisTitle = "Asymmetry::%.3f,%.3f" % (hChAsymm.GetMinimum(),hChAsymm.GetMaximum())
+    zaxisTitle = "Asymmetry::0.05,0.35"
+    if channel == "el": zaxisTitle = "Asymmetry::0.05,0.35"
+    drawCorrelationPlot(hChAsymm,
+                        xaxisTitle, yaxisTitle, zaxisTitle,
+                        hChAsymm.GetName(),
+                        "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+    if not options.hessian:
+
+        zaxisTitle = "Asymmetry uncertainty::%.3f,%.3f" % (max(0,0.99*hChAsymmErr.GetMinimum()),min(0.10,1.01*hChAsymmErr.GetMaximum()))
+        #zaxisTitle = "Asymmetry uncertainty::0,0.04" 
+        drawCorrelationPlot(hChAsymmErr,
+                            xaxisTitle, yaxisTitle, zaxisTitle,
+                            hChAsymmErr.GetName(),
+                            "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+        hChAsymmRelErr = hChAsymmErr.Clone(hChAsymmErr.GetName().replace("AsymmErr","AsymmRelErr"))
+        hChAsymmRelErr.Divide(hChAsymm)
+        hChAsymmRelErr.SetTitle(hChAsymmErr.GetTitle().replace("uncertainty","rel. uncertainty"))
+        zaxisTitle = "Asymmetry relative uncertainty::%.3f,%.3f" % (max(0,0.99*hChAsymmRelErr.GetBinContent(hChAsymmRelErr.GetMinimumBin())),
+                                                                    min(0.12,1.01*hChAsymmRelErr.GetBinContent(hChAsymmRelErr.GetMaximumBin()))
+                                                                    )
+        zaxisTitle = "Asymmetry relative uncertainty::0.01,0.3" 
+        drawCorrelationPlot(hChAsymmRelErr,
+                            xaxisTitle, yaxisTitle, zaxisTitle,
+                            hChAsymmRelErr.GetName(),
+                            "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+
+    else:
+        print "You used option --hessian, so I will quit now."
+        print "If you want to plot the differential cross section as well, you can directly use 'w-helicity-13TeV/plotDiffXsecFromFit.py'"
+        quit()
+        # stop here with hessian for now
+        # for the hessian cross section you can use w-helicity-13TeV/plotDiffXsecFromFit.py
+
+
+    for charge in ["plus","minus"]:
+
+        xaxisTitle = 'gen %s |#eta|' % lepton  # it will be modified later, so I have to restore it here
+
+
+        chargeSign = "+" if charge == "plus" else "-"
+
+        hDiffXsec = ROOT.TH2F("hDiffXsec_{lep}_{ch}".format(lep=lepton,ch=charge),
+                              "cross section: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
+                              genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
+        hDiffXsecErr = ROOT.TH2F("hDiffXsecErr_{lep}_{ch}".format(lep=lepton,ch=charge),
+                                 "cross section uncertainty: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
+                                 genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
+        hDiffXsecNorm = ROOT.TH2F("hDiffXsecNorm_{lep}_{ch}".format(lep=lepton,ch=charge),
+                                  "normalized cross section: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
+                                  genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
+        hDiffXsecNormErr = ROOT.TH2F("hDiffXsecNormErr_{lep}_{ch}".format(lep=lepton,ch=charge),
+                                     "normalized cross section uncertainty: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
+                                     genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
+
+        nbins = genBins.Neta * genBins.Npt
+        binCount = 1        
+        print "Now filling histograms with differential cross section (charge = %s)" % charge
+
+
+        denExpression = ""
+        if options.friend != "":
+            denExpression = "totxsec_" + charge
+        else:
+            denExpression = utilities.getDenExpressionForNormDiffXsec(channel, charge, genBins.Neta,genBins.Npt, ngroup)
+
+
+        for ieta in range(1,genBins.Neta+1):
+            for ipt in range(1,genBins.Npt+1):
+
+                #print "\rBin {num}/{tot}".format(num=binCount,tot=nbins),
+                sys.stdout.write('Bin {num}/{tot}   \r'.format(num=binCount,tot=nbins))
+                sys.stdout.flush()
+                binCount += 1
+
+                # normalized cross section
+                #central,up,down = utilities.getNormalizedDiffXsecFromToys(channel,charge,
+                #                                                          ieta-1,ipt-1,genBins.Neta,genBins.Npt,
+                #                                                          ngroup,options.toyfile,denExpression, options.friend)
+                central,up,down = utilities.getNormalizedDiffXsecFromToysFast(channel,charge,
+                                                                              ieta-1,ipt-1,genBins.Neta,genBins.Npt,
+                                                                              ngroup,denExpression, nHistBins=1000, minHist=0., maxHist=0.1, tree=tree)
+
+
+                error = up - central
+                hDiffXsecNorm.SetBinContent(ieta,ipt,central)        
+                hDiffXsecNorm.SetBinError(ieta,ipt,error)         
+                hDiffXsecNormErr.SetBinContent(ieta,ipt,error)
+                
+                # unnormalized cross section
+                central,up,down = utilities.getDiffXsecFromToysFast(channel,charge,ieta-1,ipt-1,genBins.Neta,genBins.Npt,ngroup,
+                                                                    nHistBins=2000, minHist=0., maxHist=200., tree=tree)
+                error = up - central
+                hDiffXsec.SetBinContent(ieta,ipt,central)        
+                hDiffXsec.SetBinError(ieta,ipt,error)         
+                hDiffXsecErr.SetBinContent(ieta,ipt,error)
+
+
+
+
+        if options.normWidth:
+            hDiffXsec.Scale(1.,"width")
+            hDiffXsecErr.Scale(1.,"width")
+            hDiffXsecNorm.Scale(1.,"width")
+            hDiffXsecNormErr.Scale(1.,"width")
+
+        hDiffXsecRelErr = hDiffXsecErr.Clone(hDiffXsecErr.GetName().replace('XsecErr','XsecRelErr'))
+        hDiffXsecRelErr.Divide(hDiffXsec)
+        hDiffXsecRelErr.SetTitle(hDiffXsecErr.GetTitle().replace('uncertainty','rel.unc.'))
+
+        hDiffXsecNormRelErr = hDiffXsecNormErr.Clone(hDiffXsecNormErr.GetName().replace('XsecNormErr','XsecNormRelErr'))
+        hDiffXsecNormRelErr.Divide(hDiffXsecNorm)
+        hDiffXsecNormRelErr.SetTitle(hDiffXsecNormErr.GetTitle().replace('uncertainty','rel.unc.'))
+
+        # now starting to draw the cross sections
+
+        if charge == "plus": zmin,zmax = 30,120
+        else:                zmin,zmax = 25,95
+        #zaxisTitle = "d#sigma / d#etadp_{T} [pb/GeV]::%.3f,%.3f" % (0.9*hDiffXsec.GetMinimum(),hDiffXsec.GetMaximum())
+        zaxisTitle = "d#sigma / d#etadp_{T} [pb/GeV]::%.3f,%.3f" % (zmin,zmax)
+        drawCorrelationPlot(hDiffXsec,
+                            xaxisTitle, yaxisTitle, zaxisTitle,
+                            hDiffXsec.GetName(),
+                            "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+        if charge == "plus": zmin,zmax = 0.5,4.5
+        else:                zmin,zmax = 0.5,3.5
+        zaxisTitle = "uncertainty on d#sigma / d#etadp_{T} [pb/GeV]::%.3f,%.3f" % (0.9*hDiffXsecErr.GetMinimum(),min(10,hDiffXsecErr.GetMaximum()))
+        #zaxisTitle = "uncertainty on d#sigma / d#etadp_{T} [pb/GeV]::%.3f,%.3f" % (zmin,zmax)
+        drawCorrelationPlot(hDiffXsecErr,
+                            xaxisTitle, yaxisTitle, zaxisTitle,
+                            hDiffXsecErr.GetName(),
+                            "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+        #zaxisTitle = "rel. uncertainty on d#sigma / d#etadp_{T}::%.3f,%.3f" % (0.9*hDiffXsecRelErr.GetMinimum(),hDiffXsecRelErr.GetMaximum())
+        zaxisTitle = "rel. uncertainty on d#sigma / d#etadp_{T}::0.025,0.1"
+        drawCorrelationPlot(hDiffXsecRelErr,
+                            xaxisTitle, yaxisTitle, zaxisTitle,
+                            hDiffXsecRelErr.GetName(),
+                            "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+        if charge == "plus": zmin,zmax = 0.008,0.028
+        else:                zmin,zmax = 0.008,0.029
+        #zaxisTitle = "d#sigma / d#etadp_{T} / #sigma_{tot}::%.3f,%.3f" % (0.9*hDiffXsecNorm.GetMinimum(),hDiffXsecNorm.GetMaximum())
+        zaxisTitle = "d#sigma / d#etadp_{T} / #sigma_{tot}::%.3f,%.3f" % (zmin,zmax)
+        drawCorrelationPlot(hDiffXsecNorm,
+                            xaxisTitle, yaxisTitle, zaxisTitle,
+                            hDiffXsecNorm.GetName(),
+                            "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+        if charge == "plus": zmin,zmax = 0.0,0.0015
+        else:                zmin,zmax = 0.0,0.0015
+        #zaxisTitle = "uncertainty on d#sigma / d#etadp_{T} / #sigma_{tot}::%.3f,%.3f" % (0.9*hDiffXsecNormErr.GetMinimum(),hDiffXsecNormErr.GetMaximum())
+        zaxisTitle = "uncertainty on d#sigma / d#etadp_{T} / #sigma_{tot}::%.3f,%.3f" % (zmin,zmax)
+        drawCorrelationPlot(hDiffXsecNormErr,
+                            xaxisTitle, yaxisTitle, zaxisTitle,
+                            hDiffXsecNormErr.GetName(),
+                            "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+        zaxisTitle = "rel. uncertainty on d#sigma / d#etadp_{T} / #sigma_{tot}::%.3f,%.3f" % (0.9*hDiffXsecNormRelErr.GetMinimum(),min(0.1,hDiffXsecNormRelErr.GetBinContent(hDiffXsecNormRelErr.GetMaximumBin())))
+        #zaxisTitle = "rel. uncertainty on d#sigma / d#etadp_{T} / #sigma_{tot}::0,0.1"
+        drawCorrelationPlot(hDiffXsecNormRelErr,
+                            xaxisTitle, yaxisTitle, zaxisTitle,
+                            hDiffXsecNormRelErr.GetName(),
+                            "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas)
+
+
+
+######
+        # now drawing a TH1 unrolling TH2
+        unrollAlongEta = False
+        xaxisTitle = "template global bin"
+        if unrollAlongEta:
+            xaxisTitle = xaxisTitle + " = 1 + ieta + ipt * %d; ipt in [%d,%d], ieta in [%d,%d]" % (netabins-1,0,nptbins-1,0,netabins-1)
+        else:
+            xaxisTitle = xaxisTitle + " = 1 + ipt + ieta * %d; ipt in [%d,%d], ieta in [%d,%d]" % (nptbins-1,0,nptbins-1,0,netabins-1)
+        h1D_pmaskedexp = getTH1fromTH2(hDiffXsec, hDiffXsecErr, unrollAlongX=unrollAlongEta)        
+        drawSingleTH1(h1D_pmaskedexp,xaxisTitle,"d#sigma/d#etadp_{T} [pb/GeV]",
+                      "unrolledXsec_abs_{ch}_{fl}".format(ch= charge,fl=channel),
+                      outname,labelRatioTmp="Rel.Unc.::0.9,1.1",draw_both0_noLog1_onlyLog2=1,canvasSize="3000,2000")
+
+        h1D_pmaskedexp_norm = getTH1fromTH2(hDiffXsecNorm, hDiffXsecNormErr, unrollAlongX=unrollAlongEta)        
+        drawSingleTH1(h1D_pmaskedexp_norm,xaxisTitle,"d#sigma/d#etadp_{T} / #sigma_{tot} [1/GeV]",
+                      "unrolledXsec_norm_{ch}_{fl}".format(ch= charge,fl=channel),
+                      outname,labelRatioTmp="Rel.Unc.::0.9,1.1",draw_both0_noLog1_onlyLog2=1,canvasSize="3000,2000")
+
+

--- a/WMass/python/plotter/w-helicity-13TeV/plotParametersFromToys.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotParametersFromToys.py
@@ -24,7 +24,8 @@ lat = ROOT.TLatex(); lat.SetNDC()
 
 def plotPars(inputFile, pois=None, selectString='', maxPullsPerPlot=30, plotdir='./', suffix='', analysis='helicity', 
              excludeName=None, paramFamily=None,plotPull=False,
-             channel='el', charge='plus'):
+             channel='el', charge='plus',
+             selection=""):
  
     
 
@@ -35,21 +36,21 @@ def plotPars(inputFile, pois=None, selectString='', maxPullsPerPlot=30, plotdir=
     if paramFamily:
         if paramFamily == "pdf":
             pois="pdf.*"
-            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName)
+            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName,selection=selection)
         elif paramFamily == "scale":
             pois="muR,muF,muRmuF,alphaS,wptSlope" 
             if channel == "el":
                 pois += ",CMS_We_sig_lepeff,CMS_We_elescale,CMS_We_FRe_slope,CMS_We_FRe_continuous"
             else:
                 pois += ",CMS_Wmu_sig_lepeff,CMS_Wmu_muscale,CMS_Wmu_FRmu_slope,CMS_Wmu_FR_continuous"
-            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName)
+            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName,selection=selection)
         elif paramFamily == "signalStrength":
             pois="W{ch}.*_mu".format(ch=charge)
             isSignalStrength = True
-            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,200,0,2,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName)
+            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,200,0,2,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName,selection=selection)
         elif paramFamily == "absxsec":
             pois="W{ch}.*_pmaskedexp".format(ch=charge)
-            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,1000,0,200,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName)
+            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,1000,0,200,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName,selection=selection)
     else:
         # warning: utilities.getHistosFromToys is working only for parameters centered around 0 (histogram is defined in -3,3)
         # this script will not work if using parameters with pmaskedexp
@@ -59,11 +60,11 @@ def plotPars(inputFile, pois=None, selectString='', maxPullsPerPlot=30, plotdir=
                 print "You might want to change behaviour of function utilities.getHistosFromToys to use those parameters as well" 
                 exit(0)
         if any ([wc in poi for wc in ["Wplus","Wminus"] for poi in pois.split(",")]):
-            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,200,0,2,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName)
+            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,200,0,2,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName,selection=selection)
             if not any("pmaskedexp" in poi for poi in pois.split(",")):
                 isSignalStrength = True
         else:
-            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName)
+            all_valuesAndErrors = utilities.getHistosFromToys(inputFile,getPull=plotPull,matchBranch=pois,excludeBranch=excludeName,selection=selection)
             
 
     print "From the list of parameters it seems that you are plotting results for channel ",channel
@@ -207,8 +208,8 @@ def plotPars(inputFile, pois=None, selectString='', maxPullsPerPlot=30, plotdir=
         while nRemainingPulls > 0:
             nThisPulls = min(maxPullsPerPlot,nRemainingPulls)
 
-            pull_rms      = ROOT.TH1F("pull_rms"     ,"", 3*nThisPulls+1,0,nThisPulls*3+1);
-            pull_effsigma = ROOT.TH1F("pull_effsigma","", 3*nThisPulls+1,0,nThisPulls*3+1);
+            pull_rms      = ROOT.TH1F("pull_rms_{pp}".format(pp=str(pullPlots)) ,"", 3*nThisPulls+1,0,nThisPulls*3+1);
+            pull_effsigma = ROOT.TH1F("pull_effsigma_{pp}".format(pp=str(pullPlots)) ,"", 3*nThisPulls+1,0,nThisPulls*3+1);
             pi=1
             sortedpulls = []
             if 'pdf' in pois:
@@ -319,6 +320,7 @@ if __name__ == "__main__":
     parser.add_option(      '--suffix'      , dest='suffix'   , default=''     , type='string', help='suffix to give to the plot files')
     parser.add_option('-a', '--analysis'    , dest='analysis' , default='helicity', type='string', help='Which analysis: helicity or diffXsec') 
     parser.add_option(      '--pull'    , dest="plotpull", action="store_true", default=False, help="When making the pull plot, get really the pull from histogram (define histogram using (x-x_gen)/x_err for parameter x");
+    parser.add_option('-s',  '--selection'  , dest="selection", default="", help="Selection to apply when reading trees to make pull distributions");
     (options, args) = parser.parse_args()
 
     if len(args)<1: 
@@ -350,5 +352,6 @@ if __name__ == "__main__":
 
     toyfile = args[0]
     plotPars(toyfile,pois=options.pois,maxPullsPerPlot=30,plotdir=outname,suffix=options.suffix,analysis=options.analysis,
-             excludeName=options.excludeParam,paramFamily=options.poisFamily,plotPull=options.plotpull,channel=options.flavour,charge=options.charge)
+             excludeName=options.excludeParam,paramFamily=options.poisFamily,plotPull=options.plotpull,channel=options.flavour,charge=options.charge,
+             selection=options.selection)
 

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -318,6 +318,13 @@ class util:
         ret = self.getExprFromToysFast('diffXsec',expr,nHistBins, minHist, maxHist, tree=tree)
         return ret
 
+    def getDiffXsecAsymmetryFromToysFast(self, channel, ieta, ipt, netabins, ngroup, nHistBins=2000, minHist=0., maxHist=1.0, tree=None):
+        igroup = int(int(ieta + ipt * netabins)/ngroup)
+        xplus  = "Wplus_{ch}_ieta_{ieta}_ipt_{ipt}_Wplus_{ch}_group_{ig}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt,ig=igroup)
+        xminus = "Wminus_{ch}_ieta_{ieta}_ipt_{ipt}_Wminus_{ch}_group_{ig}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt,ig=igroup)
+        expr = '({pl}-{mn})/({pl}+{mn})'.format(pl=xplus,mn=xminus)
+        ret = self.getExprFromToysFast('chargeAsym',expr, nHistBins, minHist, maxHist, tree=tree)
+        return ret
 
     def getExprFromHessian(self, name, expression, infile):
         f = ROOT.TFile(infile, 'read')

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -229,16 +229,9 @@ class util:
         return _dict
 
 
-    def getExprFromToys(self, name, expression, infile, friendTree=""):
+    def getExprFromToys(self, name, expression, infile):
         f = ROOT.TFile(infile, 'read')
         tree = f.Get('fitresults')        
-        if friendTree != "":
-            tree.AddFriend('toyFriend',friendTree)
-            # ff = ROOT.TFile(friendTree, 'read')
-            # ft = f.Get('toyFriend')
-            # if ft == None:
-            #     print "Error in getExprFromToys(): cannot find friend tree, please check!"
-            #     quit()            
         tmp_hist = ROOT.TH1F(name,name, 100000, -100., 5000.)
         tree.Draw(expression+'>>'+name)
         mean = tmp_hist.GetMean()

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -188,7 +188,7 @@ class util:
 
         return _dict
 
-    def getHistosFromToys(self, infile, nbins=100, xlow=-3.0, xup=3.0, getPull=False, matchBranch=None,excludeBranch=None):
+    def getHistosFromToys(self, infile, nbins=100, xlow=-3.0, xup=3.0, getPull=False, matchBranch=None,excludeBranch=None, selection=""):
 
         # getPull = True will return a histogram centered at 0 and with expected rms=1, obtained as (x-x_gen)/x_err
 
@@ -213,13 +213,13 @@ class util:
                 tmp_hist_tmp = ROOT.TH1F(p.GetName()+"_tmp",p.GetName()+"_tmp", nbins, xlow, xup)
                 tmp_hist = ROOT.TH1F(p.GetName(),p.GetName(), 100, -3, 3)
                 expression = "({p}-{pgen})/{perr}".format(p=p.GetName(),pgen=p.GetName()+"_gen",perr=p.GetName()+"_err")
-                tree.Draw(expression+'>>'+p.GetName())
-                tree.Draw(p.GetName()+'>>'+p.GetName()+"_tmp")
+                tree.Draw(expression+'>>'+p.GetName(),selection)
+                tree.Draw(p.GetName()+'>>'+p.GetName()+"_tmp",selection)
                 mean = tmp_hist_tmp.GetMean()
                 err  = tmp_hist_tmp.GetRMS()
             else:
                 tmp_hist = ROOT.TH1F(p.GetName(),p.GetName(), nbins, xlow, xup)
-                tree.Draw(p.GetName()+'>>'+p.GetName())
+                tree.Draw(p.GetName()+'>>'+p.GetName(),selection)
                 mean = tmp_hist.GetMean()
                 err  = tmp_hist.GetRMS()
 
@@ -229,9 +229,16 @@ class util:
         return _dict
 
 
-    def getExprFromToys(self, name, expression, infile):
+    def getExprFromToys(self, name, expression, infile, friendTree=""):
         f = ROOT.TFile(infile, 'read')
         tree = f.Get('fitresults')        
+        if friendTree != "":
+            tree.AddFriend('toyFriend',friendTree)
+            # ff = ROOT.TFile(friendTree, 'read')
+            # ft = f.Get('toyFriend')
+            # if ft == None:
+            #     print "Error in getExprFromToys(): cannot find friend tree, please check!"
+            #     quit()            
         tmp_hist = ROOT.TH1F(name,name, 100000, -100., 5000.)
         tree.Draw(expression+'>>'+name)
         mean = tmp_hist.GetMean()
@@ -275,19 +282,42 @@ class util:
         den = "(" + den + ")"
         return den
 
-    def getNormalizedDiffXsecFromToys(self, channel, charge, ieta, ipt, netabins, nptbins, ngroup, infile,den):
+    def getNormalizedDiffXsecFromToys(self, channel, charge, ieta, ipt, netabins, nptbins, ngroup, infile, den, friendTree=""):
         igroup = int(int(ieta + ipt * netabins)/ngroup)
         num = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_group_{ig}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt,ig=igroup)
         #den = getDenExpressionForNormDiffXsec(channel, charge, netabins, nptbins, ngroup)
         expr = '{num}/{den}'.format(num=num,den=den)
-        ret = self.getExprFromToys('normDiffXsec',expr,infile)
+        ret = self.getExprFromToys('normDiffXsec',expr,infile, friendTree=friendTree)
         return ret
+
 
     def getDiffXsecFromToys(self, channel, charge, ieta, ipt, netabins, nptbins, ngroup, infile):
         igroup = int(int(ieta + ipt * netabins)/ngroup)
         expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_group_{ig}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt,ig=igroup)
         ret = self.getExprFromToys('diffXsec',expr,infile)
         return ret
+
+    def getExprFromToysFast(self, name, expression, nHistBins=100000, minHist=-100., maxHist=5000., tree=None):
+        tmp_hist = ROOT.TH1F(name,name, nHistBins, minHist, maxHist)
+        tree.Draw(expression+'>>'+name)
+        mean = tmp_hist.GetMean()
+        err  = tmp_hist.GetRMS()
+        return (mean, mean+err, mean-err)
+
+    def getNormalizedDiffXsecFromToysFast(self, channel, charge, ieta, ipt, netabins, nptbins, ngroup, den, nHistBins=1000, minHist=0., maxHist=0.1, tree=None):
+        igroup = int(int(ieta + ipt * netabins)/ngroup)
+        num = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_group_{ig}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt,ig=igroup)
+        #den = getDenExpressionForNormDiffXsec(channel, charge, netabins, nptbins, ngroup)
+        expr = '{num}/{den}'.format(num=num,den=den)
+        ret = self.getExprFromToysFast('normDiffXsec',expr, nHistBins, minHist, maxHist, tree=tree)
+        return ret
+
+    def getDiffXsecFromToysFast(self, channel, charge, ieta, ipt, netabins, nptbins, ngroup, nHistBins=2000, minHist=0., maxHist=200., tree=None):
+        igroup = int(int(ieta + ipt * netabins)/ngroup)
+        expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_group_{ig}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt,ig=igroup)
+        ret = self.getExprFromToysFast('diffXsec',expr,nHistBins, minHist, maxHist, tree=tree)
+        return ret
+
 
     def getExprFromHessian(self, name, expression, infile):
         f = ROOT.TFile(infile, 'read')

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -280,7 +280,7 @@ class util:
         num = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_group_{ig}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt,ig=igroup)
         #den = getDenExpressionForNormDiffXsec(channel, charge, netabins, nptbins, ngroup)
         expr = '{num}/{den}'.format(num=num,den=den)
-        ret = self.getExprFromToys('normDiffXsec',expr,infile, friendTree=friendTree)
+        ret = self.getExprFromToys('normDiffXsec',expr,infile)
         return ret
 
 

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_forPlots.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_forPlots.txt
@@ -123,46 +123,46 @@ EWK : WW+WW_ext : xsec;      FillColor=ROOT.kRed+2, Label="EWK", NormSystematic=
 EWK : WZ+WZ_ext : xsec; FillColor=ROOT.kRed+2, Label="EWK", NormSystematic=0.05
 EWK : ZZ+ZZ_ext : xsec; FillColor=ROOT.kRed+2, Label="EWK", NormSystematic=0.05
 
-EWK_bkg  : DYJetsToLL_M50_NLO* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
+EWK_bkg  : DYJetsToLL_M50_NLO* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
 #EWK_bkg  : NoSkim_WJetsToLNu_NLO* : 3.*20508.9    : genw_decayId != 12 && genw_decayId != 14 ; FillColor=ROOT.kSpring+9   ,  Label="W\#rightarrow\#tau\#nu", NormSystematic=0.038
-EWK_bkg  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.09
-EWK_bkg  : TTJets_SingleLeptonFromTbar_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.09
-EWK_bkg  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg  : T_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg  : TBar_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg  : T_tWch_ext :      xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.06
-EWK_bkg  : TBar_tWch_ext :   xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.06
-EWK_bkg : WW+WW_ext : xsec;      FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.03
-EWK_bkg : WZ+WZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.05
-EWK_bkg : ZZ+ZZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.05
+EWK_bkg  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.09
+EWK_bkg  : TTJets_SingleLeptonFromTbar_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.09
+EWK_bkg  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg  : T_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg  : TBar_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg  : T_tWch_ext :      xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.06
+EWK_bkg  : TBar_tWch_ext :   xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.06
+EWK_bkg : WW+WW_ext : xsec;      FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.03
+EWK_bkg : WZ+WZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.05
+EWK_bkg : ZZ+ZZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.05
 
 
-EWK_bkg_andTau  : DYJetsToLL_M50_NLO* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg_andTau  : NoSkim_WJetsToLNu_NLO* : 3.*20508.9    : genw_decayId != 12 && genw_decayId != 14 ; FillColor=ROOT.kSpring+9, Label="EWK bkg", NormSystematic=0.038
-EWK_bkg_andTau  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.09
-EWK_bkg_andTau  : TTJets_SingleLeptonFromTbar_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.09
-EWK_bkg_andTau  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg_andTau  : T_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg_andTau  : TBar_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg_andTau  : T_tWch_ext :      xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.06
-EWK_bkg_andTau  : TBar_tWch_ext :   xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.06
-EWK_bkg_andTau : WW+WW_ext : xsec;      FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.03
-EWK_bkg_andTau : WZ+WZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.05
-EWK_bkg_andTau : ZZ+ZZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.05
+EWK_bkg_andTau  : DYJetsToLL_M50_NLO* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg_andTau  : NoSkim_WJetsToLNu_NLO* : 3.*20508.9    : genw_decayId != 12 && genw_decayId != 14 ; FillColor=ROOT.kSpring+9, Label="EWK + top", NormSystematic=0.038
+EWK_bkg_andTau  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.09
+EWK_bkg_andTau  : TTJets_SingleLeptonFromTbar_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.09
+EWK_bkg_andTau  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg_andTau  : T_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg_andTau  : TBar_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg_andTau  : T_tWch_ext :      xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.06
+EWK_bkg_andTau  : TBar_tWch_ext :   xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.06
+EWK_bkg_andTau : WW+WW_ext : xsec;      FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.03
+EWK_bkg_andTau : WZ+WZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.05
+EWK_bkg_andTau : ZZ+ZZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.05
 
-EWK_bkg_Full  : DYJetsToLL_M50_NLO* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg_Full  : WJetsToLNu_NLO* : 3.*20508.9    : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge==-24 ; FillColor=ROOT.kAzure+2  , Label="EWK bkg"
-EWK_bkg_Full  : NoSkim_WJetsToLNu_NLO* : 3.*20508.9    : genw_decayId != 12 && genw_decayId != 14 ; FillColor=ROOT.kAzure+2   ,  Label="EWK bkg", NormSystematic=0.038
-EWK_bkg_Full  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.09
-EWK_bkg_Full  : TTJets_SingleLeptonFromTbar_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.09
-EWK_bkg_Full  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg_Full  : T_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg_Full  : TBar_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.04
-EWK_bkg_Full  : T_tWch_ext :      xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.06
-EWK_bkg_Full  : TBar_tWch_ext :   xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.06
-EWK_bkg_Full : WW+WW_ext : xsec;      FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.03
-EWK_bkg_Full : WZ+WZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.05
-EWK_bkg_Full : ZZ+ZZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK bkg", NormSystematic=0.05
+EWK_bkg_Full  : DYJetsToLL_M50_NLO* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg_Full  : WJetsToLNu_NLO* : 3.*20508.9    : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge==-24 ; FillColor=ROOT.kAzure+2  , Label="EWK + top"
+EWK_bkg_Full  : NoSkim_WJetsToLNu_NLO* : 3.*20508.9    : genw_decayId != 12 && genw_decayId != 14 ; FillColor=ROOT.kAzure+2   ,  Label="EWK + top", NormSystematic=0.038
+EWK_bkg_Full  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.09
+EWK_bkg_Full  : TTJets_SingleLeptonFromTbar_* :  xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.09
+EWK_bkg_Full  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg_Full  : T_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg_Full  : TBar_tch_powheg_part* :     xsec;  FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.04
+EWK_bkg_Full  : T_tWch_ext :      xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.06
+EWK_bkg_Full  : TBar_tWch_ext :   xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.06
+EWK_bkg_Full : WW+WW_ext : xsec;      FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.03
+EWK_bkg_Full : WZ+WZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.05
+EWK_bkg_Full : ZZ+ZZ_ext : xsec; FillColor=ROOT.kAzure+2, Label="EWK + top", NormSystematic=0.05
 
 # 
 W_nomi   : WJetsToLNu_NLO_* :  3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kBlack, Label="W", NormSystematic=0.001

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-includes/mca-80X-wenu-bkgmc.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-includes/mca-80X-wenu-bkgmc.txt
@@ -1,6 +1,6 @@
 
-Top         : TTJets_SingleLeptonFromT_part*         : xsec;                                      FillColor=ROOT.kGreen+2,  Label="Top",      NormSystematic=0.09
-Top         : TTJets_SingleLeptonFromTbar_part*      : xsec;                                      FillColor=ROOT.kGreen+2,  Label="Top",      NormSystematic=0.09
+Top         : TTJets_SingleLeptonFromT_*             : xsec;                                      FillColor=ROOT.kGreen+2,  Label="Top",      NormSystematic=0.09
+Top         : TTJets_SingleLeptonFromTbar_*          : xsec;                                      FillColor=ROOT.kGreen+2,  Label="Top",      NormSystematic=0.09
 Top         : TToLeptons_sch_amcatnlo                : xsec;                                      FillColor=ROOT.kGreen+2,  Label="Top",      NormSystematic=0.04
 Top         : T_tch_powheg_part*                     : xsec;                                      FillColor=ROOT.kGreen+2,  Label="Top",      NormSystematic=0.04
 Top         : TBar_tch_powheg_part*                  : xsec;                                      FillColor=ROOT.kGreen+2,  Label="Top",      NormSystematic=0.04

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/skimming/tests/mca-80X-skimsFR_31July2018.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/skimming/tests/mca-80X-skimsFR_31July2018.txt
@@ -1,14 +1,14 @@
 # signal from the weighted uncut sample should not be skimmed
 #W    : WJetsToLNu_* : 3.*20508.9  ; FillColor=ROOT.kGray+1   , Label="W"
-Z    : DYJetsToLL_M50_part* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
-Z    : DYJetsToLL_M50_ext2_part* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
-# Top  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
-# Top  : TTJets_SingleLeptonFromTbar_* :  xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
-# Top  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.04
-# Top  : T_tch_powheg_part* :     xsec;  FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.04
-# Top  : TBar_tch_powheg_part* :     xsec;  FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.04
-# Top  : T_tWch_ext :      xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.06
-# Top  : TBar_tWch_ext :   xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.06
+#Z    : DYJetsToLL_M50_part* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
+#Z    : DYJetsToLL_M50_ext2_part* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
+Top  : TTJets_SingleLeptonFromT_* :  xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
+Top  : TTJets_SingleLeptonFromTbar_* :  xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.09
+Top  : TToLeptons_sch_amcatnlo :      xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.04
+Top  : T_tch_powheg_part* :     xsec;  FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.04
+Top  : TBar_tch_powheg_part* :     xsec;  FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.04
+Top  : T_tWch_ext :      xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.06
+Top  : TBar_tWch_ext :   xsec; FillColor=ROOT.kGray+2, Label="Top", NormSystematic=0.06
 # DiBosons : WW+WW_ext : xsec;      FillColor=ROOT.kViolet+2, Label="DiBosons", NormSystematic=0.03
 # DiBosons : WZ+WZ_ext : xsec; FillColor=ROOT.kViolet+2, Label="DiBosons", NormSystematic=0.05
 # DiBosons : ZZ+ZZ_ext : xsec; FillColor=ROOT.kViolet+2, Label="DiBosons", NormSystematic=0.05

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/skimming/tests/wenu-80X-skim_fullsel.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/skimming/tests/wenu-80X-skim_fullsel.txt
@@ -1,5 +1,5 @@
 alwaystrue: 1
-genEle: abs(prefsrw_decayId) == 12
+#genEle: abs(prefsrw_decayId) == 12
 HLT_SingleEL : HLT_BIT_HLT_Ele27_WPTight_Gsf_v == 1
 onelep : nLepGood == 1 && abs(LepGood1_pdgId)==11
 eleKin : ptElFull(LepGood1_calPt,LepGood1_eta) >= 30 && ptElFull(LepGood1_calPt,LepGood1_eta) < 45 && abs(LepGood1_eta)<2.5

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/test_plots.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/test_plots.txt
@@ -22,7 +22,7 @@ ptl1_narrow: ptElFull(LepGood1_calPt,LepGood1_eta): 30,30,45 ; XTitle="electron 
 etal1: LepGood1_eta: 50,-2.5,2.5 ; XTitle="leading electron #eta", Legend='TL', IncludeOverflows=False
 etal1_varBin: LepGood1_eta: [-2.5,-2.25,-2.0,-1.8,-1.566,-1.4442,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4442,1.566,1.8,2.0,2.25,2.5] ; XTitle="leading electron #eta", Legend='TL', IncludeOverflows=False
 absetal1_binFR: abs(LepGood1_eta): [0.0,0.3,0.6,0.9,1.2,1.479,1.7,1.9,2.1,2.3,2.5]; XTitle="leading electron |#eta|", Legend='TL', IncludeOverflows=False
-etal1_binFR: LepGood1_eta: [-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.6,-1.566,-1.4442,-1.4,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.4442,1.566,1.6,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5]; XTitle="electron #eta", Legend='TL', IncludeOverflows=False
+etal1_binFR: LepGood1_eta: [-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.6,-1.566,-1.4442,-1.4,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.4442,1.566,1.6,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5]; XTitle="electron #eta", Legend='TC', IncludeOverflows=False
 
 ptl1_range: ptElFull(LepGood1_calPt,LepGood1_eta): 100,40,50 ; XTitle="leading electron p_{T} [GeV]", Legend='TR', IncludeOverflows=False
 ptl1_granBin: ptElFull(LepGood1_calPt,LepGood1_eta): 100,30,55 ; XTitle="leading electron p_{T} [GeV]", Legend='TR', IncludeOverflows=False


### PR DESCRIPTION
Most of the stuff is an update for the differential xsection.

Common stuff:

**w-helicity-13TeV/DatacardsChecker.py**
Adding option to split logs, errs and outs in different folders (useful for me)
Also adding "next_job_start_delay = 1"  in condor configuration

**w-helicity-13TeV/makeNewBranchToyTree.py**
new script to make a friend tree for toys, for example containing the total cross section, to speed up production of plots from toys
It should work out of the box also for the POI's name for helicity but should be checked
It is a little slow to run but it is really worth the time

**w-helicity-13TeV/utilities.py**
Adding new functions to speed up flow to read tree.
There are two independent items that were improved:
1) Use new script makeNewBranchToyTree.py to make a tree with total xsection for each charge (for diffxsec, this improves time to make normalized cross section plot by factor ~5
2) Open file and read tree OUTSIDE function getExprFromToys(), and avoid defining  100k bins for the histogram, better to pass Nbins and range from outside as well, tuned on specific needs
I found this to improve running time by factor ~10 !
I created a new function **getExprFromToysFast()** that features these items, which I am using with new functions **getNormalizedDiffXsecFromToysFast()** and others (expression for denominator can be defined once outside the function, or it can be taken from the friend tree)
You can see usage inside **w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py**, which I use for all the plots

