### PR TITLE
fix DatacardsChecker.py

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/DatacardsChecker.py
+++ b/WMass/python/plotter/w-helicity-13TeV/DatacardsChecker.py
@@ -18,6 +18,7 @@ class CardsChecker:
         for f in os.listdir(card_dir+'/jobs/'):
             if not f.endswith('.sh'): 
                 continue
+            if "dummy_exec" in f: continue
             key = f.replace('.sh','')
             tmp_f = open(card_dir+'/jobs/'+f, 'r')
             lines = tmp_f.readlines()
@@ -57,10 +58,13 @@ class CardsChecker:
         condor_file_name = jobdir+'/condor_submit.condor'
         condor_file = open(condor_file_name,'w')
         if splitdir:
+            os.system("mkdir -p {jd}/logs/".format(jd=self.resub_card_dir))
+            os.system("mkdir -p {jd}/errs/".format(jd=self.resub_card_dir))
+            os.system("mkdir -p {jd}/errs/".format(jd=self.resub_card_dir))
             # write new logs overwriting the original ones for failed jobs
-            logdir = self.card_dir + "/logs/"
-            outdirCondor = self.card_dir + "/outs/"
-            errdir = self.card_dir + "/errs/"
+            logdir = self.resub_card_dir + "/logs/"
+            outdirCondor = self.resub_card_dir + "/outs/"
+            errdir = self.resub_card_dir + "/errs/"
             condor_file.write('''Universe = vanilla
 Executable = {de}
 use_x509userproxy = $ENV(X509_USER_PROXY)
@@ -132,7 +136,7 @@ request_memory = 4000
                     if not tfile or tfile.IsZombie():
                         if self.options.verbose>1: print '# ',f, ' is Zombie'
                         f_ok = False
-                    if len(tfile.GetListOfKeys()) < 0:
+                    elif tfile.GetNkeys() == 0:
                         if self.options.verbose>1: print '# WARNING',f, ' has no keys inside!!'
                         f_ok = False
 

--- a/WMass/python/plotter/w-helicity-13TeV/make_diff_xsec_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_diff_xsec_cards.py
@@ -264,7 +264,7 @@ def writeEfficiencyStatErrorSystsToMCA_diffXsec(mcafile,odir,channel,syst="EffSt
     open("%s/systEnv-dummy.txt" % odir, 'a').close()
     incl_file=getMcaIncl(mcafile,incl_mca)
     if len(incl_file)==0: 
-        print "Warning! '%s' include directive not found. Not adding pdf systematics samples to MCA file" % incl_mca
+        print "Warning! '%s' include directive not found. Not adding EffStat systematics samples to MCA file" % incl_mca
         return
     if append:
         filename = "%s/mca_systs.txt" % odir
@@ -374,7 +374,7 @@ queue 1\n
 def getShFile(jobdir, name):
     tmp_srcfile_name = jobdir+'/job_{i}.sh'.format(i=name)
     tmp_srcfile = open(tmp_srcfile_name, 'w')
-    tmp_srcfile.write("#! /bin/sh\n")
+    tmp_srcfile.write("#! /bin/bash\n")
     tmp_srcfile.write("ulimit -c 0 -S\n")
     tmp_srcfile.write("ulimit -c 0 -H\n")
     tmp_srcfile.write("cd {cmssw};\neval $(scramv1 runtime -sh);\ncd {d};\n".format( d= os.getcwd(), cmssw = os.environ['CMSSW_BASE']))


### PR DESCRIPTION
Skip dummy_exec.sh when reading .sh files to get headers
In case option --splitdir is used, recreate logs/, errs/, and outs/ folders in retry_XXX and use them to save new logs