### PR TITLE
A new script to check the goodness of the friend chunks

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -743,7 +743,7 @@ if __name__ == "__main__":
         combinedCard.write('\nEffStat group = '+' '.join(filter(lambda x: re.match('.*ErfPar\dEffStat.*',x),finalsystnames))+'\n') 
         combinedCard.write('\nFakes group = '+' '.join(filter(lambda x: re.match('FakesEtaUncorrelated.*',x),finalsystnames) +
                                                        filter(lambda x: re.match('.*FR.*(lnN|slope|continuous)',x),finalsystnames))+'\n')
-        combinedCard.write('\nOtherBkg group = '+' '.join(filter(lambda x: re.match('CMS_DY|CMS_Top|CMS_VV|CMS_W$|CMS_We_flips',x),finalsystnames))+'\n')
+        combinedCard.write('\nOtherBkg group = '+' '.join(filter(lambda x: re.match('CMS_DY|CMS_Top|CMS_VV|CMS_Tau|CMS_We_flips',x),finalsystnames))+'\n')
         combinedCard.write('\nOtherExp group = '+' '.join(filter(lambda x: re.match('CMS.*lepVeto|CMS.*bkg_lepeff|CMS.*sig_lepeff',x),finalsystnames))+'\n')
         combinedCard.close() 
 

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -509,7 +509,7 @@ if __name__ == "__main__":
                 syst = name.split('_')[-1]
                 binWsyst = '_'.join(name.split('_')[1:-1])
                 if re.match('.*_pdf.*|.*_muR.*|.*_muF.*|.*alphaS.*|.*mW.*',name):
-                    if re.match('.*_muR.*|.*_muF.*',name) and name.startswith('x_Z_'): continue # patch: these are the wpT binned systematics that are filled by makeShapeCards but with 0 content
+                    if re.match('.*_muR\d+|.*_muF\d+',name) and name.startswith('x_Z_'): continue # patch: these are the wpT binned systematics that are filled by makeShapeCards but with 0 content
                     if syst not in theosyst: theosyst[syst] = [binWsyst]
                     else: theosyst[syst].append(binWsyst)
                 if re.match('.*ErfPar\dEffStat.*|.*FakesEtaUncorrelated.*|.*(ele|mu)scale.*',name):

--- a/WMass/python/plotter/w-helicity-13TeV/systRatios.py
+++ b/WMass/python/plotter/w-helicity-13TeV/systRatios.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
                             histo_pdfi = infile.Get('x_{proc}_pdf{ip}Up'.format(proc=proc,ip=ip))
                             title2D = 'Z : pdf {ip}'.format(ip=ip)
                             key = 'syst_{proc}_{ch}_{flav}_pdf{ip}'.format(proc=proc,ch=charge,flav=channel,ip=ip)
-                        if not histo_central.GetEntries() == histo_pdfi.GetEntries():
+                        if not histo_central.GetEntries() == histo_pdfi.GetEntries() or histo_pdfi.Integral() == 0.:
                             print 'WARNING/ERROR: THE CENTRAL HISTO AND PDF HISTO DO NOT HAVE THE SAME NUMBER OF ENTRIES'
                             print 'this just happened for {ch} and {pol} and pdf {syst}'.format(ch=charge, pol=pol, syst=ip)
                             errors.append('{ch}_{pol}_pdf{syst}'.format(ch=charge, pol=pol, syst=ip))

--- a/WMass/python/plotter/w-helicity-13TeV/testRolling.py
+++ b/WMass/python/plotter/w-helicity-13TeV/testRolling.py
@@ -4,8 +4,8 @@
 
 import ROOT, os, re
 from array import array
-from CMGTools.TTHAnalysis.plotter.histoWithNuisances import *
-from CMGTools.WMass.plotter.mcPlots import doShadedUncertainty
+#from CMGTools.TTHAnalysis.plotter.histoWithNuisances import *
+#from CMGTools.WMass.plotter.mcPlots import doShadedUncertainty
 
 import utilities
 utilities = utilities.util()

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
@@ -34,7 +34,7 @@ CMS_We_FRe_lnN        : data_fakes  : .* : 1.30
 
 # shape uncertainties (slope of FR with pt up/down, and continuous variation in eta, and awayjet 45)
 CMS_We_FRe_slope         : data_fakes  : .* : FRe_slope       : templatesShapeOnly
-#CMS_We_FRe_continuous    : data_fakes  : .* : FRe_continuous  : templates
+CMS_We_FRe_continuous    : data_fakes  : .* : FRe_continuous  : templates
 #CMS_We_FRe_awayJetPt45   : data_fakes  : .* : data_fakes_FRe_awayJetPt45 : alternateShapeOnly
 
 # ==================================================================

