### PR TITLE
1D impact summaries also for the new groups

### DIFF
--- a/WMass/python/plotter/resultPlots.py
+++ b/WMass/python/plotter/resultPlots.py
@@ -127,7 +127,7 @@ if __name__ == '__main__':
                 for target in targets:
                     print "RUNNING 1D SUMMARIES OF SYSTEMATICS..."
                     cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuisgroups .* --pois {pois} -y {cd}/binningYW.txt --target {tg} --suffix summary_{sfx}'.format(fr=results[tmp_file], od=tmp_outdir, pois=POIsForSummary[target], cd=results['cardsdir'], tg=target, sfx=tmp_suffix)
-                    if re.match('asym|A\d',target): cmd += ' --absolute '
+                    if re.match('.*asym|A\d',target): cmd += ' --absolute '
                     print cmd
                     os.system(cmd)
 

--- a/WMass/python/plotter/resultPlots.py
+++ b/WMass/python/plotter/resultPlots.py
@@ -95,35 +95,40 @@ if __name__ == '__main__':
 
     ## plot impacts
     ## ================================
-    if options.make in ['all','imp']:
+    if options.make in ['all','imp','imp1D']:
         print 'making impact plots'
         tmp_outdir = options.outdir+'/impactPlots/'
         poisGroups = ['W{ch}.*{pol}.*'.format(ch=charge,pol=pol) for charge in ['plus','minus'] for pol in ['left','right','long']]
         singleNuisGroups = ['CMS.*','pdf.*','mu.*','ErfPar0.*','ErfPar1.*','ErfPar2.*']
-        targets = ['xsec','xsecnorm']
+        targets = ['xsec','xsecnorm','asym','unpolasym','unpolxsec', 'A0', 'A4']
+        POIsForSummary = {'xsec': '.*', 'xsecnorm': '.*', 'asym': '.*chargeasym', 'unpolasym': '.*chargemetaasym', 'unpolxsec': '.*sumxsec', 'A0': '.*a0', 'A4': '.*a4'}
         for t in toysHessian:
             for tmp_file in [i for i in results.keys() if re.match('both_floatingPOIs_{toyhess}'.format(toyhess=t),i)]:
                 tmp_suffix = '_'.join(tmp_file.split('_')[1:])
-                for target in targets:
-                    for poig in poisGroups:
-                        print "RUNNING SINGLE NUISANCE IMPACTS..."
-                        for nuis in singleNuisGroups:
-                            cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuis {nuis} --pois {pois} --target {tg} --suffix {sfx}'.format(fr=results[tmp_file], od=tmp_outdir, nuis=nuis, pois=poig, tg=target, sfx=tmp_suffix)
+                if options.make != 'imp1D':
+                    for target in targets[:2]:
+                        for poig in poisGroups:
+                            print "RUNNING SINGLE NUISANCE IMPACTS..."
+                            for nuis in singleNuisGroups:
+                                cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuis {nuis} --pois {pois} --target {tg} --suffix {sfx}'.format(fr=results[tmp_file], od=tmp_outdir, nuis=nuis, pois=poig, tg=target, sfx=tmp_suffix)
+                                print "running ",cmd
+                                os.system(cmd)
+                            # now do the groups of systematics
+                            print "RUNNING GROUPED NUISANCE IMPACTS..."
+                            cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuisgroups .* --pois {pois} --target {tg} --suffix {sfx}'.format(fr=results[tmp_file], od=tmp_outdir, pois=poig, tg=target, sfx=tmp_suffix)
                             print "running ",cmd
                             os.system(cmd)
