### PR TITLE
Add the unrolled plots to systRatios and resultPlots

### DIFF
--- a/WMass/python/plotter/resultPlots.py
+++ b/WMass/python/plotter/resultPlots.py
@@ -1,4 +1,4 @@
-import ROOT, optparse, os
+import ROOT, optparse, os, re
 
 ## usage:
 ## python resultPlots.py --config results_config_mu.txt --outdir <outputdirectory> (--runtoys)
@@ -39,7 +39,7 @@ if __name__ == '__main__':
         systs += ['muF'   +str(i) for i in range(1,11)]
         systs += ['muRmuF'+str(i) for i in range(1,11)]
         for nuis in systs:
-            os.system('python w-helicity-13TeV/systRatios.py --outdir {od} -s {p} {d} {ch}'.format(od=tmp_outdir, p=nuis, d=results['cardsdir'], ch=muEl))
+            os.system('python w-helicity-13TeV/systRatios.py --unrolled --outdir {od} -s {p} {d} {ch}'.format(od=tmp_outdir, p=nuis, d=results['cardsdir'], ch=muEl))
 
     ## plot correlation matrices
     ## ================================
@@ -101,7 +101,7 @@ if __name__ == '__main__':
         os.system('mkdir -p {od}'.format(od=tmp_outdir))
         os.system('cp ~mdunser/public/index.php {od}'.format(od=tmp_outdir))
         for t in toysHessian:
-            for tmp_file in [i for i in results.keys() if 'both_floatingPOIs_'+t in i]:
+            for tmp_file in [i for i in results.keys() if re.match('both_(floating|fixed)POIs_{toyhess}'.format(toyhess=t),i)]:
                 tmp_suffix = '_'.join(tmp_file.split('_')[1:])
                 nuisancesAndPOIs = ['pdf', 'muR,muF,muRmuF,alphaS,wpt', 'CMS_', 'ErfPar']
                 if 'floatingPOIs' in results[tmp_file]: nuisancesAndPOIs += ['W{charge}_{pol}.*_mu'.format(charge=charge,pol=pol) for charge in ['plus','minus'] for pol in ['left','right','long'] ]

--- a/WMass/python/plotter/results_config_el.txt
+++ b/WMass/python/plotter/results_config_el.txt
@@ -1,19 +1,24 @@
 basedir = '/afs/cern.ch/work/e/emanuele/wmass/heppy/CMSSW_8_0_25/src/CMGTools/WMass/python/plotter/w-helicity-13TeV'
 cardsdir = basedir+'/cards_el'
-fitsdir = basedir+'/fits/tf/21-11-18'
+fitsdir = basedir+'/fits/tf/06-12-18/fakesLnNoLepScale'
 toysdir = basedir+'/toys/tf/21-11-18'
 
+### FLOATING POIS ###
+both_floatingPOIs_hessian_BBB   = fitsdir+'/fitresults_poim1_exp1_bbb1.root'
+both_floatingPOIs_hessian_noBBB = fitsdir+'/fitresults_poim1_exp1_bbb0.root'
+both_floatingPOIs_hessian_mt0_BBB   = fitsdir+'/fitresults_poim1_exp0_bbb1.root'
+both_floatingPOIs_hessian_mt0_noBBB = fitsdir+'/fitresults_poim1_exp0_bbb0.root'
 
-both_floatingPOIs_hessian = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15.root'
-#both_floatingPOIs_hessian_withSyst_noBBB = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15_withSystematic_noBinByBin.root'
 #both_floatingPOIs_hessian_noSyst_withBBB = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15_noSystematic_withBinByBin.root'
 #both_floatingPOIs_hessian_noSyst_noBBB   = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15_noSystematic_noBinByBin.root'
-both_floatingPOIs_hessian_mt0 = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15_withBinByBin_mt0.root'
-#both_floatingPOIs_hessian_mt0_noBBB = fitsdir+'/fitresults_both_floatingPOIs_hessian_fix14and15_noBinByBin_mt0.root'
 both_floatingPOIs_toys    = toysdir+'/floatPOIs/bbb/toys_floatPOIs.root'
 