--- a/WMass/python/postprocessing/scripts/friendChunkCheck.py
+++ b/WMass/python/postprocessing/scripts/friendChunkCheck.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import sys,os,re
+import ROOT
+
+if __name__ == "__main__":
+    
+    from optparse import OptionParser
+    parser = OptionParser(usage="%prog [options] dir_with_friend_trees dir_with_trees [checkedfile.txt]")
+    parser.add_option("-z", "--zombies",  dest="zombies", action='store_true', default=False, help="Check zombies");
+    (options, args) = parser.parse_args()
+
+    fdir = args[0]
+    allfiles = os.listdir(fdir)
+
+    chunks = {}
+    samples = []
+    for f in allfiles:
+        tokens = (os.path.basename(f)).split('.')
+        s = tokens[0]
+        c = tokens[1]
+        if not re.match('chunk\d+',c): continue
+        if s not in samples: samples.append(s)
+        if s not in chunks:
+            chunks[s] = [c]
+        else:
+            chunks[s].append(c)
+
+    goodfiles = {}
+    for s,c in chunks.iteritems():
+        c.sort(key=lambda x: int(x.split('chunk')[-1]))
+        maxc = int(c[-1].split('chunk')[-1])
+        #print "Sample ",s," has ",len(c)," chunks: ",c,". Max chunk = ",maxc
+        for ic in xrange(maxc+1):
+            ftest = '{fdir}/{sample}.chunk{c}.root'.format(fdir=fdir,sample=s,c=ic)
+            if not os.path.isfile(ftest):
+                print ftest, " # not present"
+            else:
+                if os.stat(ftest)<1000:
+                    print ftest, " # has zero size"
+                else:
+                    if s not in goodfiles:
+                        goodfiles[s] = [ftest]
+                    else:
+                        goodfiles[s].append(ftest)
+    
+    if options.zombies:
+        print "# Testing for zombies or not correctly closed files"
+        for s,chunks in goodfiles.iteritems():
+            good = True
+            for f in chunks:
+                tf = ROOT.TFile(f)
+                if not tf: good=False
+                else:
+                    if tf.IsZombie() or tf.TestBit(ROOT.TFile.kRecovered): good=False
+                print '{f} # {qual}'.format(f=f,qual="OK" if good else "zombie")
+    
+    print "DONE."

--- a/WMass/python/postprocessing/scripts/friendChunkResub.py
+++ b/WMass/python/postprocessing/scripts/friendChunkResub.py
@@ -19,17 +19,17 @@ if __name__ == "__main__":
     maindir = args[1]
 
     if options.runChecker:
-        print "Running friendChunkCheck.sh now on ",fdir,". Will take time..."
+        print "Running friendChunkCheck.py now on ",fdir,". Will take time..."
         if len(args)==3:
             print "Can't run the checker if you pass the output file of a previous check (for safety)"
             sys.exit(1)
-        bashCheckScript = '{cmssw}/src/CMGTools/WMass/python/postprocessing/scripts/friendChunkCheck.sh -z {frienddir} > tmpcheck.txt'.format(cmssw=os.environ['CMSSW_BASE'],
+        pyCheckScript = '{cmssw}/src/CMGTools/WMass/python/postprocessing/scripts/friendChunkCheck.py -z {frienddir} > tmpcheck.txt'.format(cmssw=os.environ['CMSSW_BASE'],
                                                                                                                                               frienddir=fdir)
         if os.path.isfile('tmpcheck.txt'):
             print "File tmpcheck.txt exists. It means you could be running friendChunkCheck.sh. If not, remove it, and run it again."
             sys.exit()
         else:
-            os.system(bashCheckScript)
+            os.system(pyCheckScript)
         print "Done. The list of files is in tmpcheck.txt."
 
     tmpfile = 'tmpcheck.txt' if len(args)<3 else args[2]


### PR DESCRIPTION
Move from friendChunkCheck.sh to friendChunkCheck.py
The mother script "friendChunkResub.py" is updated, so the usage is still the same. 
 - The basic check on the presence of the file is fixed (apart the last one that can still be missed).
 - The check of the zombiness or recovery of the TFile seems to be much faster, not sure if it is working for real (need some experience on the ground)

In this PR, something for the latest changes in systematics names in the merger is also updated:
 - consider the unbinned QCD scale uncertainties for Z
 - move to CMS_Tau naming to cope with @cippy PR #430 