### PR TITLE
postFitPlots update

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/postFitPlots.py
+++ b/WMass/python/plotter/w-helicity-13TeV/postFitPlots.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# USAGE: python postFitPlots.py wel_minus_floatPOI.root cards_el -o outputdir
+# USAGE: python postFitPlots.py wel_minus_floatPOI.root cards_el -o outputdir [--prefit]
 
 import ROOT, os, re
 from array import array
@@ -36,6 +36,7 @@ def roll1Dto2D(h1d, histo):  #,h2dname):#,plotfile,options):
         ybin = i / histo.GetNbinsX() + (1 if i%histo.GetNbinsX() else 0)
         val = h1d.GetBinContent(i)
         histo.SetBinContent(xbin,ybin,h1d.GetBinContent(i))
+        histo.SetBinError(xbin,ybin,h1d.GetBinError(i))
     return histo
 
 def unroll2Dto1D(h):
@@ -59,7 +60,7 @@ def unroll2Dto1D(h):
     newh.SetLineColor(h.GetLineColor())
     return newh
 
-def dressed2D(h1d,binning,name,title=''):
+def dressed2D(h1d,binning,name,title='',shift=0,nCharges=2,nMaskedCha=2):
     if len(binning) == 4:
         n1 = binning[0]; bins1 = array('d', binning[1])
         n2 = binning[2]; bins2 = array('d', binning[3])
@@ -68,12 +69,29 @@ def dressed2D(h1d,binning,name,title=''):
         n1 = binning[0]; min1 = binning[1]; max1 = binning[2]
         n2 = binning[3]; min2 = binning[4]; max2 = binning[5]
         h2_1 = ROOT.TH2F(name, title, n1, min1, max1, n2, min2, max2)
-    #h2_backrolled_1 = roll1Dto2D(h1_1, h2_1 )
-    h2_backrolled_1 = roll1Dto2D(h1d, h2_1 )
+    extrabins = 0 if 'obs' in h1d.GetName() else nCharges*nMaskedCha
+    nbins = int((h1d.GetNbinsX()-extrabins)/2)
+    h1d_shifted = ROOT.TH1D('shift','',nbins,1,nbins)
+    for b in xrange(nbins):
+        h1d_shifted.SetBinContent(b+1,h1d.GetBinContent(b+shift+1))
+        h1d_shifted.SetBinError(b+1,h1d.GetBinError(b+shift+1))
+    h2_backrolled_1 = roll1Dto2D(h1d_shifted, h2_1 )
     h2_backrolled_1 .GetXaxis().SetTitle('lepton #eta')
     h2_backrolled_1 .GetYaxis().SetTitle('lepton p_{T} (GeV)')
     h2_backrolled_1 .GetZaxis().SetRangeUser(0.01*h2_backrolled_1.GetMaximum(),1.1*h2_backrolled_1.GetMaximum())
     return h2_backrolled_1
+
+def chargeUnrolledBinShifts(infile,nCharges=2,nMaskedCha=2):
+    # guess from a signal with charge defined name
+    h1d = infile.Get('expproc_Wplus_left_Wplus_left_el_Ybin_0_postfit')
+    # shift the 1D to remove the empty bins of the other charge
+    nbins = int((h1d.GetNbinsX()-nCharges*nMaskedCha)/2)
+    ret = {}
+    if h1d.Integral(0,nbins)==0:
+        ret = {'plus': nbins, 'minus': 0}
+    else:
+        ret = {'plus': 0, 'minus': nbins}
+    return ret
 
 def doRatioHists(data,total,maxRange,fixRange=False,ylabel="Data/pred.",yndiv=505,doWide=False,showStatTotLegend=False,textSize=0.035):
     ratio = data.Clone("data_div"); 
@@ -163,14 +181,17 @@ if __name__ == "__main__":
     parser = OptionParser(usage="%prog [options] fitresults.root cards_dir")
     parser.add_option('-o','--outdir', dest='outdir', default='.', type='string', help='output directory to save the matrix')
     parser.add_option(     '--no2Dplot', dest="no2Dplot", default=False, action='store_true', help="Do not plot templates (but you can still save them in a root file with option -s)");
