### PR TITLE
Make the postfit unrolled and its pull

### DIFF
--- a/WMass/python/plotter/resultPlots.py
+++ b/WMass/python/plotter/resultPlots.py
@@ -87,6 +87,10 @@ if __name__ == '__main__':
                 cmd  = 'python w-helicity-13TeV/postFitPlots.py --no2Dplot {pf} '.format(pf=prepostfit)
                 cmd += ' {inf} {cd} --outdir {od} --suffix {suf} '.format(inf=results[tmp_file], cd=results['cardsdir'], od=tmp_outdir, suf=tmp_file.replace('postfit',''))
                 os.system(cmd)
+                for charge in ['plus','minus']:
+                    prepost = 'prefit' if prepostfit=='--prefit' else 'postfit'
+                    cmdpull = 'python w-helicity-13TeV/monsterPull.py -i {od}/plots_{prepost}{suf}.root -d unrolled_{ch} --suffix {prepost}{suf}'.format(od=tmp_outdir,prepost=prepost,suf=tmp_file.replace('postfit',''),ch=charge)
+                    os.system(cmdpull)
 
     ## do this at the end, it takes the longest
     ## diff nuisances

--- a/WMass/python/plotter/results_config_el.txt
+++ b/WMass/python/plotter/results_config_el.txt
@@ -21,4 +21,5 @@ shapes_files = cardsdir+'/Wel_shapes.root'
 xsecs_plus  = cardsdir+'/Wel_plus_shapes_xsec.root'
 xsecs_minus = cardsdir+'/Wel_minus_shapes_xsec.root'
 
-postfit_both  = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15_noBinByBin_mt0.root'
+postfit_noBBB  = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15_noBinByBin_mt0.root'
+postfit_BBB  = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15_withBinByBin_mt0.root'


### PR DESCRIPTION
- postFitPlots.py:
   1. does the unrolled plots too (divided by + and - charges)
   2. saves them into a root files (data and sig+bkg as "full")
- monsterPull.py uses the full if it finds it in the root file, otherwise look for signal and backgrund as before when running on the output of mcPlots.py
- resultPlots.py now also does the monsterpulls
Output should be like this:
![image](https://user-images.githubusercontent.com/4517974/49301734-9c21de00-f4c5-11e8-90fa-68605ee999d3.png)
