### PR TITLE
Normalized xsecs with the correct variable from the Hessians

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -366,16 +366,12 @@ if __name__ == "__main__":
                     if   options.type == 'toys': 
                         xsec_fit = utilities.getNormalizedXsecFromToys(ybins,charge,pol,channel,iy,options.infile,MAXYFORNORM)
                     elif options.type == 'hessian':
-                        # to be correct, this shoould be done with _pmaskedexpnorm, but cannot exclude the outer bins
-                        xsec_fit = valuesAndErrors[parname+'_pmaskedexp']
-                        xsecnorm = sum(valuesAndErrors['W{charge}_{pol}_W{charge}_{pol}_{ch}_Ybin_{iy}_pmaskedexp'.format(charge=charge,pol=allpol,ch=channel,iy=tmpiy)][0] for allpol in ['left','right', 'long'] for tmpiy in xrange(len(ybins[cp])-nOuterBinsToExclude-1))
-                        scale = 1./xsecnorm
+                        xsec_fit = valuesAndErrors[parname+'_pmaskedexpnorm']
                     else:
                         print "--normxsec not implemented yet for scans."
                         sys.exit()
                 else:
-                    xsec_parname = parname+'_pmaskedexp'
-                    xsec_fit = valuesAndErrors[xsec_parname]
+                    xsec_fit = valuesAndErrors[parname+'_pmaskedexp']
                 
                 tmp_val.val_fit.append(xsec_fit[0]*scale/ybinwidths[cp][iy])
                 tmp_val.elo_fit.append(abs(xsec_fit[0]-xsec_fit[1])*scale/ybinwidths[cp][iy])


### PR DESCRIPTION
since with the separation of the masked channel w/o acceptance the error on the pmaskedexpnorm is OK, going back to use that (which has the correct error propagation) for Hessians @bendavid

Notes:
- the number of out-of-acceptance Y bins is hardcoded (14,15), while it should be read from the cards now. @emanueledimarco can try to do this tomorrow
- looking at the plots only Y bin 15 ([3-6]) needs to be separated