-    parser.add_option('-s','--save', dest='outfile_templates', default='templates_2D', type='string', help='pass name of output file to save 2D histograms (charge is automatically appended before extension). No need to specify extension, .root is automatically addedx')
+    parser.add_option('-s','--save', dest='outfile_templates', default='templates_2D.root', type='string', help='pass name of output file to save 2D histograms (charge is automatically appended before extension). No need to specify extension, .root is automatically addedx')
     parser.add_option(     '--prefit', dest="prefit", default=False, action='store_true', help="");
     groupJobs=5 # used in make_helicity_cards.py
-
+    nCharges = 2; nMaskedChanPerCharge = 2; # edm hardcoded, but to be guessed 
+    
     (options, args) = parser.parse_args()
     if len(args) < 1:
         parser.print_usage()
         quit()
+
+    prepost = 'prefit' if options.prefit else 'postfit'
 
     ## get the binning of the YW bins
     ybinfile = args[1]+'/binningYW.txt'
@@ -185,14 +206,9 @@ if __name__ == "__main__":
 
     infile = ROOT.TFile(args[0], 'read')
     channel = 'el' if any(['el_Ybin' in k.GetName() for k in infile.GetListOfKeys()]) else 'mu'
-    charge = 'plus' if any(['Wplus' in k.GetName() for k in infile.GetListOfKeys()]) else 'minus'
-    print "From the list of histograms it seems that you are plotting results for channel ",channel," and charge ",charge
+    print "From the list of histograms it seems that you are plotting results for channel ",channel
 
     outfile_templates = options.outfile_templates
-    if outfile_templates.endswith(".root"):
-        outfile_templates = outfile_templates.replace(".root","_%s.root" % str(charge))
-    else:
-        outfile_templates = outfile_templates + "_" + str(charge) + ".root"
 
     full_outfileName = outname + "/" + outfile_templates
     outfile = ROOT.TFile(full_outfileName, 'recreate')
@@ -208,146 +224,155 @@ if __name__ == "__main__":
     nbinspt  = len( ptbins)-1
     binning = [nbinseta, etabins, nbinspt, ptbins]
 
+    shifts = chargeUnrolledBinShifts(infile,nCharges,nMaskedChanPerCharge)
+
     # doing signal