-both_fixedPOIs_hessian       = fitsdir+'/fitresults_both_fixedPOIs_hessian_fix14and15.root'
-both_fixedPOIs_hessian_mt0   = fitsdir+'/fitresults_both_fixedPOIs_hessian_fix14and15_withBinByBin_mt0.root'
+### FIXED POIS ###
+both_fixedPOIs_hessian_BBB   = fitsdir+'/fitresults_poim0_exp1_bbb1.root'
+both_fixedPOIs_hessian_noBBB = fitsdir+'/fitresults_poim0_exp1_bbb0.root'
+both_fixedPOIs_hessian_mt0_BBB   = fitsdir+'/fitresults_poim0_exp0_bbb1.root'
+both_fixedPOIs_hessian_mt0_noBBB = fitsdir+'/fitresults_poim0_exp0_bbb0.root'
+
 both_fixedPOIs_toys          = toysdir+'/fixPOIs/bbb/toys_fixPOIs_bbb.root'
 
 shapes_files = cardsdir+'/Wel_shapes.root'

--- a/WMass/python/plotter/w-helicity-13TeV/rollingFunctions.py
+++ b/WMass/python/plotter/w-helicity-13TeV/rollingFunctions.py
@@ -26,7 +26,7 @@ def dressed2D(h1d,binning,name,title=''):
     h2_backrolled_1 .GetZaxis().SetRangeUser(0.01*h2_backrolled_1.GetMaximum(),1.1*h2_backrolled_1.GetMaximum())
     return h2_backrolled_1
 
-def unroll2Dto1D(h,newname=''):
+def unroll2Dto1D(h,newname='',cropNegativeBins=True):
     nbins = h.GetNbinsX() * h.GetNbinsY()
     goodname = h.GetName()
     h.SetName(goodname+"_oldbinning")
@@ -38,10 +38,11 @@ def unroll2Dto1D(h,newname=''):
             bin = 1 + i + j*h.GetNbinsX()
             newh.SetBinContent(bin,h.GetBinContent(i+1,j+1))
             newh.SetBinError(bin,h.GetBinError(i+1,j+1))
-    for bin in range(1,nbins+1):
-        if newh.GetBinContent(bin)<0:
-            print 'Warning: cropping to zero bin %d in %s (was %f)'%(bin,newh.GetName(),newh.GetBinContent(bin))
-            newh.SetBinContent(bin,0)
+    if cropNegativeBins:
+        for bin in range(1,nbins+1):
+            if newh.GetBinContent(bin)<0:
+                print 'Warning: cropping to zero bin %d in %s (was %f)'%(bin,newh.GetName(),newh.GetBinContent(bin))
+                newh.SetBinContent(bin,0)
     newh.SetLineWidth(h.GetLineWidth())
     newh.SetLineStyle(h.GetLineStyle())
     newh.SetLineColor(h.GetLineColor())

--- a/WMass/python/plotter/w-helicity-13TeV/systRatios.py
+++ b/WMass/python/plotter/w-helicity-13TeV/systRatios.py
@@ -5,7 +5,8 @@
 
 import ROOT, os, copy, re
 from array import array
-from testRolling import getbinning,roll1Dto2D,unroll2Dto1D,dressed2D
+from testRolling import getbinning
+from rollingFunctions import *
 
 ROOT.gROOT.SetBatch()
 ##ROOT.gStyle.SetPalette(55)
@@ -14,11 +15,88 @@ ROOT.gErrorIgnoreLevel = 100
 
 canv = ROOT.TCanvas()
 
