### PR TITLE
1D summary of the uncertainty impacts

### DIFF
--- a/WMass/python/plotter/resultPlots.py
+++ b/WMass/python/plotter/resultPlots.py
@@ -120,6 +120,10 @@ if __name__ == '__main__':
                         for charge in ['plus','minus']:
                             cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --latex --nuisgroups .* --pois "W{charge}.*(left|right).*(bin_0|bin_4|bin_7|bin_9)" --target {tg} --suffix {sfx}'.format(fr=results[tmp_file], od=tmp_outdir, pois=poig, tg=target, sfx=tmp_suffix, charge=charge) 
                             os.system(cmd)
+                    # now do the 1D summaries
+                    print "RUNNING 1D SUMMARIES OF SYSTEMATICS..."
+                    cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuisgroups .* -y {cd}/binningYW.txt --target {tg} --suffix summary'.format(fr=results[tmp_file], od=tmp_outdir, cd=results['cardsdir'], tg=target)
+                    os.system(cmd)
 
     ## do this at the end, it takes the longest
     ## diff nuisances

--- a/WMass/python/plotter/w-helicity-13TeV/postFitPlots.py
+++ b/WMass/python/plotter/w-helicity-13TeV/postFitPlots.py
@@ -65,8 +65,8 @@ def singleChargeUnrolled(h1d,shift,nCharges=2,nMaskedCha=2):
         h1d_shifted.SetBinError(b+1,h1d.GetBinError(b+shift+1))
     return h1d_shifted
 
-def prepareLegend(legWidth=0.50,textSize=0.035):
-    (x1,y1,x2,y2) = (.75-legWidth, .70, .85, .87)
+def prepareLegend(legWidth=0.50,textSize=0.035,xmin=0.75):
+    (x1,y1,x2,y2) = (xmin-legWidth, .70, .85, .87)
     leg = ROOT.TLegend(x1,y1,x2,y2)
     leg.SetNColumns(3)
     leg.SetFillColor(0)

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -588,3 +588,8 @@ class util:
         ret.SetMarkerStyle(0)
         ret.Draw("PE2 SAME")
         return ret
+
+    def safecolor(self, index):
+        SAFE_COLOR_LIST=[ROOT.kBlack, ROOT.kRed, ROOT.kGreen+2, ROOT.kBlue, ROOT.kMagenta+1, ROOT.kOrange+7, ROOT.kCyan+1, ROOT.kGray+2, ROOT.kViolet+5, ROOT.kSpring+5, ROOT.kAzure+1, ROOT.kPink+7, ROOT.kOrange+3, ROOT.kBlue+3, ROOT.kMagenta+3, ROOT.kRed+2]+range(11,40)
+        if index<len(SAFE_COLOR_LIST): return SAFE_COLOR_LIST[index]
+        else: return index


### PR DESCRIPTION
Make a plot vs W rapidity of the systematics, and compare with total fit error. 
Maybe the same should be done for the 2-diff xsec (@cippy ) and on the charge asymmetry as well both for YW and pt-eta. @emanueledimarco will try to do the one on charge asymmetry once used the new @bendavid tensorflow branch 

Produces plots like this:
![image](https://user-images.githubusercontent.com/4517974/52487143-39337e00-2bbd-11e9-88ed-8c6704c1b2cc.png)