-    total_sig = {}
-    canv = ROOT.TCanvas()
-    for pol in ['right', 'left', 'long']:
-        print "\tPOLARIZATION ",pol
-        chpol = '{ch}_{pol}'.format(ch=charge,pol=pol)
-        nYbins=len(ybins[chpol])-1
-        #for ybin in range(1):
-        for ybin in range(nYbins): 
-
-            group = ybin/groupJobs + 1
-            jobind = min(groupJobs * group - 1,nYbins-1)
-            line = ybin%groupJobs
-            
-            ymin = ybins[chpol][ybin]
-            ymax = ybins[chpol][ybin+1]
-            
-
-            chs = '+' if charge == 'plus' else '-' 
-            h1_1 = infile.Get('expproc_W{ch}_{pol}_W{ch}_{pol}_{flav}_Ybin_{ybin}_postfit'.format(ch=charge,pol=pol,flav=channel,ybin=ybin))
-            name2D = 'W{ch}_{pol}_W{ch}_{pol}_{flav}_Ybin_{ybin}'.format(ch=charge,pol=pol,flav=channel,ybin=ybin)
-            title2D = 'W{ch} {pol} : |Y_{{W}}| #in [{ymin},{ymax}]'.format(ymin=ymin,ymax=ymax,pol=pol,ybin=ybin,ch=chs)
-            h2_backrolled_1 = dressed2D(h1_1,binning,name2D,title2D)
-            if ybin==0:
-                total_sig["W"+chpol] = h2_backrolled_1.Clone('W{ch}_{pol}_{flav}'.format(ch=charge,pol=pol,flav=channel))
-            else:
-                total_sig["W"+chpol].Add(h2_backrolled_1)
-            total_sig["W"+chpol].SetDirectory(None)
-            h2_backrolled_1.Draw('colz')
-            h2_backrolled_1.Write(name2D)
+    for charge in ['plus','minus']:
+        total_sig = {}
+        canv = ROOT.TCanvas()
+        binshift = shifts[charge]
+        for pol in ['right', 'left', 'long']:
+            print "\tPOLARIZATION ",pol
+            chpol = '{ch}_{pol}'.format(ch=charge,pol=pol)
+            nYbins=len(ybins[chpol])-1
+            #for ybin in range(1):
+            for ybin in range(nYbins): 
+     
+                group = ybin/groupJobs + 1
+                jobind = min(groupJobs * group - 1,nYbins-1)
+                line = ybin%groupJobs
+                
+                ymin = ybins[chpol][ybin]
+                ymax = ybins[chpol][ybin+1]
+     
+                chs = '+' if charge == 'plus' else '-' 
+                h1_1 = infile.Get('expproc_W{ch}_{pol}_W{ch}_{pol}_{flav}_Ybin_{ybin}_{sfx}'.format(ch=charge,pol=pol,flav=channel,ybin=ybin,sfx=prepost))
+                name2D = 'W{ch}_{pol}_W{ch}_{pol}_{flav}_Ybin_{ybin}'.format(ch=charge,pol=pol,flav=channel,ybin=ybin)
+                title2D = 'W{ch} {pol} : |Y_{{W}}| #in [{ymin},{ymax}]'.format(ymin=ymin,ymax=ymax,pol=pol,ybin=ybin,ch=chs)
+                h2_backrolled_1 = dressed2D(h1_1,binning,name2D,title2D,binshift)
+                if ybin==0:
+                    total_sig["W"+chpol] = h2_backrolled_1.Clone('W{ch}_{pol}_{flav}'.format(ch=charge,pol=pol,flav=channel))
+                else:
+                    total_sig["W"+chpol].Add(h2_backrolled_1)
+                total_sig["W"+chpol].SetDirectory(None)
+                h2_backrolled_1.Draw('colz')
+                h2_backrolled_1.Write(name2D)
+                if not options.no2Dplot:
+                    for ext in ['pdf', 'png']:
+                        canv.SaveAs('{odir}/W{ch}_{pol}_W{ch}_{flav}_Ybin_{ybin}_PFMT40_absY_{sfx}.{ext}'.format(odir=outname,ch=charge,flav=channel,pol=pol,ybin=ybin,sfx=prepost,ext=ext))
+            total_sig["W"+chpol].Draw('colz')
+            total_sig["W"+chpol].Write(total_sig["W"+chpol].GetName())
+     
             if not options.no2Dplot:
                 for ext in ['pdf', 'png']:
-                    canv.SaveAs('{odir}/W{ch}_{pol}_W{ch}_{flav}_Ybin_{ybin}_PFMT40_absY.{ext}'.format(odir=outname,ch=charge,flav=channel,pol=pol,ybin=ybin,ext=ext))
-        total_sig["W"+chpol].Draw('colz')
-        total_sig["W"+chpol].Write(total_sig["W"+chpol].GetName())
+                    canv.SaveAs('{odir}/W{ch}_{pol}_{flav}_TOTALSIG_PFMT40_absY_{sfx}.{ext}'.format(odir=outname,ch=charge,flav=channel,pol=pol,sfx=prepost,ext=ext))
 