-                        # now do the groups of systematics
-                        print "RUNNING GROUPED NUISANCE IMPACTS..."
-                        cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuisgroups .* --pois {pois} --target {tg} --suffix {sfx}'.format(fr=results[tmp_file], od=tmp_outdir, pois=poig, tg=target, sfx=tmp_suffix)
-                        print "running ",cmd
-                        os.system(cmd)
-                        # now make the latex tables for the nuisance groups
-                        print "RUNNING TABLES FOR GROUPED NUISANCE IMPACTS..."
-                        for charge in ['plus','minus']:
-                            cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --latex --nuisgroups .* --pois "W{charge}.*(left|right).*(bin_0|bin_4|bin_7|bin_9)" --target {tg} --suffix {sfx}'.format(fr=results[tmp_file], od=tmp_outdir, pois=poig, tg=target, sfx=tmp_suffix, charge=charge) 
-                            os.system(cmd)
-                    # now do the 1D summaries
+                            # now make the latex tables for the nuisance groups
+                            print "RUNNING TABLES FOR GROUPED NUISANCE IMPACTS..."
+                            for charge in ['plus','minus']:
+                                cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --latex --nuisgroups .* --pois "W{charge}.*(left|right).*(bin_0|bin_4|bin_7|bin_9)" --target {tg} --suffix {sfx}'.format(fr=results[tmp_file], od=tmp_outdir, pois=poig, tg=target, sfx=tmp_suffix, charge=charge) 
+                                os.system(cmd)
+                # now do the 1D summaries
+                for target in targets:
                     print "RUNNING 1D SUMMARIES OF SYSTEMATICS..."
-                    cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuisgroups .* -y {cd}/binningYW.txt --target {tg} --suffix summary_{sfx}'.format(fr=results[tmp_file], od=tmp_outdir, cd=results['cardsdir'], tg=target, sfx=tmp_suffix)
+                    cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuisgroups .* --pois {pois} -y {cd}/binningYW.txt --target {tg} --suffix summary_{sfx}'.format(fr=results[tmp_file], od=tmp_outdir, pois=POIsForSummary[target], cd=results['cardsdir'], tg=target, sfx=tmp_suffix)
+                    if re.match('asym|A\d',target): cmd += ' --absolute '
+                    print cmd
                     os.system(cmd)
 
     ## do this at the end, it takes the longest

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -294,7 +294,7 @@ def plotUnpolarizedValues(values,charge,channel,options):
                     mg.GetYaxis().SetTitle('d#sigma/d|Y_{W}| (pb)')
                     mg.GetYaxis().SetRangeUser(1500,4500)
             else:
-                mg.GetYaxis().SetRangeUser(-0.5 if normstr=='A0' else -1,1 if normstr=='A0' else 2)
+                mg.GetYaxis().SetRangeUser(-0.05 if normstr=='A0' else -1,0.4 if normstr=='A0' else 2)
                 mg.GetYaxis().SetTitle('|A_{0}|' if normstr=='A0' else '|A_{4}|')
             mg.GetXaxis().SetTitleSize(0.06)
             mg.GetXaxis().SetLabelSize(0.04)
@@ -458,6 +458,7 @@ if __name__ == "__main__":
             shape_syst[pol] = histos
             value_syst[pol] = values
 
+
         systematics = {}
         xsec_systematics = {}
         for pol in polarizations:
@@ -465,12 +466,13 @@ if __name__ == "__main__":
             systs=[]
             xsec_systs=[]
             for iy,y in enumerate(ybinwidths['{ch}_{pol}'.format(ch=charge,pol=pol if not pol=='long' else 'right')]):
-                #print "\tBin iy=%d,y=%f = " % (iy,y)
                 nom = nominal[pol][iy]
                 xsec_nom = xsec_nominal[pol][iy]
+                #print "\tBin iy={iy},y={y}. Nom = {nom} ".format(iy=iy,y=y,nom=nom)
                 totUp=0; xsec_totUp=0
                 for ip,pdf in enumerate(shape_syst[pol]):
                     xsec_pdf = value_syst[pol][ip]
+                    #print "\tip = {ip}  pdf = {pdf}".format(ip=ip,pdf=pdf[iy])
                     # debug
                     relsyst = abs(nom-pdf[iy])/nom
                     xsec_relsyst = abs(xsec_nom-xsec_pdf[iy])/xsec_nom if xsec_nom else 0.0

