### PR TITLE
For electrons: make the fakes eta uncorrelated systematics eta dependent and remove the continuous

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -186,6 +186,15 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
             borderBins.append(next(x[0] for x in enumerate(etabins) if x[1] > i))
         borderBins += [len(etabins)]
 
+        if isMu: scalings = [0.05 for b in borderBins]
+        else:
+            scalings = []
+            for ib, borderBin in enumerate(borderBins):
+                distFromCenter = abs(ib-(len(borderBins)-1)/2+0.5)
+                if   distFromCenter<1: scalings.append(0.01)
+                elif distFromCenter<2: scalings.append(0.02)
+                else:                  scalings.append(0.05)
+
         ## loop over all eta bins of the 2d histogram
         for ib, borderBin in enumerate(borderBins[:-1]):
 
@@ -198,7 +207,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
                 ## loop over all pT bins in that bin of eta (which is ieta)
                 for ipt in range(1,tmp_scaledHisto_up.GetNbinsY()+1):
                     tmp_bincontent = tmp_scaledHisto_up.GetBinContent(ieta, ipt)
-                    scaling = 0.05
+                    scaling = scalings[ib]
                     ## scale up and down with what we got from the histo
                     tmp_bincontent_up = tmp_bincontent*(1.+scaling)
                     tmp_bincontent_dn = tmp_bincontent*(1.-scaling)

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
@@ -34,7 +34,7 @@ CMS_We_FRe_lnN        : data_fakes  : .* : 1.30
 
 # shape uncertainties (slope of FR with pt up/down, and continuous variation in eta, and awayjet 45)
 CMS_We_FRe_slope         : data_fakes  : .* : FRe_slope       : templatesShapeOnly
-CMS_We_FRe_continuous    : data_fakes  : .* : FRe_continuous  : templates
+#CMS_We_FRe_continuous    : data_fakes  : .* : FRe_continuous  : templates
 #CMS_We_FRe_awayJetPt45   : data_fakes  : .* : data_fakes_FRe_awayJetPt45 : alternateShapeOnly
 
 # ==================================================================


### PR DESCRIPTION
This makes the fit easier to converge. 

For the moment:
1% in the central 2 bins, 2% in the neighbors, 5% elsewhere.
Still present 30% lnN and ptslope

change affects only electrons. 