-        if not options.no2Dplot:
+
+        # do backgrounds now
+        procs=["Flips","Z","Top","DiBosons","TauDecaysW","data_fakes","obs"]
+        titles=["charge flips","Drell-Yan","Top","di-bosons","W#rightarrow#tau#nu","QCD","toy data"]
+        procsAndTitles = dict(zip(procs,titles))
+        bkg_and_data = {}
+        for i,p in enumerate(procs):
+            h1_1 = infile.Get('expproc_{p}_{sfx}'.format(p=p,sfx=prepost)) if 'obs' not in p else infile.Get('obs')
+            if not h1_1: continue # muons don't have Flips components
+            h2_backrolled_1 = dressed2D(h1_1,binning,p,titles[i],binshift)
+            bkg_and_data[p] = h2_backrolled_1
+            bkg_and_data[p].SetDirectory(None)
+            h2_backrolled_1.Draw('colz')
+            h2_backrolled_1.Write(str(p))
+            if not options.no2Dplot:
+                for ext in ['pdf', 'png']:
+                    canv.SaveAs('{odir}/{proc}_{ch}_{flav}_PFMT40_absY_{sfx}.{ext}'.format(odir=outname,proc=p,ch=charge,flav=channel,sfx=prepost,ext=ext))
+                
+
+        # now draw the 1D projections
+        all_procs = total_sig.copy()
+        all_procs.update(bkg_and_data)
+        polsym = {'left': 'L', 'right': 'R', 'long': '0'}; chargesym={'plus':'+', 'minus':'-'}
+        for pol in ['right', 'left', 'long']:
+            procsAndTitles['W{ch}_{pol}'.format(ch=charge,pol=pol)] = 'W^{{{sign}}}_{{{pol}}}'.format(sign=chargesym[charge],pol=polsym[pol])
+     
+        colors = {'Wplus_long' : ROOT.kGray+1,   'Wplus_left' : ROOT.kBlue-1,   'Wplus_right' : ROOT.kGreen+1,
+                  'Wminus_long': ROOT.kYellow+1, 'Wminus_left': ROOT.kViolet-1, 'Wminus_right': ROOT.kAzure+1,
+                  'Top'        : ROOT.kGreen+2,  'DiBosons'   : ROOT.kViolet+2, 'TauDecaysW'  : ROOT.kPink,       
+                  'Z'          : ROOT.kAzure+2,  'Flips'      : ROOT.kGray+1,   'data_fakes'  : ROOT.kGray+2 }
+     
+        for p,h in all_procs.iteritems():
+            h.integral = h.Integral()
+
+        # this has the uncertainty propagated with the full covariance matrix
+        h1_expfull = infile.Get('expfull_{sfx}'.format(sfx=prepost))
+        h2_expfull_backrolled = dressed2D(h1_expfull,binning,'expfull','expfull',binshift)
+
+        for projection in ['X','Y']:
+            nbinsProj = all_procs['obs'].GetNbinsY() if projection=='X' else all_procs['obs'].GetNbinsX()
+            hexpfull = h2_expfull_backrolled.ProjectionX("x_expfull_{ch}".format(ch=charge),1,nbinsProj,"e") if projection=='X' else h2_expfull_backrolled.ProjectionY("y_expfull_{ch}".format(ch=charge),1,nbinsProj,"e")
+            hdata = all_procs['obs'].ProjectionX("x_data_{ch}".format(ch=charge),1,nbinsProj,"e") if projection=='X' else all_procs['obs'].ProjectionY("y_data_{ch}".format(ch=charge),1,nbinsProj,"e")
+            htot = hdata.Clone('tot'); htot.Reset(); htot.Sumw2()
+            stack = ROOT.THStack("stack","")
+            
+            legWidth=0.50; textSize=0.035
+            (x1,y1,x2,y2) = (.75-legWidth, .70, .85, .87)
+            leg = ROOT.TLegend(x1,y1,x2,y2)
+            leg.SetNColumns(3)
+            leg.SetFillColor(0)
+            leg.SetFillColorAlpha(0,0.6)
+            leg.SetShadowColor(0)
+            leg.SetLineColor(0)
+            leg.SetBorderSize(0)
+            leg.SetTextFont(42)
+            leg.SetTextSize(textSize)
+        
+            for key,histo in sorted(all_procs.iteritems(), key=lambda (k,v): (v.integral,k)):
+                if key=='obs': continue
+                proj1d = all_procs[key].ProjectionX(all_procs[key].GetName()+"_px",0,-1,"e") if  projection=='X' else all_procs[key].ProjectionY(all_procs[key].GetName()+"_py",0,-1,"e")
+                proj1d.SetFillColor(colors[key])
+                stack.Add(proj1d)
+                htot.Add(proj1d)                    
+                leg.AddEntry(proj1d,procsAndTitles[key],'F')
+     
+            leg.AddEntry(hdata,'toy data','PE')
+            
+            doRatio=True
+            htot.GetYaxis().SetRangeUser(0, 1.8*max(htot.GetMaximum(), hdata.GetMaximum()))
+            htot.GetYaxis().SetTitle('Events')
+         
+        
+            ## Prepare split screen
+            c1 = ROOT.TCanvas("c1", "c1", 600, 750); c1.Draw()
+            c1.SetWindowSize(600 + (600 - c1.GetWw()), (750 + (750 - c1.GetWh())));
+            ROOT.gStyle.SetPadLeftMargin(0.18)
+            p1 = ROOT.TPad("pad1","pad1",0,0.29,1,0.99);
+            p1.SetBottomMargin(0.03);
+            p1.Draw();
+            p2 = ROOT.TPad("pad2","pad2",0,0,1,0.31);
+            p2.SetTopMargin(0);
+            p2.SetBottomMargin(0.3);
+            p2.SetFillStyle(0);
+            p2.Draw();
+            p1.cd();
+            ## Draw absolute prediction in top frame
+            htot.Draw("HIST")
+            #htot.SetLabelOffset(9999.0);
+            #htot.SetTitleOffset(9999.0);
+            stack.Draw("HIST F SAME")
+            hdata.SetMarkerColor(ROOT.kBlack)
+            hdata.SetMarkerStyle(ROOT.kFullCircle)
+            hdata.Draw("E SAME")
+            htot.Draw("AXIS SAME")
+            totalError = doShadedUncertainty(htot)            
+            leg.Draw()
+            lat = ROOT.TLatex()
+            lat.SetNDC(); lat.SetTextFont(42)
+            lat.DrawLatex(0.16, 0.92, '#bf{CMS} #it{Preliminary}')
+            lat.DrawLatex(0.65, 0.92, '36 fb^{-1} (13 TeV)')
+     
+            p2.cd()
+            maxrange = [0.99,1.01] if prepost == 'postfit' else [0.90,1.10]
+            rdata,rnorm,rline = doRatioHists(hdata, hexpfull, maxRange=maxrange, fixRange=True)
+            c1.cd()
             for ext in ['pdf', 'png']:
-                canv.SaveAs('{odir}/W{ch}_{pol}_{flav}_TOTALSIG_PFMT40_absY.{ext}'.format(odir=outname,ch=charge,flav=channel,pol=pol,ext=ext))
-
-
-    # do backgrounds now
-    procs=["Flips","Z","Top","DiBosons","TauDecaysW","data_fakes","obs"]
-    titles=["charge flips","Drell-Yan","Top","di-bosons","W#rightarrow#tau#nu","QCD","toy data"]
-    procsAndTitles = dict(zip(procs,titles))
-    bkg_and_data = {}
-    for i,p in enumerate(procs):
-        h1_1 = infile.Get('expproc_{p}_postfit'.format(p=p)) if 'obs' not in p else infile.Get('obs')
-        if not h1_1: continue # muons don't have Flips components
-        h2_backrolled_1 = dressed2D(h1_1,binning,p,titles[i])
-        bkg_and_data[p] = h2_backrolled_1
-        bkg_and_data[p].SetDirectory(None)
-        h2_backrolled_1.Draw('colz')
-        h2_backrolled_1.Write(str(p))
-        if not options.no2Dplot:
-            for ext in ['pdf', 'png']:
-                canv.SaveAs('{odir}/{proc}_{ch}_{flav}_PFMT40_absY.{ext}'.format(odir=outname,proc=p,ch=charge,flav=channel,ext=ext))
+                c1.SaveAs('{odir}/projection{proj}_{ch}_{flav}_PFMT40_absY_{sfx}.{ext}'.format(odir=outname,proj=projection,ch=charge,flav=channel,sfx=prepost,ext=ext))
         
     outfile.Close()