+def plotUnrolledRatios(ratios2d,outdir,name):
+    ROOT.gStyle.SetPadLeftMargin(0.13)
+    ROOT.gStyle.SetPadRightMargin(0.07)
+    ROOT.gStyle.SetPadBottomMargin(0.3);
+
+    plotformat = (2400,600)
+    c1 = ROOT.TCanvas("c1", "c1", plotformat[0], plotformat[1]); c1.Draw()
+    c1.SetWindowSize(plotformat[0] + (plotformat[0] - c1.GetWw()), (plotformat[1] + (plotformat[1] - c1.GetWh())));
+
+    ratios,rnorm,rline = doUnrolledRatios(ratios2d)
+
+    lat = ROOT.TLatex()
+    lat.SetNDC(); lat.SetTextFont(42)
+    lat.DrawLatex(0.15, 0.92, '#bf{CMS} #it{Preliminary}')
+    lat.DrawLatex(0.85, 0.92, '36 fb^{-1} (13 TeV)')
+    for ext in ['pdf', 'png']:
+        c1.SaveAs('{odir}/{name}_unrolled.{ext}'.format(odir=outdir,name=name,ext=ext))
+
+def doUnrolledRatios(ratios2d):
+    
+    ratios = [unroll2Dto1D(r2,cropNegativeBins=False) for k,r2 in ratios2d.iteritems() if "TH2" in r2.ClassName()]
+
+    unity = ratios[0].Clone("unity")
+    rmax = 0
+
+    for b in xrange(1,unity.GetNbinsX()+1):
+        unity.SetBinContent(b, 0); unity.SetBinError(b, 0)
+        for ratio in ratios:
+            r = abs(ratio.GetBinContent(b))
+            unity.SetBinError(b,max([r,abs(unity.GetBinError(b))]))
+        rmax = max([rmax, unity.GetBinError(b)])
+        rmin = -rmax
+
+    unity.SetFillStyle(1001);
+    unity.SetFillColor(ROOT.kCyan);
+    unity.SetMarkerStyle(1);
+    unity.SetMarkerColor(ROOT.kCyan);
+    ROOT.gStyle.SetErrorX(0.5);
+    unity.Draw("E2");
+    unity.GetYaxis().SetRangeUser(1.2*rmin,1.2*rmax);
+    unity.GetXaxis().SetTitleFont(42)
+    unity.GetXaxis().SetTitleSize(0.14)
+    unity.GetXaxis().SetTitleOffset(0.9)
+    unity.GetXaxis().SetLabelFont(42)
+    unity.GetXaxis().SetLabelSize(0.1)
+    unity.GetXaxis().SetLabelOffset(0.007)
+    unity.GetYaxis().SetNdivisions(505)
+    unity.GetYaxis().SetTitleFont(42)
+    unity.GetYaxis().SetTitleSize(0.14)
+    unity.GetYaxis().SetLabelFont(42)
+    unity.GetYaxis().SetLabelSize(0.11)
+    unity.GetYaxis().SetLabelOffset(0.01)
+    unity.GetYaxis().SetDecimals(True) 
+    unity.GetYaxis().SetTitle('Syst./Nom.')
+    unity.GetXaxis().SetTitle('unrolled lepton (#eta,p_{T}) bin')
+    unity.GetYaxis().SetTitleOffset(0.40)
+    line = ROOT.TLine(unity.GetXaxis().GetXmin(),1,unity.GetXaxis().GetXmax(),1)
+    line.SetLineWidth(2);
+    line.SetLineColor(58);
+    line.Draw("L")
+    for ir,ratio in enumerate(ratios):
+        ratio.SetLineColor(ROOT.kRed + 2*ir)
+        ratio.Draw("HIST SAME" if ratio.ClassName() != "TGraphAsymmErrors" else "PZ SAME");
+    leg1 = ROOT.TLegend(0.45, 0.8, 0.7, 0.9)
+    leg1.SetFillColor(0)
+    leg1.SetShadowColor(0)
+    leg1.SetLineColor(0)
+    leg1.SetTextFont(42)
+    leg1.SetTextSize(0.035*0.7/0.3)
+    leg1.AddEntry(unity, "envelope unc.", "F")
+    leg1.Draw()
+
+    return (ratios, unity, line)
+
+
 if __name__ == "__main__":
     from optparse import OptionParser
     parser = OptionParser(usage="%prog [options] shapesdir channel")
     parser.add_option('-o','--outdir', dest='outdir', default='.', type='string', help='outdput directory to save the matrix')
     parser.add_option('-s','--syst', dest='systematics', default=None, type='string', help='systematics of which drawing the ratio (comma-separated list of)')
+    parser.add_option(     '--no2Dplot', dest="no2Dplot", default=False, action='store_true', help="Do not plot templates (but you can still save them in a root file with option -s)");
+    parser.add_option('-u','--unrolled', dest='unrolled', default=False, action='store_true', help='make the 1D ratios on the unrolled plot for all the listed systematics')
     (options, args) = parser.parse_args()
     channel = args[1]
 