--- a/WMass/python/plotter/w-helicity-13TeV/subMatrix.py
+++ b/WMass/python/plotter/w-helicity-13TeV/subMatrix.py
@@ -26,9 +26,14 @@ def niceName(name):
 
     if '_Ybin' in name:
         nn  = '#mu: ' if '_mu_' in name else 'el: '
-        nn += 'W+ ' if 'plus' in name else 'W- '
-        nn += 'left ' if 'left' in name else 'right ' if 'right' in name else 'long '
-        idx = -2 if ('masked' in name or name.endswith('mu')) else -1
+        if 'plus' in name: nn += 'W+ '
+        elif 'minus' in name: nn += 'W- '
+        else: nn += 'W '
+        if 'left' in name: nn += 'left '
+        elif 'right' in name: nn += 'right '
+        elif 'long' in name: nn += 'long '
+        else: nn += 'unpolarized '
+        idx = -2 if (name.endswith('mu') or any([x in name for x in ['masked','sumxsec','charge','a0','a4']])) else -1
         nn += name.split('_')[idx]
         #if 'pmaskedexp' in name: nn += ' #sigma'
         #if 'norm' in name: nn += '_{norm}'

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -76,7 +76,7 @@ class util:
                 istart = histo.FindBin(val+epsilon)
                 iend   = histo.FindBin(ybins[cp][iv+1]+epsilon)
                 val = histo.IntegralAndError(istart, iend-1, err)/36000. ## do not include next bin
-                conts.append(float(int(val)))
+                conts.append(float(val))
             histos[pol] = conts
         histo_file.Close()
         return histos
@@ -599,7 +599,7 @@ class util:
         histos = { 'a0': ROOT.TH1D('a0','',100,-0.4,0.6),
                    'a4': ROOT.TH1D('a4','',100,-0.4,3.0)
                    }
-        print "getCoeffs: ",toyEvents," toyMC running..."
+        #print "getCoeffs: ",toyEvents," toyMC running..."
         for i in xrange(toyEvents):
             ixL = np.random.normal(xL,err_xL)
             ixR = np.random.normal(xR,err_xR)
@@ -607,7 +607,7 @@ class util:
             sumPol = ixL+ixR+ix0
             histos['a0'].Fill(2*ix0/sumPol)
             histos['a4'].Fill(2*(ixL-ixR)/sumPol)
-        print "toyMC done"
+        #print "toyMC done"
         ret = {}
         for k,h in histos.iteritems():
             ret[k] = (h.GetMean(),h.GetRMS())
@@ -615,11 +615,11 @@ class util:
             
     def getChargeAsy(self,xplus,xminus,err_xplus,err_xminus,toyEvents=10000):
         histo = ROOT.TH1D('asy','',100,-0.05,0.5)
-        print "getChargeAsy: ",toyEvents," toyMC running..."
+        #print "getChargeAsy: ",toyEvents," toyMC running..."
         for i in xrange(toyEvents):
             ixplus  = np.random.normal(xplus,err_xplus)
             ixminus = np.random.normal(xminus,err_xminus)
             histo.Fill((ixplus-ixminus)/(ixplus+ixminus))
-        print "toyMC done"
+        #print "toyMC done"
         ret = {'asy': (histo.GetMean(),histo.GetRMS())}
         return ret


### PR DESCRIPTION
Can now do the 1D impact of systematics, vs |YW| also for: 
- unpolarized cross sections
- charge asymmetry (for each polarization)
- charge asymmetry unpolarized
- A0, A4
By default, for the cross sections the relative impact is plotted, for the charge asymmetry and the A0, A4, the absolute impact is plotted. 

@bendavid plots for electrons, bin-by-bin included, expected fit are in:

   https://emanuele.web.cern.ch/emanuele/Analysis/WMass/13TeV/plots/fit/absY/results/2019-02-12/impactPlots/?match=exp1*bbb1