-    
-
-    # now draw the 1D projections
-    all_procs = total_sig.copy()
-    all_procs.update(bkg_and_data)
-    polsym = {'left': 'L', 'right': 'R', 'long': '0'}; chargesym={'plus':'+', 'minus':'-'}
-    for pol in ['right', 'left', 'long']:
-        procsAndTitles['W{ch}_{pol}'.format(ch=charge,pol=pol)] = 'W^{{{sign}}}_{{{pol}}}'.format(sign=chargesym[charge],pol=polsym[pol])
-
-    colors = {'Wplus_long' : ROOT.kGray+1,   'Wplus_left' : ROOT.kBlue-1,   'Wplus_right' : ROOT.kGreen+1,
-              'Wminus_long': ROOT.kYellow+1, 'Wminus_left': ROOT.kViolet-1, 'Wminus_right': ROOT.kAzure+1,
-              'Top'        : ROOT.kGreen+2,  'DiBosons'   : ROOT.kViolet+2, 'TauDecaysW'  : ROOT.kPink,       
-              'Z'          : ROOT.kAzure+2,  'Flips'      : ROOT.kGray+1,   'data_fakes'  : ROOT.kGray+2 }
-
-    for p,h in all_procs.iteritems():
-        h.integral = h.Integral()
-
-    for projection in ['X','Y']:
-        hdata = all_procs['obs'].ProjectionX("x_total",0,-1,"e") if projection=='X' else all_procs['obs'].ProjectionY("y_total",0,-1,"e")
-        htot = hdata.Clone('tot'); htot.Reset(); htot.Sumw2()
-        stack = ROOT.THStack("stack","")
-        
-        legWidth=0.50; textSize=0.035
-        (x1,y1,x2,y2) = (.75-legWidth, .70, .85, .87)
-        leg = ROOT.TLegend(x1,y1,x2,y2)
-        leg.SetNColumns(3)
-        leg.SetFillColor(0)
-        leg.SetFillColorAlpha(0,0.6)
-        leg.SetShadowColor(0)
-        leg.SetLineColor(0)
-        leg.SetBorderSize(0)
-        leg.SetTextFont(42)
-        leg.SetTextSize(textSize)
-    
-        for key,histo in sorted(all_procs.iteritems(), key=lambda (k,v): (v.integral,k)):
-            if key=='obs': continue
-            proj1d = all_procs[key].ProjectionX(all_procs[key].GetName()+"_px",0,-1,"e") if  projection=='X' else all_procs[key].ProjectionY(all_procs[key].GetName()+"_py",0,-1,"e")
-            proj1d.SetFillColor(colors[key])
-            stack.Add(proj1d)
-            htot.Add(proj1d)                    
-            leg.AddEntry(proj1d,procsAndTitles[key],'F')
-
-        leg.AddEntry(hdata,'toy data','PE')
-        
-        doRatio=True
-        htot.GetYaxis().SetRangeUser(0, 1.8*max(htot.GetMaximum(), hdata.GetMaximum()))
-        htot.GetYaxis().SetTitle('Events')
-     
-    
-        ## Prepare split screen
-        c1 = ROOT.TCanvas("c1", "c1", 600, 750); c1.Draw()
-        c1.SetWindowSize(600 + (600 - c1.GetWw()), (750 + (750 - c1.GetWh())));
-        ROOT.gStyle.SetPadLeftMargin(0.18)
-        p1 = ROOT.TPad("pad1","pad1",0,0.29,1,0.99);
-        p1.SetBottomMargin(0.03);
-        p1.Draw();
-        p2 = ROOT.TPad("pad2","pad2",0,0,1,0.31);
-        p2.SetTopMargin(0);
-        p2.SetBottomMargin(0.3);
-        p2.SetFillStyle(0);
-        p2.Draw();
-        p1.cd();
-        ## Draw absolute prediction in top frame
-        htot.Draw("HIST")
-        #htot.SetLabelOffset(9999.0);
-        #htot.SetTitleOffset(9999.0);
-        stack.Draw("HIST F SAME")
-        hdata.SetMarkerColor(ROOT.kBlack)
-        hdata.SetMarkerStyle(ROOT.kFullCircle)
-        hdata.Draw("E SAME")
-        htot.Draw("AXIS SAME")
-        totalError = doShadedUncertainty(htot)            
-        leg.Draw()
-        lat = ROOT.TLatex()
-        lat.SetNDC(); lat.SetTextFont(42)
-        lat.DrawLatex(0.16, 0.92, '#bf{CMS} #it{Preliminary}')
-        lat.DrawLatex(0.65, 0.92, '36 fb^{-1} (13 TeV)')
-
-        p2.cd()
-        rdata,rnorm,rline = doRatioHists(hdata, htot, maxRange=[0.99,1.01], fixRange=True)
-        c1.cd()
-        for ext in ['pdf', 'png']:
-            c1.SaveAs('{odir}/projection{proj}_{ch}_{flav}_PFMT40_absY.{ext}'.format(odir=outname,proj=projection,ch=charge,flav=channel,ext=ext))
-        


### PR DESCRIPTION
two main updates:

- starts from the fitresult of the combined charges
- uses the plot of full sig+bkg to show the error on the postfit/prefit with the correct error propagation in the fit

other:
- with --prefit it shows data wrt the prefit exp.

There could be many bugs still, but wanted to share