@@ -45,8 +123,8 @@ if __name__ == "__main__":
         nY[charge+'_long'] = max( int(i.split('_')[-2]) for i in siglist if 'pdf' in i and 'long' in i)
         nPDF = max( int(i.split('_')[-1].replace('pdf','').replace('Down','').replace('Up','')) for i in siglist if 'pdf' in i)
 
-        ## bkgs = ['data_fakes','Flips','DiBosons','Top','TauDecaysW','Z','W%s_long'%charge] # other than W_{L,R}
-        bkgs = []#['data_fakes'] # other than W_{L,R}
+        bkgs = ['data_fakes','Flips','DiBosons','Top','TauDecaysW','Z']
+        #bkgs = []#['data_fakes'] # other than W_{L,R}
         wlr = ['W{ch}_{p}_W{ch}_{p}_{flav}_Ybin_0'.format(ch=charge,p=pol,flav=channel) for pol in ['left','right', 'long'] ]
         procs=wlr+bkgs
 
@@ -116,13 +194,12 @@ if __name__ == "__main__":
                             for iy in xrange(1,nY[cp]+1):
                                 hname_iy = 'x_W{ch}_{pol}_W{ch}_{pol}_{flav}_Ybin_{iy}_{syst}'.format(ch=charge,pol=pol,flav=channel,iy=iy,syst=fullsyst)
                                 histo_syst_iy = infile.Get(hname_iy) if hname in keylist else None
-                                if histo_syst_iy == None: 
-                                    print 'ERROR!!! DID NOT FIND SYSTEMATIC', syst, 'AND YBIN', iy
                                 if histo_syst_iy: histo_syst.Add(histo_syst_iy)
                             title2D = 'W{ch} {pol} : variation={syst}'.format(pol=pol,ch=chs,syst=syst)
                             key = 'syst_W{ch}_{pol}_W{ch}_{pol}_{flav}_{syst}'.format(ch=charge,pol=pol,flav=channel,syst=syst)
                     else:
                         hname = 'x_{proc}_{syst}'.format(proc=proc,syst=fullsyst)
+                        print "Lookiig for shape ",hname
                         if hname in fulllist:
                             histo_syst = infile.Get(hname)
                         title2D = '{proc} : variation={syst}'.format(proc=proc,syst=syst)
@@ -146,12 +223,18 @@ if __name__ == "__main__":
                             print 'nentries of syst:   ', histo_syst.GetEntries()
                             errors.append('{ch}_{pol}_{syst}'.format(ch=charge, pol=pol, syst=fullsyst))
 
-        print ratios
-        canv = ROOT.TCanvas()
-        for k,r in ratios.iteritems():
-            r.Draw('colz')
-            for ext in ['pdf', 'png']:
-                canv.SaveAs('{odir}/{name}.{ext}'.format(odir=outname,name=k,ext=ext))
+        if len(ratios):
+            if not options.no2Dplot:
+                canv = ROOT.TCanvas()
+                for k,r in ratios.iteritems():
+                    r.Draw('colz')
+                    for ext in ['pdf', 'png']:
+                        canv.SaveAs('{odir}/{name}.{ext}'.format(odir=outname,name=k,ext=ext))
+     
+            if options.unrolled:
+                systNames = options.systematics.replace(',','AND').replace('.','').replace('*','').replace('$','').replace('^','').replace('|','').replace('[','').replace(']','')
+                plotUnrolledRatios(ratios,outname,'{syst}_{ch}'.format(syst=systNames,ch=charge))
+
 
     if len(errors):
         print '=== WARNING === WARNING === WARNING ==='


### PR DESCRIPTION
the unrolled plot shows, for the set of systematic requested, the unrolled systematic *prefit* effect. 
The cyan band is the envelope of the set of systematics. 

This is mostly for debugging, since I only understand 1D distributions. 
Eg for 60 pdfs on signal, pretty much unparsable, but at least one sees that there are no crazy components:

![image](https://user-images.githubusercontent.com/4517974/49595743-f8c74200-f978-11e8-8107-7da4cf94f68f.png)
