### PR TITLE
Some general improvements

### DIFF
--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -3,19 +3,20 @@
 import ROOT, os, sys, re, array
 
 dryrun=0
-skipUnpack=1
-skipMergeRoot=1
-skipSingleCard=1
+skipUnpack=0
+skipMergeRoot=0
+skipSingleCard=0
 skipMergeCard=0
 
-folder = "diffXsec_el_2019_02_04_genpt2from26to30_pt1p5from30to45_eta0p2From1p2_dressed/" # keep "/" at the end
-th3file = "cards/" + folder + "wele_FixElescale_badSkim_genpt2from26to30_pt1p5from30to45_eta0p2From1p2_dressed.root"
-#folder = "diffXsec_mu_2019_01_24_pt2from26to30_pt1p5from30to45_eta0p2From1p2_dressed/" # keep "/" at the end
-#th3file = "cards/" + folder + "whist_eosTrees_skim_pt2from26to30_pt1p5from30to45_eta0p2From1p2.root"
+#folder = "diffXsec_el_2019_02_22_ptMax50_dressed/" # keep "/" at the end
+#th3file = "cards/" + folder + "wenu_histo_ptMax50.root"
+
+folder = "diffXsec_mu_2019_02_23_ptMax50_dressed/" # keep "/" at the end
+th3file = "cards/" + folder + "wmunu_histo_ptMax50.root"
 
 optionsForRootMerger = " --etaBordersForFakesUncorr 0.5,1.0,1.6,2.0 " # use 0.5,1.0,1.5,2.0 for muons, where eta bins are 0.1 wide
-optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --exclude-nuisances 'CMS_DY' " # --wXsecLnN 0.038 
-optionsForCardMakerMerger = " --postfix fixlepscale_fakesCont_noDYsigBkgNorm_fitgap_dressed --no-bbb --no-text2hdf5  "  # --no-text2hdf5
+optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous' " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta
+optionsForCardMakerMerger = " --postfix fakesPtEtaUncorr_noDYsigBkgNorm_dressed  "  # --no-text2hdf5
 
 # folder = "diffXsec_el_2018_12_16_onlyBkg_pt1GeV_eta0p2From1p3/"  # keep "/" at the end
 # th3file = "cards/" + folder + "wmass_varhists_ele_pt1GeV_eta0p2From1p3.root"

--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -3,9 +3,9 @@
 import ROOT, os, sys, re, array
 
 dryrun=0
-skipUnpack=0
-skipMergeRoot=0
-skipSingleCard=0
+skipUnpack=1
+skipMergeRoot=1
+skipSingleCard=1
 skipMergeCard=0
 
 folder = "diffXsec_el_2019_02_04_genpt2from26to30_pt1p5from30to45_eta0p2From1p2_dressed/" # keep "/" at the end
@@ -15,7 +15,7 @@ th3file = "cards/" + folder + "wele_FixElescale_badSkim_genpt2from26to30_pt1p5fr
 
 optionsForRootMerger = " --etaBordersForFakesUncorr 0.5,1.0,1.6,2.0 " # use 0.5,1.0,1.5,2.0 for muons, where eta bins are 0.1 wide
 optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --exclude-nuisances 'CMS_DY' " # --wXsecLnN 0.038 
-optionsForCardMakerMerger = " --postfix fixlepscale_fakesCont_noDYsigBkgNorm_fitgap_dressed "  # --no-text2hdf5
+optionsForCardMakerMerger = " --postfix fixlepscale_fakesCont_noDYsigBkgNorm_fitgap_dressed --no-bbb --no-text2hdf5  "  # --no-text2hdf5
 
 # folder = "diffXsec_el_2018_12_16_onlyBkg_pt1GeV_eta0p2From1p3/"  # keep "/" at the end
 # th3file = "cards/" + folder + "wmass_varhists_ele_pt1GeV_eta0p2From1p3.root"

--- a/WMass/python/plotter/getSumWeightPerSample.py
+++ b/WMass/python/plotter/getSumWeightPerSample.py
@@ -9,7 +9,9 @@ import re, sys, os, os.path
 #folder = "/afs/cern.ch/work/m/mdunser/public/wmassTrees/SKIMS_muons_latest/"
 #folder = "/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/ntuplesRecoil/TREES_SIGNAL_1l_recoil_fullTrees/"
 #folder = "/eos/cms/store/cmst3/group/wmass/mciprian/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_NOMT_V2/"
-folder = "/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/SKIMS_muons_latest/"
+#folder = "/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/SKIMS_muons_latest/"
+#folder = "/eos/cms/store/cmst3/group/wmass/mciprian/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_14Feb2019/"
+folder = "/eos/cms/store/cmst3/group/wmass/mciprian/TREES_WELE_19Feb2019/"
 print "Folder: %s " % folder
 
 

--- a/WMass/python/plotter/makeTH1FromTH3.py
+++ b/WMass/python/plotter/makeTH1FromTH3.py
@@ -187,6 +187,11 @@ for ikey,e in enumerate(tf.GetListOfKeys()):
                 newname += "_" + lasttoken
             if isEffStat and "ErfPar" not in lasttoken: newname = newname.replace("Erf","ErfPar")  # patch for bad names inside input file (ErfXX instead of ErfParXX)
             if newname.endswith('Dn'): newname = newname[:-2] + "Down"
+            # for EffStat, add <flavour><charge> at the end, because we use independent systs for charge and flavour, so the names must be different
+            # note that at this point the histograms don't have Up/Down in their name
+            if isEffStat:
+                suffixToAdd = "{fl}{ch}".format(fl=flavour, ch=charge)
+                newname += suffixToAdd
         hist = ROOT.TH1D(newname,"", len(thd1binning)-1, array('d', thd1binning))
         # unroll a slice of TH3 at fixed z (this is a TH2) into a 1D histogram
         for ix in range(1,1+obj.GetNbinsX()):

--- a/WMass/python/plotter/mergeRootComponentsDiffXsec.py
+++ b/WMass/python/plotter/mergeRootComponentsDiffXsec.py
@@ -44,7 +44,7 @@ def putEffStatHistosDiffXsec(infile,regexp,charge, outdir=None, isMu=True):
 
     basedir = '/afs/cern.ch/work/m/mdunser/public/cmssw/w-helicity-13TeV/CMSSW_8_0_25/src/CMGTools/WMass/python/postprocessing/data/'
     if isMu:
-        parfile_name = basedir+'/leptonSF/new2016_madeSummer2018/systEff_trgmu.root'
+        parfile_name = basedir+'/leptonSF/new2016_madeSummer2018/systEff_trgmu_{ch}_mu.root'.format(ch=charge)
     else:
         parfile_name = basedir+'/leptonSF/new2016_madeSummer2018/systEff_trgel.root'
 
@@ -80,7 +80,7 @@ def putEffStatHistosDiffXsec(infile,regexp,charge, outdir=None, isMu=True):
 
         # get width of bins in multiples of 0.1
         # for electrons the region around the gap is odd
-        # we don't need this value to be integer, otherwise keep in mind that 0.1 is not perfectly represeted with float in python
+        # we don't need this value to be integer, otherwise keep in mind that 0.1 is not perfectly represented with float in python
         # which entails that 0.2/0.1 might not yield 2.0, but 1.999
         binwidths = []
         for ieta in range(1,tmp_nominal_2d.GetNbinsX()+1):

--- a/WMass/python/plotter/mergeRootComponentsDiffXsec.py
+++ b/WMass/python/plotter/mergeRootComponentsDiffXsec.py
@@ -42,7 +42,7 @@ def putEffStatHistosDiffXsec(infile,regexp,charge, outdir=None, isMu=True):
     #genBins = templateBinning(gen_etaPtBinningVec[0],gen_etaPtBinningVec[1])        # this create a class to manage the binnings
 
 
-    basedir = '/afs/cern.ch/work/m/mdunser/public/cmssw/w-helicity-13TeV/CMSSW_8_0_25/src/CMGTools/WMass/python/postprocessing/data/'
+    basedir = '/afs/cern.ch/work/m/mdunser/public/cmssw/w-helicity-13TeV/CMSSW_8_0_25/src/CMGTools/WMass/python/postprocessing/data/'    
     if isMu:
         parfile_name = basedir+'/leptonSF/new2016_madeSummer2018/systEff_trgmu_{ch}_mu.root'.format(ch=charge)
     else:
@@ -53,7 +53,8 @@ def putEffStatHistosDiffXsec(infile,regexp,charge, outdir=None, isMu=True):
 
     tmp_infile = ROOT.TFile(infile, 'read')
 
-    outfile = ROOT.TFile(indir+'/ErfParEffStat_{ch}.root'.format(ch=charge), 'recreate')
+    flavour = "mu" if isMu else "el"
+    outfile = ROOT.TFile(indir+'/ErfParEffStat_{fl}_{ch}.root'.format(fl=flavour, ch=charge), 'recreate')
 
     ndone = 0
     for k in tmp_infile.GetListOfKeys():
@@ -87,16 +88,6 @@ def putEffStatHistosDiffXsec(infile,regexp,charge, outdir=None, isMu=True):
             binwidths.append(tmp_nominal_2d.GetXaxis().GetBinWidth(ieta)/0.1)  
 
         nEtaErfPar = 48 if isMu else 50
-
-        #nEtaErfPar = int(2* (genBins.etaBins[-1] + 0.001) * 10)
-        #parhistBinOffset = 0
-        #if nEtaErfPar == 48 and not isMu: 
-        #    parhistBinOffset = 1
-        # the offset is needed when for electrons the gen_eta bins arrive up to 2.4 (even though the reco arrives to 2.5)
-        # the reason is that the histogram h used for the reweigthing is defined from -2.5 to 2.5 for electrons, therefore in case the gen_bins stops at 2.4
-        # we prefer to skip thefirst and last bin of h
-        # this is because for the diffxsec we only reweight the strip whose eta correspond to the gen_eta bin, otherwise we would just need to consider the reco 
-        # binning, which can get up to 2.5 regardless the gen binning
 
         ## loop over the three parameters
         for npar in range(3):
@@ -133,7 +124,7 @@ def putEffStatHistosDiffXsec(infile,regexp,charge, outdir=None, isMu=True):
                 # one could device a fancy way to isolate the gap and assign a larger uncertainty around it but let's keep it simple
 
                 #print "ErfPar{p}EffStat{ieta}".format(p=npar,ieta=ietaErf)
-                outname_2d = tmp_nominal_2d.GetName().replace('backrolled','')+'_ErfPar{p}EffStat{ieta}2DROLLED'.format(p=npar,ieta=ietaErf)
+                outname_2d = tmp_nominal_2d.GetName().replace('backrolled','')+'_ErfPar{p}EffStat{ieta}{fl}{ch}2DROLLED'.format(p=npar,ieta=ietaErf,fl=flavour,ch=charge)
             
                 tmp_scaledHisto_up = copy.deepcopy(tmp_nominal_2d.Clone(outname_2d+'Up'))
                 tmp_scaledHisto_dn = copy.deepcopy(tmp_nominal_2d.Clone(outname_2d+'Down'))
@@ -146,6 +137,9 @@ def putEffStatHistosDiffXsec(infile,regexp,charge, outdir=None, isMu=True):
                     phistybin = parhist.GetYaxis().FindBin(ybincenter)
                     tmp_scale = parhist.GetBinContent(ietaErf, phistybin)
                     scaling = math.sqrt(2.)*tmp_scale
+                    ## scale electrons by sqrt(2) due to the input file being charge inclusive
+                    if flavour == 'el':
+                        scaling *= math.sqrt(2)
                     # modify scaling if template bin has larger width than the ErfPar histogram
                     if binwidths[ietaTemplate-1] > 1.: scaling = scaling / binwidths[ietaTemplate-1]
                     ## scale up and down with what we got from the histo
@@ -306,7 +300,7 @@ if not options.dryrun: os.system("rm {tmp}".format(tmp=tmpZfile))
 print "-"*20
 print ""
 
-fileZeffStat = "{od}ErfParEffStat_{ch}.root".format(od=outdir, ch=options.charge)  
+fileZeffStat = "{od}ErfParEffStat_{fl}_{ch}.root".format(od=outdir, fl=flavour, ch=options.charge)  
 # this name is used inside putEffStatHistosDiffXsec (do not change it outside here)
 print "Now adding ErfParXEffStatYY systematics to x_Z process"
 print "Will create file --> {of}".format(of=fileZeffStat)
@@ -356,21 +350,28 @@ print "-"*20
 print ""
 
 fileFakesEtaUncorr = "{od}FakesEtaUncorrelated_{ch}.root".format(od=outdir, ch=options.charge) 
-# this name is used inside putUncorrelatedFakes (do not change it outside here)
-print "Now adding FakesEtaUncorrelated systematics to x_data_fakes process"
+fileFakesPtUncorr  = "{od}FakesPtUncorrelated_{ch}.root".format(od=outdir, ch=options.charge) 
+# these names are used inside putUncorrelatedFakes (do not change them outside here)
+print "Now adding FakesEtaUncorrelated and FakesPtUncorrelated systematics to x_data_fakes process"
 print "Will create file --> {of}".format(of=fileFakesEtaUncorr)
+print "Will create file --> {of}".format(of=fileFakesPtUncorr)
 etaBordersForFakes = [float(x) for x in options.etaBordersForFakesUncorr.split(',')]
-if not options.dryrun: putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, etaBordersTmp=etaBordersForFakes)
+if not options.dryrun: 
+    putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, 
+                         etaBordersTmp=etaBordersForFakes, uncorrelateCharges=True)
+    putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, etaBordersTmp=etaBordersForFakes, 
+                         doPt = 'x_data_fakes_.*slope.*', uncorrelateCharges=True)
 
 print "Now merging signal + Z + data + other backgrounds + FakesEtaUncorrelated + ZEffStat"
 sigfile = "{osig}W{fl}_{ch}_shapes_signal.root".format(osig=options.indirSig, fl=flavour, ch=charge)
 
-cmdFinalMerge="hadd -f -k -O {of} {sig} {zf} {bkg} {fakesEta} {zEffStat}".format(of=shapename, 
-                                                                                 sig=sigfile, 
-                                                                                 zf=Zfile, 
-                                                                                 bkg=dataAndBkgFileTmp, 
-                                                                                 fakesEta=fileFakesEtaUncorr,
-                                                                                 zEffStat=fileZeffStat)
+cmdFinalMerge="hadd -f -k -O {of} {sig} {zf} {bkg} {fakesEta} {fakesPt} {zEffStat}".format(of=shapename, 
+                                                                                           sig=sigfile, 
+                                                                                           zf=Zfile, 
+                                                                                           bkg=dataAndBkgFileTmp, 
+                                                                                           fakesEta=fileFakesEtaUncorr,
+                                                                                           fakesPt=fileFakesPtUncorr,
+                                                                                           zEffStat=fileZeffStat)
 print "Final merging ..."
 print cmdFinalMerge
 if not options.dryrun: os.system(cmdFinalMerge)

--- a/WMass/python/plotter/myinstructions/instructions_to_do_skims.txt
+++ b/WMass/python/plotter/myinstructions/instructions_to_do_skims.txt
@@ -58,3 +58,5 @@ python  w-helicity-13TeV/skims.py w-helicity-13TeV/wmass_mu/skimming/mca-signal.
 
 # muon signal friends (see comment above)
 python  w-helicity-13TeV/skims.py w-helicity-13TeV/wmass_mu/skimming/mca-signal.txt w-helicity-13TeV/wmass_e/skimming/skimCuts_wmunu.txt /eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/SKIMS_muons_latest/ /eos/cms/store/cmst3/group/wmass/mciprian/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_NOMT -f w-helicity-13TeV/wmass_e/skimming/tests/varsSkim_80X_Wmu_sig_friends.txt --fo -q cmscaf1nd --log logs_friends_Wskim_24Nov2018
+
+

--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -6,29 +6,36 @@ import ROOT, os, sys, re, array
 
 dryrun = 0
 skipData = 0
-onlyData = 1
+onlyData = 0
 
 skipPlot = 0
+skipTemplate = 0
 skipDiffNuis = 1
 skipCorr = 1
-skipImpacts = 1
+skipImpacts = 0
+
 
 seed = 123456789
 #folder = "diffXsec_el_2018_12_31_pt2from26to30_pt1p5from30to45_recoPtFrom30_recoGenEta0p2from1p2to2p4/"
 #folder = "diffXsec_el_2018_12_27_pt2from26to30_pt1p5from30to45_eta0p2From1p2/"
+folder = "diffXsec_el_2019_02_22_ptMax50_dressed/"
 
 #folder = "diffXsec_mu_2019_01_24_pt2from26to30_pt1p5from30to45_eta0p2From1p2_dressed/"
-folder = "diffXsec_el_2019_02_04_genpt2from26to30_pt1p5from30to45_eta0p2From1p2_dressed/"
+#folder = "diffXsec_mu_2019_02_23_ptMax50_dressed/"
 
 #postfix = "allSyst_eosSkim_noZandWoutNorm_bbb1_cxs1"
 #postfix = "eosSkim_noZandWoutNorm_ZshapeEffAndScaleSyst_bbb1_cxs1"
-postfix = "fixlepscale_fakesCont_noDYsigBkgNorm_fitgap_dressed_bbb1_cxs1"
+postfix = "fakesPtEtaUncorr_noDYsigBkgNorm_dressed_bbb1_cxs1"
 
 flavour = "el" if "_el_" in folder else "mu"
 lepton = "electron" if flavour == "el"  else "muon"
 fits = ["Asimov", "Data"]
 
-ptBinsSetting = " --pt-range-bkg 25.9 30.1 --pt-range '30,45' " if flavour == "el"  else ""  # " --eta-range-bkg 1.39 1.61 "
+ptBinsSetting = " --pt-range-bkg 25.9 30.1 --pt-range '30,50' " if flavour == "el"  else ""  # " --eta-range-bkg 1.39 1.61 "
+
+optTemplate = " --draw-selected-etaPt 0.45,38.5 --syst-ratio-range 'template' --palette 57 "  # --draw-selected-etaPt 0.45,38 --zmin 10 # kLightTemperature=87
+ptMaxTemplate = "50"
+ptMinTemplate = "30" if flavour == "el" else "26"
 
 # do not ask Wplus.*_ieta_.*_mu$ to select signal strength rejecting pmasked, because otherwise you must change diffNuisances.py
 # currently it uses GetFromHessian with keepGen=True, so _mu$ would create a problem (should implement the possibility to reject a regular expression)
@@ -81,7 +88,8 @@ targets = [#"mu",
            #"xsec", 
            #"xsecnorm",
            #"etaptasym",
-           #"etaxsec",
+           "etaxsec",
+           "etaxsecnorm",
            "etaasym"
            ]
 
@@ -107,6 +115,23 @@ impacts_pois = [#"Wplus.*_ipt_2_.*" if flavour == "el" else "Wplus.*_ipt_0_.*",
 
 
 print ""
+
+for charge in ["plus","minus"]:
+    print ""
+    print "="*30
+    print "TEMPLATE ROLLING for charge " + charge
+    print ""
+
+    command = "python w-helicity-13TeV/templateRolling.py"
+    command += " cards/{fd} -o plots/diffXsecAnalysis/{lep}/{fd}/templateRolling/ -c {fl}".format(fd=folder, lep=lepton, fl=flavour)
+    command += " --plot-binned-signal -a diffXsec -C {ch} --pt-range '{ptmin},{ptmax}' ".format(ch=charge, ptmin=ptMinTemplate, ptmax=ptMaxTemplate)
+    command += " {opt} ".format(opt=optTemplate)
+    if not skipTemplate:
+        print ""
+        print command
+        if not dryrun:
+            os.system(command)
+
 
 for fit in fits:
 
@@ -199,7 +224,7 @@ for fit in fits:
                 varopt = " --nuis '{nuis_regexp}' --pois '{poi_regexp}' ".format(nuis_regexp=nuis, poi_regexp=poi)
             for target in targets:
                 tmpcommand = command + " {vopt} --target {t} ".format(vopt=varopt, t=target)            
-                if any(target == x for x in ["etaxsec", "etaasym"]):
+                if any(target == x for x in ["etaxsec", "etaxsecnorm", "etaasym"]):
                     tmpcommand += " --etaptbinfile cards/{fd}/binningPtEta.txt ".format(fd=folder)
                 if not skipImpacts:
                     print ""

--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -5,13 +5,13 @@ import ROOT, os, sys, re, array
 # to run plots from Asimov fit and data. For toys need to adapt this script
 
 dryrun = 0
-skipData = 1
-onlyData = 0
+skipData = 0
+onlyData = 1
 
-skipPlot = 1
+skipPlot = 0
 skipDiffNuis = 1
 skipCorr = 1
-skipImpacts = 0
+skipImpacts = 1
 
 seed = 123456789
 #folder = "diffXsec_el_2018_12_31_pt2from26to30_pt1p5from30to45_recoPtFrom30_recoGenEta0p2from1p2to2p4/"

--- a/WMass/python/plotter/runfakerateElectron.sh
+++ b/WMass/python/plotter/runfakerateElectron.sh
@@ -38,7 +38,7 @@ fi
 istest="y"
 # following option testdir is used only if istest is 'y'
 today=`date +"%d_%m_%Y"`
-testdir="testFRv8/fr_${today}_eta_${ptDefinition}_mT40_${lumi/./p}fb_signedEta_subtrAllMC_L1EGprefire_jetPt30_Zveto_newSkim_metSmear10"
+testdir="testFRv8/fr_${today}_eta_${ptDefinition}_mT40_${lumi/./p}fb_signedEta_subtrAllMC_L1EGprefire_jetPt30_Zveto_newSkim_ChargeMinus"
 ######################
 ######################
 # additional options to be passed to w-helicity-13TeV/make_fake_rates_data.py
@@ -49,8 +49,8 @@ testdir="testFRv8/fr_${today}_eta_${ptDefinition}_mT40_${lumi/./p}fb_signedEta_s
 #addOption=" -A eleKin pfmet 'met_pt<20' -A eleKin awayJetPt 'LepGood_awayJet_pt > 45' "
 #addOption=" -A eleKin pfmet 'met_pt<20' "
 #addOption=" -A eleKin json 'isGoodRunLS(isData,run,lumi)' -A eleKin pfmtLess40 'mt_2(met_pt,met_phi,ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_phi) < 40' "
-#addOption=" -A eleKin pfmtLess40 'mt_2(met_pt,met_phi,ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_phi) < 40' -A eleKin awayJetPt 'LepGood_awayJet_pt > 45' "
-addOption=" -A eleKin pfmtLess40_smearMet10 'mt_2(getSmearedVar(met_pt,0.1,evt,isData),met_phi,ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_phi) < 40' -A eleKin zveto 'fabs(100 - mass_2(LepGood_awayJet_pt,LepGood_awayJet_eta,LepGood_awayJet_phi,0,ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_eta,LepGood1_phi,0.000511)) > 10' "
+addOption=" -A eleKin pfmtLess40 'mt_2(met_pt,met_phi,ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_phi) < 40' -A eleKin minus 'LepGood1_charge < 0' "
+#addOption=" -A eleKin pfmtLess40_smearMet10 'mt_2(getSmearedVar(met_pt,0.1,evt,isData),met_phi,ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_phi) < 40' -A eleKin zveto 'fabs(100 - mass_2(LepGood_awayJet_pt,LepGood_awayJet_eta,LepGood_awayJet_phi,0,ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_eta,LepGood1_phi,0.000511)) > 10' "
 # for the Z veto, see plots here:
 # http://mciprian.web.cern.ch/mciprian/wmass/13TeV/distribution/TREES_1LEP_80X_V3_FRELSKIM_V8/FR_computation_region/full2016data_01_11_2018_FRvarNotNorm/
 

--- a/WMass/python/plotter/runplotsCondor.sh
+++ b/WMass/python/plotter/runplotsCondor.sh
@@ -36,6 +36,8 @@ mtMax=" -A eleKin pfmt 'mt_2(met_pt,met_phi,${ptcorr},LepGood1_phi) <= XX' "
 WselFull=" ${mtMin/XX/40} ${ptMax/XX/45} ${fiducial} "
 WselAllpt=" ${mtMin/XX/40} ${fiducial} "
 mtMinSmear=" -A eleKin pfmt_smear 'mt_2(getSmearedVar(met_pt,0.2,evt,isData),met_phi,${ptcorr},LepGood1_phi) >= XX' "
+chargePlus=" -A eleKin plus 'LepGood1_charge > 0'
+chargeMinus=" -A eleKin minus 'LepGood1_charge < 0'
 
 ##############################################################
 ##############################################################
@@ -64,8 +66,8 @@ else
 fi
 
 #useHLTpt27="y" # already in selection txt file
-runCondor="y"
-nameTag="_fakesTest_ptslopeAndEWKscaling" 
+runCondor="n"
+nameTag="_fakes_chPlus" 
 #nameTag="_varStudy"
 useLessMC="n"
 usePtCorrForScaleFactors="n" # y: use corrected pt for scale factor weight; n: use LepGood_pt (which is what would have been used if the scale factors where in a friend tree)
@@ -112,7 +114,8 @@ excludeprocesses="Z_LO,W_LO" # decide whether to use NLO (amc@NLO) or LO (MadGra
 #selectplots="trkmt_trkmetEleCorr_dy,trkmetEleCorr_dy"
 #selectplots="etal1_binFR"
 #selectplots="unrolled"
-selectplots="ptl1_narrow,etal1_binFR,ptl1__etal1_binFR"
+#selectplots="ptl1_narrow,etal1_binFR,ptl1__etal1_binFR"
+selectplots="ptl1large__etal1,ptl1_large,etal1_binFR"
 #selectplots="wminus_wpt,wminus_wy"
 #selectplots="nVert,rho"
 #selectplots="ptl1_wmass,pfmt_wmass"
@@ -137,9 +140,10 @@ maxentries=""  # all events if ""
 #scaleAllMCtoData=" --scaleBkgToData QCD --scaleBkgToData W --scaleBkgToData Z --scaleBkgToData Top --scaleBkgToData DiBosons " # does not seem to work as expected
 plottingMode="" # stack (default), nostack, norm (can leave "" for stack, otherwise " --plotmode <arg> ")
 
+#ratioPlotDataOptions="  "
 #ratioPlotDataOptions=" --plotmode norm --contentAxisTitle 'arbitrary units' "
-#ratioPlotDataOptions="--showRatio --maxRatioRange 0.9 1.1 --fixRatioRange " #--ratioDen background --ratioNums data,data_noJson --ratioYLabel 'data/MC' --sp data_noJson --noStackSig --showIndivSigs"
-ratioPlotDataOptions=" --plotmode nostack  --noLegendRatioPlot --showRatio --maxRatioRange 0.9 1.1 --fixRatioRange --ratioDen data_fakes --ratioNums data_fakes_slopeUp,data_fakes_slopeDn,data_fakes_EWKUp,data_fakes_EWKDn,data_fakes_EWKUpSlopeDn,data_fakes_EWKDnSlopeUp --ratioYLabel 'Var./Nomi.'"
+ratioPlotDataOptions="--showRatio --maxRatioRange 0.9 1.1 --fixRatioRange " #--ratioDen background --ratioNums data,data_noJson --ratioYLabel 'data/MC' --sp data_noJson --noStackSig --showIndivSigs"
+#ratioPlotDataOptions=" --plotmode nostack  --noLegendRatioPlot --showRatio --maxRatioRange 0.9 1.1 --fixRatioRange --ratioDen data_fakes --ratioNums data_fakes_slopeUp,data_fakes_slopeDn,data_fakes_EWKUp,data_fakes_EWKDn,data_fakes_EWKUpSlopeDn,data_fakes_EWKDnSlopeUp --ratioYLabel 'Var./Nomi.'"
 #ratioPlotDataOptions=" --noLegendRatioPlot  --plotmode nostack --showRatio --maxRatioRange 0.9 1.1 --fixRatioRange --ratioDen data_fakes --ratioNums data_fakes_slopeUp,data_fakes_pol1fitPt30to48,data_fakes_pol2 --ratioYLabel 'var/nomi' "
 #ratioPlotDataOptions=" --plotmode nostack --showRatio --maxRatioRange 0.8 1.2 --fixRatioRange --ratioDen W --ratioNums W_lepeff_Up,W_lepeff_Dn,W_elescale_Up,W_elescale_Dn --ratioYLabel 'var/nomi' "
 ratioPlotDataOptions_MCclosureTest="--showRatio --maxRatioRange 0.0 2.0 --fixRatioRange --ratioDen QCD --ratioNums QCDandEWK_fullFR,QCD_fakes --ratioYLabel 'FR/QCD' "
@@ -202,15 +206,15 @@ scaleMCdata["FRcompNumRegion"]=""
 # FR validation REGION
 #----------------------------
 regionKey["FRcheckRegion"]="FRcheckRegion"
-runRegion["FRcheckRegion"]="n"
+runRegion["FRcheckRegion"]="y"
 regionName["FRcheckRegion"]="FR_check_region"
 #skimTreeDir["FRcheckRegion"]="TREES_electrons_1l_V6_TINY"
 skimTreeDir["FRcheckRegion"]="TREE_4_XSEC_AFS"
 outputDir["FRcheckRegion"]="full2016data_${today}"
-regionCuts["FRcheckRegion"]=" -X nJet30 ${FRnumSel} ${fiducial} ${ptMax/XX/45} ${mtMax/XX/30}"
+regionCuts["FRcheckRegion"]=" -X nJet30 ${FRnumSel} ${fiducial} ${ptMax/XX/45} ${mtMax/XX/30} ${chargePlus} "
 #processManager["FRcheckRegion"]=" --xp W,WFlips,TauDecaysW "
 qcdFromFR["FRcheckRegion"]="y"
-scaleMCdata["FRcheckRegion"]=" -p data,Wincl,Z,data_fakes_pol1,TauTopVVFlips --scaleSigToData --sp data_fakes_pol1" #--fitData " # --scaleSigToData --sp data_fakes  " # --fitData
+scaleMCdata["FRcheckRegion"]=" -p data,Wincl,Z,data_fakes,TauTopVVFlips --scaleSigToData --sp data_fakes" #--fitData " # --scaleSigToData --sp data_fakes  " # --fitData
 #
 # --noLegendRatioPlot --canvasSize 3000 750 --setTitleYoffset 0.3
 #
@@ -247,19 +251,22 @@ scaleMCdata["WmassSignalRegion"]="--fitData"
 # WHELICITY SIGNAL REGION (avoid possibly all kinematic selections)
 #----------------------------
 regionKey["WhelicitySignalRegion"]="WhelicitySignalRegion"
-runRegion["WhelicitySignalRegion"]="y"
+runRegion["WhelicitySignalRegion"]="n"
 regionName["WhelicitySignalRegion"]="whelicity_signal_region"
 #skimTreeDir["WhelicitySignalRegion"]="TREES_1LEP_80X_V3_WSKIM_NEW" 
 #skimTreeDir["WhelicitySignalRegion"]="TREES_electrons_1l_V6_TINY" 
 skimTreeDir["WhelicitySignalRegion"]="TREE_4_XSEC_AFS" 
+#skimTreeDir["WhelicitySignalRegion"]="TREES_1LEP_80X_V3_MC" 
+#skimTreeDir["WhelicitySignalRegion"]="actualTrees" 
+#skimTreeDir["WhelicitySignalRegion"]="TREES_DYELE_19Feb2019" 
 #skimTreeDir["WhelicitySignalRegion"]="signalSkim" 
 outputDir["WhelicitySignalRegion"]="full2016data_${today}"
-regionCuts["WhelicitySignalRegion"]=" -X nJet30  ${fiducial} ${ptMax/XX/45} ${FRnumSel} ${mtMin/XX/40} " # "${WselAllPt} ${WselFull}" "${mtMinSmear/XX/40}"
+regionCuts["WhelicitySignalRegion"]=" -X nJet30  ${fiducial} ${ptMax/XX/55} ${FRnumSel} ${mtMin/XX/40} ${chargePlus} " # "${WselAllPt} ${WselFull}" "${mtMinSmear/XX/40}"
 qcdFromFR["WhelicitySignalRegion"]="y"
 #scaleMCdata["WhelicitySignalRegion"]=" -p data,W,data_fakes,Z,TauTopVVFlips --fitData " #--scaleSigToData --sp data_fakes " # " --fitData "
-scaleMCdata["WhelicitySignalRegion"]=" -p data_fakes,data_fakes_slopeUp,data_fakes_slopeDn,data_fakes_EWKUp,data_fakes_EWKDn,data_fakes_EWKUpSlopeDn,data_fakes_EWKDnSlopeUp  "
+#scaleMCdata["WhelicitySignalRegion"]=" -p data_fakes,data_fakes_slopeUp,data_fakes_slopeDn,data_fakes_EWKUp,data_fakes_EWKDn,data_fakes_EWKUpSlopeDn,data_fakes_EWKDnSlopeUp  "
 #scaleMCdata["WhelicitySignalRegion"]=" -p W,W_lepeff_Up,W_lepeff_Dn,W_elescale_Up,W_elescale_Dn  "
-#scaleMCdata["WhelicitySignalRegion"]=" -p W  "
+scaleMCdata["WhelicitySignalRegion"]=" -p data_fakes  "
 #--noLegendRatioPlot --canvasSize 3000 750 --setTitleYoffset 0.3" #--scaleSigToData --sp data_fakes " # --pg 'EWK := Wincl,Z,Top,Dibosons'
 #
 # data_fakes,Z,TauDecaysW,Top,DiBosons,WFlips
@@ -544,6 +551,20 @@ do
 
 	if [[ "${treedir}" == "signalSkim" ]]; then		
 	    treepath="/u2/mciprian/TREES_13TeV/electron/"
+	fi
+
+	# here add an hardcoded path
+	if [[ "${treedir}" == "TREES_1LEP_80X_V3_MC" ]]; then		
+	    #treepath="/eos/cms/store/group/dpg_ecal/comm_ecal/localreco/"
+	    treepath="/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/"
+	fi
+
+	if [[ "${treedir}" == "actualTrees" ]]; then		
+	    treepath="/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/TREES_1LEP_80X_V3_MC/"
+	fi
+
+	if [[ "${treedir}" == *"_19Feb2019"* ]]; then		
+	    treepath="/eos/cms/store/cmst3/group/wmass/mciprian/"
 	fi
 
 

--- a/WMass/python/plotter/runplotsCondor.sh
+++ b/WMass/python/plotter/runplotsCondor.sh
@@ -36,8 +36,8 @@ mtMax=" -A eleKin pfmt 'mt_2(met_pt,met_phi,${ptcorr},LepGood1_phi) <= XX' "
 WselFull=" ${mtMin/XX/40} ${ptMax/XX/45} ${fiducial} "
 WselAllpt=" ${mtMin/XX/40} ${fiducial} "
 mtMinSmear=" -A eleKin pfmt_smear 'mt_2(getSmearedVar(met_pt,0.2,evt,isData),met_phi,${ptcorr},LepGood1_phi) >= XX' "
-chargePlus=" -A eleKin plus 'LepGood1_charge > 0'
-chargeMinus=" -A eleKin minus 'LepGood1_charge < 0'
+chargePlus=" -A eleKin plus 'LepGood1_charge > 0'"
+chargeMinus=" -A eleKin minus 'LepGood1_charge < 0'"
 
 ##############################################################
 ##############################################################
@@ -66,8 +66,8 @@ else
 fi
 
 #useHLTpt27="y" # already in selection txt file
-runCondor="n"
-nameTag="_fakes_chPlus" 
+runCondor="y"
+nameTag="_fakes_chMinus_ptMax55_pol2" 
 #nameTag="_varStudy"
 useLessMC="n"
 usePtCorrForScaleFactors="n" # y: use corrected pt for scale factor weight; n: use LepGood_pt (which is what would have been used if the scale factors where in a friend tree)
@@ -211,7 +211,7 @@ regionName["FRcheckRegion"]="FR_check_region"
 #skimTreeDir["FRcheckRegion"]="TREES_electrons_1l_V6_TINY"
 skimTreeDir["FRcheckRegion"]="TREE_4_XSEC_AFS"
 outputDir["FRcheckRegion"]="full2016data_${today}"
-regionCuts["FRcheckRegion"]=" -X nJet30 ${FRnumSel} ${fiducial} ${ptMax/XX/45} ${mtMax/XX/30} ${chargePlus} "
+regionCuts["FRcheckRegion"]=" -X nJet30 ${FRnumSel} ${fiducial} ${ptMax/XX/55} ${mtMax/XX/30} ${chargeMinus} "
 #processManager["FRcheckRegion"]=" --xp W,WFlips,TauDecaysW "
 qcdFromFR["FRcheckRegion"]="y"
 scaleMCdata["FRcheckRegion"]=" -p data,Wincl,Z,data_fakes,TauTopVVFlips --scaleSigToData --sp data_fakes" #--fitData " # --scaleSigToData --sp data_fakes  " # --fitData
@@ -445,7 +445,7 @@ fi
 # otherwise the parsing of the option parameters is not done correctly
 
 
-commonCommand="python ${plotterPath}/mcPlots.py -f -l ${luminosity} --s2v --tree treeProducerWMass --obj tree --lspam '#bf{CMS} #it{Preliminary}' --legendWidth 0.25 --legendFontSize 0.05 ${plotterPath}/w-helicity-13TeV/wmass_e/${mcafile} ${plotterPath}/w-helicity-13TeV/wmass_e/${cutfile} ${plotterPath}/w-helicity-13TeV/wmass_e/${plotfile} ${dataOption} ${plottingMode} --noCms "
+commonCommand="python ${plotterPath}/mcPlots.py -f -l ${luminosity} --s2v --tree treeProducerWMass --obj tree --lspam '#bf{CMS} #it{Preliminary}' --legendWidth 0.25 --legendFontSize 0.05 ${plotterPath}/w-helicity-13TeV/wmass_e/${mcafile} ${plotterPath}/w-helicity-13TeV/wmass_e/${cutfile} ${plotterPath}/w-helicity-13TeV/wmass_e/${plotfile} ${dataOption} ${plottingMode} --noCms --n-column-legend 2 --setLegendCoordinates '0.2,0.78,0.9,0.92' "
 
 # if [[ "X${scaleAllMCtoData}" != "X" ]]; then
 #     commonCommand="${commonCommand} ${scaleAllMCtoData} "

--- a/WMass/python/plotter/skimFTrees.py
+++ b/WMass/python/plotter/skimFTrees.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
     parser.add_option("-q", "--queue",   dest="queue",     type="string", default=None, help="Run jobs on lxbatch instead of locally");
     parser.add_option("--log", "--log-dir", dest="logdir", type="string", default=None, help="Directory of stdout and stderr");
     parser.add_option("--pretend",     dest="pretend", default=False, action="store_true",  help="Pretend to skim, don't actually do it") 
+    parser.add_option("-n", "--job-name", dest="jobName",   type="string", default="skimTrees", help="Name assigned to jobs");
     (options, args) = parser.parse_args()
     if len(args)<3:
         print "Usage: program <BIGTREE_DIR> <FTREE_DIR> <outdir>"
@@ -100,8 +101,9 @@ Output     = {ld}/$(ProcId).out
 Error      = {ld}/$(ProcId).error
 getenv      = True
 request_memory = 4000
-+MaxRuntime = 43200\n
-'''.format(runner=runner,ld=options.logdir))
++MaxRuntime = 43200
++JobBatchName = "{name}"\n
+'''.format(runner=runner,ld=options.logdir,name=options.jobName))
         if os.environ['USER'] in ['mdunser', 'psilva']:
             condor_f.write('+AccountingGroup = "group_u_CMST3.all"\n')
         condor_f.write('\n')

--- a/WMass/python/plotter/skimTrees.py
+++ b/WMass/python/plotter/skimTrees.py
@@ -130,6 +130,7 @@ def addSkimTreesOptions(parser):
     parser.add_option("-q", "--queue",   dest="queue",     type="string", default=None, help="Run jobs on lxbatch instead of locally");
     parser.add_option("-c", "--component", dest="component",   type="string", default=None, help="skim only this component");
     parser.add_option("--log", "--log-dir", dest="logdir", type="string", default=None, help="Directory of stdout and stderr");
+    parser.add_option("-n", "--job-name", dest="jobName",   type="string", default="skimTrees", help="Name assigned to jobs");
     
 
 if __name__ == "__main__":
@@ -187,8 +188,9 @@ Output     = {ld}/{p}_$(ProcId).out
 Error      = {ld}/{p}_$(ProcId).error
 getenv      = True
 request_memory = 4000
-+MaxRuntime = 43200\n
-'''.format(runner=runner,p=proc,ld=options.logdir))
++MaxRuntime = 43200
++JobBatchName = "{name}"\n
+'''.format(runner=runner,p=proc,ld=options.logdir, name=options.jobName))
             if os.environ['USER'] in ['mdunser', 'psilva']:
                 condor_f.write('+AccountingGroup = "group_u_CMST3.all"\n')
             condor_f.write('\n')

--- a/WMass/python/plotter/utilityMacros/src/loopNtuplesSkeleton.C
+++ b/WMass/python/plotter/utilityMacros/src/loopNtuplesSkeleton.C
@@ -78,11 +78,11 @@ void fillHistograms(const string& treedir = "./",
   					    1.1,1.2,1.4,1.6,1.8,2.0, 2.2, 2.4};
   //vector<Double_t> ptBinEdgesTemplateMu = {26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45};
   //vector<Double_t> ptBinEdgesTemplateMu = {26,28,30,32,34,36,38,40,42,44,46};
-  vector<Double_t> ptBinEdgesTemplateMu = {26,28,30,31.5,33,34.5,36,37.5,39.0,40.5,42,43.5,45,47.5,50,52.5,55};
+  vector<Double_t> ptBinEdgesTemplateMu = {26,28,30,31.5,33,34.5,36,37.5,39.0,40.5,42,43.5,45,46.5,48,50};
   //vector<Double_t> genEtaBinEdgesTemplateMu = {0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.2,2.4}; // ,2.1,2.2,2.3,2.4};
   vector<Double_t> genEtaBinEdgesTemplateMu = {0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.4,1.6,1.8,2.0,2.2,2.4}; // ,2.1,2.2,2.3,2.4};
   //vector<Double_t> genPtBinEdgesTemplateMu = {26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,47.5,50,52.5,55};
-  vector<Double_t> genPtBinEdgesTemplateMu = {26,28,30,31.5,33,34.5,36,37.5,39.0,40.5,42,43.5,45,47.5,50,52.5,55};
+  vector<Double_t> genPtBinEdgesTemplateMu = {26,28,30,31.5,33,34.5,36,37.5,39.0,40.5,42,43.5,45,46.5,48,50};
 
   // electron
   // vector<Double_t> etaBinEdgesTemplateEl = {-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.6,-1.566,-1.5,-1.4442,-1.4,-1.3,-1.2,-1.1,-1.0,-0.9,
@@ -101,10 +101,10 @@ void fillHistograms(const string& treedir = "./",
   vector<Double_t> etaBinEdgesTemplateEl = {-2.4,-2.2,-2.0,-1.8,-1.6,-1.566,-1.4442,-1.4,-1.2,-1.1,-1.0,-0.9,
 					    -0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.4,
 					    1.4442,1.566,1.6,1.8,2.0,2.2,2.4};
-  vector<Double_t> ptBinEdgesTemplateEl = {30,31.5,33,34.5,36,37.5,39,40.5,42,43.5,45};
-  //vector<Double_t> ptBinEdgesTemplateEl = {26,28,30,31.5,33,34.5,36,37.5,39,40.5,42,43.5,45};
+  vector<Double_t> ptBinEdgesTemplateEl = {30,31.5,33,34.5,36,37.5,39,40.5,42,43.5,45,46.5,48,50};
+  //vector<Double_t> ptBinEdgesTemplateEl = {26,28,30,31.5,33,34.5,36,37.5,39,40.5,42,43.5,45,46.5,48,50};
   vector<Double_t> genEtaBinEdgesTemplateEl = {0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.4,1.6,1.8,2.0,2.2,2.4};
-  vector<Double_t> genPtBinEdgesTemplateEl = {26,28,30,31.5,33,34.5,36,37.5,39,40.5,42,43.5,45};
+  vector<Double_t> genPtBinEdgesTemplateEl = {26,28,30,31.5,33,34.5,36,37.5,39,40.5,42,43.5,45,46.5,48,50};
   
   vector<Double_t> etaBinEdgesTemplate;
   vector<Double_t> ptBinEdgesTemplate;
@@ -537,10 +537,18 @@ void fillHistograms(const string& treedir = "./",
   ////////////////////
 
   Double_t sumWgt = 9.56169443709e+13;
-  if (treedir == "/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/SKIMS_muons_latest/")
+  // if (treedir == "/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/SKIMS_muons_latest/")
+  //   sumWgt = 9.47291822594e+13;
+  // else if (treedir == "/eos/cms/store/cmst3/group/wmass/mciprian/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_14Feb2019/")
+  //   sumWgt = 9.47291822594e+13;
+  // else if (treedir == "/u1/mciprian/trees/muon/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_14Feb2019/")
+  //   sumWgt = 9.47291822594e+13;
+
+  if (treedir.find("TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_14Feb2019") != string::npos || 
+      treedir.find("SKIMS_muons_latest") != string::npos) {
     sumWgt = 9.47291822594e+13;
-  else if (treedir == "/eos/cms/store/cmst3/group/wmass/mciprian/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_14Feb2019/")
-    sumWgt = 9.47291822594e+13;
+    cout << "Warning: setting sumWgt = " << sumWgt << endl;
+  }
   
   Double_t intLumiPb = 1000.0 * intLumi;
   Double_t intLumiPbXsecZ = intLumiPb * 2008.4 * 3.; // for Z the xsec in the ntuples is no more valid, it changed

--- a/WMass/python/plotter/utilityMacros/src/makeFakeRateGraphPlotsAndSmoothing.C
+++ b/WMass/python/plotter/utilityMacros/src/makeFakeRateGraphPlotsAndSmoothing.C
@@ -843,6 +843,9 @@ void doFakeRateGraphPlots(const string& inputFileName = "",
 
       // hFR2D->SetMinimum(0.0);
       // hFR2D->SetMaximum(1.0);
+      // save also unsmoothed FR for future reference
+      cout << endl;      
+      hFR2D->SaveAs((outDir_num_den + Form("fakeRate_pt_vs_eta_%s",processes[j].c_str()) + ".root").c_str());
       drawCorrelationPlot(hFR2D, 
 			  ptXaxisName,
 			  etaYaxisName,
@@ -1217,10 +1220,10 @@ void doFakeRateGraphPlots(const string& inputFileName = "",
 }
 
 //================================================================
-void makeFakeRateGraphPlotsAndSmoothing(const string& inputFilePath = "www/wmass/13TeV/fake-rate/test/testFRv8/fr_06_02_2019_eta_pt_granular_mT40_35p9fb_signedEta_subtrAllMC_L1EGprefire_jetPt30_Zveto_newSkim_metSmear10/el/comb/",
+void makeFakeRateGraphPlotsAndSmoothing(const string& inputFilePath = "www/wmass/13TeV/fake-rate/test/testFRv8/fr_22_02_2019_eta_pt_granular_mT40_35p9fb_signedEta_subtrAllMC_L1EGprefire_jetPt30_Zveto_newSkim_ChargePlus/el/comb/",
 					//const string& outDir_tmp = "SAME", 
-					const string& outDir_tmp = "www/wmass/13TeV/fake-rate/electron/FR_graphs_tests/fr_L1EGprefire_jetPt30_Zveto_newSkim_fitPol1_compareManyFits_xMaxFit48_metSmear10/", 
-					const string& outfileTag = "fr_L1EGprefire_jetPt30_Zveto_newSkim_fitPol1_compareManyFits_xMaxFit48_metSmear10",
+					const string& outDir_tmp = "www/wmass/13TeV/fake-rate/electron/FR_graphs_tests/fr_L1EGprefire_jetPt30_Zveto_newSkim_fitPol1_compareManyFits_xMaxFit48_ChargePlus/", 
+					const string& outfileTag = "fr_L1EGprefire_jetPt30_Zveto_newSkim_fitPol1_compareManyFits_xMaxFit48_ChargePlus",
 					const string& histPrefix = "fakeRateNumerator_el_vs_etal1_pt_granular",
 					const Bool_t isMuon = false, 
 					const Bool_t showMergedEWK = true, // even if it is false, this is added in the final output root file

--- a/WMass/python/plotter/utilityMacros/src/makeLoopTree.C
+++ b/WMass/python/plotter/utilityMacros/src/makeLoopTree.C
@@ -14,7 +14,7 @@ using namespace std;
 
 void makeLoopTree(const bool isMuon = false, 
 		  const string& outfileName = "wmass_varhists.root",
-		  const string& usePreFSRvar = "true"  // if "false", use DressedLepton. Pass it as a string to build command below ("1" or "0" work as well)
+		  const string& usePreFSRvar = "false"  // if "false", use DressedLepton. Pass it as a string to build command below ("1" or "0" work as well)
 		  ) 
 
 {
@@ -41,19 +41,14 @@ void makeLoopTree(const bool isMuon = false,
 
     if (host_name.find("lxplus") != string::npos) 
       command = "loopNtuplesSkeleton(\"/eos/cms/store/cmst3/group/wmass/mciprian/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_14Feb2019/\",\"./\",\"" + outfileName + "\",true,"+ usePreFSRvar + ")";
-    // command = "loopNtuplesSkeleton(\"/eos/cms/store/cmst3/group/wmass/mciprian/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_NOMT_V2/\",\"./\",\"" + outfileName + "\",true,"+ usePreFSRvar + ")";
-      // command = "loopNtuplesSkeleton(\"/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/ntuplesRecoil/TREES_SIGNAL_1l_recoil_fullTrees/\",\"./\",\"" + outfileName + "\",true,"+ usePreFSRvar + ")";
-    
-    // the following does not work, requires to read tree.root.url
-    //command = "loopNtuplesSkeleton(\"/afs/cern.ch/work/m/mdunser/public/wmassTrees/SKIMS_muons_latest/\",\"./\",\"" + outfileName + "\",true,"+ usePreFSRvar + ")";
 
     else if (host_name.find("pccmsrm") != string::npos) 
-      command = "loopNtuplesSkeleton(\"/u2/mciprian/TREES_13TeV/muon/signalSkim/\",\"./\",\"" + outfileName + "\",true,"+ usePreFSRvar + ")";
+      command = "loopNtuplesSkeleton(\"/u1/mciprian/trees/muon/TREES_1LEP_80X_V3_SIGSKIM_WMUNU_FULLSEL_14Feb2019/\",\"./\",\"" + outfileName + "\",true,"+ usePreFSRvar + ")";
 
   } else {
 
     if (host_name.find("lxplus") != string::npos) 
-      command = "loopNtuplesSkeleton(\"/eos/cms/store/cmst3/group/wmass/mciprian/TREES_1LEP_80X_V3_SIGSKIM_WENU_FULLSEL_NOMT/\",\"./\",\"" + outfileName + "\",false,"+ usePreFSRvar + ")";
+      command = "loopNtuplesSkeleton(\"/eos/cms/store/cmst3/group/wmass/mciprian/TREES_WELE_19Feb2019/\",\"./\",\"" + outfileName + "\",false,"+ usePreFSRvar + ")";
     else if (host_name.find("pccmsrm") != string::npos) 
       command = "loopNtuplesSkeleton(\"/u2/mciprian/TREES_13TeV/electron/signalSkim/\",\"./\",\"" + outfileName + "\",false,"+ usePreFSRvar + ")";
   }

--- a/WMass/python/plotter/utilityMacros/src/makeLoopTree.C
+++ b/WMass/python/plotter/utilityMacros/src/makeLoopTree.C
@@ -50,7 +50,7 @@ void makeLoopTree(const bool isMuon = false,
     if (host_name.find("lxplus") != string::npos) 
       command = "loopNtuplesSkeleton(\"/eos/cms/store/cmst3/group/wmass/mciprian/TREES_WELE_19Feb2019/\",\"./\",\"" + outfileName + "\",false,"+ usePreFSRvar + ")";
     else if (host_name.find("pccmsrm") != string::npos) 
-      command = "loopNtuplesSkeleton(\"/u2/mciprian/TREES_13TeV/electron/signalSkim/\",\"./\",\"" + outfileName + "\",false,"+ usePreFSRvar + ")";
+      command = "loopNtuplesSkeleton(\"/u1/mciprian/trees/electron/TREES_WELE_19Feb2019/\",\"./\",\"" + outfileName + "\",false,"+ usePreFSRvar + ")";
   }
 
   //string command = "loopNtuplesSkeleton(\"/eos/cms/store/cmst3/group/wmass/w-helicity-13TeV/trees/TREES_electrons_1l_V6_TINY/\",\"./\",\"" + outfileName + "\")";

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -134,7 +134,7 @@ def combCharges(options):
             combineCmd = 'combinetf.py -t -1 --binByBinStat --correlateXsecStat {metafile}'.format(metafile=combinedCard.replace('.txt','_sparse.hdf5' if options.sparse else '.hdf5'))
         print combineCmd
 
-def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBordersTmp=[], doPt = False, uncorrelateCharges = False):
+def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBordersTmp=[], doPt = False):
 
     # for differential cross section I don't use the same option for inputs, so I pass it from outside
     indir = outdir if outdir != None else options.inputdir 
@@ -155,9 +155,11 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
     binning = [recoBins.Neta, recoBins.etaBins, recoBins.Npt, recoBins.ptBins]
     etabins = recoBins.etaBins
 
+    flav = 'mu' if isMu else 'el'
+
     tmp_infile = ROOT.TFile(infile, 'read')
     
-    outfile = ROOT.TFile('{od}/Fakes{sn}Uncorrelated_{ch}.root'.format(od=indir, sn='Eta' if not doPt else 'Pt', ch=charge), 'recreate')
+    outfile = ROOT.TFile('{od}/Fakes{sn}Uncorrelated_{flav}_{ch}.root'.format(od=indir, sn='Eta' if not doPt else 'Pt', flav=flav, ch=charge), 'recreate')
 
     ndone = 0
 
@@ -171,6 +173,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
             if re.match(doPt, tmp_name) and 'Down' in tmp_name: var_dn = tmp_name
         if var_up == None or var_dn == None:
             print 'DID NOT FIND THE RIGHT KEY!!!'
+            quit()
 
     for k in tmp_infile.GetListOfKeys():
         tmp_name = k.GetName()
@@ -215,17 +218,11 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
                 elif distFromCenter<2: scalings.append(0.02)
                 else:                  scalings.append(0.05)
 
-        postfixForFlavourAndCharge = ""
-        # postfixForFlavourAndCharge = "mu" if isMu else "el"
-        # if uncorrelateCharges:
-        #     postfixForFlavourAndCharge += charge
-        
-
         ## loop over all eta bins of the 2d histogram
         for ib, borderBin in enumerate(borderBins[:-1]):
 
             systName = 'Fakes{v}Uncorrelated'.format(v='Eta' if not doPt else 'Pt')
-            outname_2d = tmp_nominal_2d.GetName().replace('backrolled','')+'_{sn}{ib}{flch}2DROLLED'.format(sn=systName,ib=ib+1,flch=postfixForFlavourAndCharge)
+            outname_2d = tmp_nominal_2d.GetName().replace('backrolled','')+'_{sn}{ib}{flav}{ch}2DROLLED'.format(sn=systName,ib=ib+1,flav=flav,ch=charge)
         
             tmp_scaledHisto_up = copy.deepcopy(tmp_nominal_2d.Clone(outname_2d+'Up'))
             tmp_scaledHisto_dn = copy.deepcopy(tmp_nominal_2d.Clone(outname_2d+'Down'))

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -215,9 +215,10 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
                 elif distFromCenter<2: scalings.append(0.02)
                 else:                  scalings.append(0.05)
 
-        postfixForFlavourAndCharge = "mu" if isMu else "el"
-        if uncorrelateCharges:
-            postfixForFlavourAndCharge += charge
+        postfixForFlavourAndCharge = ""
+        # postfixForFlavourAndCharge = "mu" if isMu else "el"
+        # if uncorrelateCharges:
+        #     postfixForFlavourAndCharge += charge
         
 
         ## loop over all eta bins of the 2d histogram

--- a/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
@@ -161,6 +161,8 @@ if __name__ == "__main__":
 
     lepton = "electron" if channel == "el" else "muon"
     Wchannel = "W #rightarrow %s#nu" % ("e" if channel == "el" else "#mu")
+    ptRangeText = "p_{{T}}^{{{l}}} #in [{ptmin:3g}, {ptmax:3g}] GeV".format(l="e" if channel == "el" else "#mu", ptmin=genBins.ptBins[0], ptmax=genBins.ptBins[-1])
+
 
     hChAsymm = ROOT.TH2F("hChAsymm_{lep}".format(lep=lepton),"Charge asymmetry: {Wch}".format(Wch=Wchannel),
                          genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
@@ -224,10 +226,10 @@ if __name__ == "__main__":
         yaxisTitle = yaxisTitle + "::%s,%s" % (ptmin, ptmax)
     #zaxisTitle = "Asymmetry::%.3f,%.3f" % (hChAsymm.GetMinimum(),hChAsymm.GetMaximum())
     if options.fitData:
-        zaxisTitle = "Asymmetry::0.05,0.45"
+        zaxisTitle = "Asymmetry::0.05,0.35"
         if channel == "el": zaxisTitle = "Asymmetry::0.0,0.45"
         zaxisTitle = "Asymmetry::%.3f,%.3f" % (max(0,0.99*hChAsymm.GetBinContent(hChAsymm.GetMinimumBin())),
-                                               min(0.5,hChAsymm.GetBinContent(hChAsymm.GetMaximumBin())))
+                                               min(0.30,hChAsymm.GetBinContent(hChAsymm.GetMaximumBin())))
 
     else:
         zaxisTitle = "Asymmetry::0.05,0.35"
@@ -263,13 +265,18 @@ if __name__ == "__main__":
                         "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas,palette=options.palette)
 
 
-    additionalText = "W #rightarrow {lep}#nu::0.2,0.5,0.4,0.6".format(lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
+    #additionalText = "W #rightarrow {lep}#nu::0.2,0.5,0.4,0.6".format(lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
+    #additionalText = "W #rightarrow {lep}#nu;{pttext}::0.2,0.6,0.5,0.7".format(lep="e" if channel == "el" else "#mu", pttext=ptRangeText) # pass x1,y1,x2,y2
+    texCoord = "0.2,0.65"
+    additionalText = "W #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(lep="e" if channel == "el" else "#mu", 
+                                                                               pttext=ptRangeText,
+                                                                               txc=texCoord)
     legendCoords = "0.2,0.4,0.75,0.85"
     drawSingleTH1(hChAsymm1Deta,xaxisTitle,"charge asymmetry",
-                  "chargeAsym1D_eta_abs_{fl}".format(fl=channel),
+                  "chargeAsym1D_eta_{fl}".format(fl=channel),
                   outname,labelRatioTmp="Rel.Unc.::0.9,1.1",legendCoords=legendCoords, draw_both0_noLog1_onlyLog2=1, drawLineLowerPanel="",
                   passCanvas=canvas1D, lumi=options.lumiInt,
-                  lowerPanelHeight=0.35, moreText=additionalText
+                  lowerPanelHeight=0.35, moreTextLatex=additionalText
                   )
 
     icharge = 0
@@ -306,6 +313,11 @@ if __name__ == "__main__":
         hDiffXsec_1Deta = ROOT.TH1F("hDiffXsec_1Deta_{lep}_{ch}".format(lep=lepton,ch=charge),
                                     "cross section: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
                                     genBins.Neta, array('d',genBins.etaBins))
+
+        hDiffXsecNorm_1Deta = ROOT.TH1F("hDiffXsecNorm_1Deta_{lep}_{ch}".format(lep=lepton,ch=charge),
+                                        "cross section: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
+                                        genBins.Neta, array('d',genBins.etaBins))
+
 
         #nbins = genBins.Neta * (genBins.Npt - nPtBinsBkg)
         binCount = 1        
@@ -381,12 +393,19 @@ if __name__ == "__main__":
             hDiffXsec_1Deta.SetBinContent(ieta, central)
             hDiffXsec_1Deta.SetBinError(ieta, error)
 
+            central = utilities.getNormalizedDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=tree)
+            error   = utilities.getNormalizedDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=tree, getErr=True)
+            hDiffXsecNorm_1Deta.SetBinContent(ieta, central)
+            hDiffXsecNorm_1Deta.SetBinError(ieta, error)
+
+
         if options.normWidth:
             hDiffXsec.Scale(1.,"width")
             hDiffXsecErr.Scale(1.,"width")
             hDiffXsecNorm.Scale(1.,"width")
             hDiffXsecNormErr.Scale(1.,"width")
             hDiffXsec_1Deta.Scale(1.,"width")
+            hDiffXsecNorm_1Deta.Scale(1.,"width")
 
         if options.lumiNorm > 0:
             scaleFactor = 1./options.lumiNorm
@@ -487,13 +506,23 @@ if __name__ == "__main__":
                             "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas,palette=options.palette)
 
 
-        additionalText = "W^{{{chs}}} #rightarrow {lep}#nu::0.45,0.8,0.65,0.9".format(chs=" "+chargeSign,lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
+        # with only W -> munu, coordinates can be 0.45,0.8,0.65,0.9 with TPaveText
+        texCoord = "0.45,0.85" if charge == "plus" else "0.45,0.5"
+        additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(chs=" "+chargeSign,lep="e" if channel == "el" else "#mu",
+                                                                                             pttext=ptRangeText,
+                                                                                             txc=texCoord) 
         legendCoords = "0.2,0.4,0.75,0.85" if charge == "plus" else "0.2,0.4,0.4,0.5"
         drawSingleTH1(hDiffXsec_1Deta,xaxisTitle,"d#sigma/d|#eta| [pb]",
                       "xsec_eta_abs_{ch}_{fl}".format(ch=charge,fl=channel),
                       outname,labelRatioTmp="Rel.Unc.::0.9,1.1",legendCoords=legendCoords, draw_both0_noLog1_onlyLog2=1,
                       passCanvas=canvas1D, lumi=options.lumiInt,
-                      lowerPanelHeight=0.35, moreText=additionalText
+                      lowerPanelHeight=0.35, moreTextLatex=additionalText
+                      )
+        drawSingleTH1(hDiffXsecNorm_1Deta,xaxisTitle,"d#sigma/d|#eta| / #sigma_{tot}",
+                      "xsec_eta_norm_{ch}_{fl}".format(ch=charge,fl=channel),
+                      outname,labelRatioTmp="Rel.Unc.::0.9,1.1",legendCoords=legendCoords, draw_both0_noLog1_onlyLog2=1,
+                      passCanvas=canvas1D, lumi=options.lumiInt,
+                      lowerPanelHeight=0.35, moreTextLatex=additionalText
                       )
 
 
@@ -545,7 +574,7 @@ if __name__ == "__main__":
             h1D_pmaskedexp_norm[unrollAlongEta] = getTH1fromTH2(hDiffXsecNorm, hDiffXsecNormErr, unrollAlongX=unrollAlongEta)        
             drawSingleTH1(h1D_pmaskedexp_norm[unrollAlongEta],xaxisTitle,"d^{2}#sigma/d|#eta|dp_{T} / #sigma_{tot} [1/GeV]",
                           "unrolledXsec_{var}_norm_{ch}_{fl}".format(var=unrollVar,ch=charge,fl=channel),
-                          outname,labelRatioTmp=ratioYaxis,draw_both0_noLog1_onlyLog2=1,passCanvas=canvUnroll, lumi=options.lumiInt,
+                          outname,labelRatioTmp=ratioYaxis,draw_both0_noLog1_onlyLog2=1,passCanvas=canvUnroll, lumi=options.lumiInt, drawLineLowerPanel="",
                           drawVertLines=vertLinesArg, textForLines=varBinRanges, lowerPanelHeight=0.35,moreText=additionalText,
                           leftMargin=leftMargin, rightMargin=rightMargin)
 
@@ -587,6 +616,10 @@ if __name__ == "__main__":
                                                 "charge asymmetry: {Wch}".format(Wch=Wchannel),
                                                 genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
 
+                    hChAsymm1Deta_exp = ROOT.TH1F("hChAsymm1Deta_{lep}_exp".format(lep=lepton),"Charge asymmetry: {Wch}".format(Wch=Wchannel),
+                                                  genBins.Neta, array('d',genBins.etaBins))
+
+
                 hDiffXsec_exp = ROOT.TH2F("hDiffXsec_{lep}_{ch}_exp".format(lep=lepton,ch=charge),
                                           "cross section: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
                                           genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
@@ -599,6 +632,16 @@ if __name__ == "__main__":
                 #hDiffXsecNormErr = ROOT.TH2F("hDiffXsecNormErr_{lep}_{ch}".format(lep=lepton,ch=charge),
                 #                             "normalized cross section uncertainty: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
                 #                             genBins.Neta, array('d',genBins.etaBins), genBins.Npt, array('d',genBins.ptBins))
+
+
+                hDiffXsec_1Deta_exp = ROOT.TH1F("hDiffXsec_1Deta_{lep}_{ch}_exp".format(lep=lepton,ch=charge),
+                                                "cross section: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
+                                                genBins.Neta, array('d',genBins.etaBins))
+
+                hDiffXsecNorm_1Deta_exp = ROOT.TH1F("hDiffXsecNorm_1Deta_{lep}_{ch}_exp".format(lep=lepton,ch=charge),
+                                                    "cross section: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
+                                                    genBins.Neta, array('d',genBins.etaBins))
+
 
                 binCount = 0
                 print ""
@@ -642,13 +685,39 @@ if __name__ == "__main__":
                         hDiffXsec_exp.SetBinContent(ieta,ipt,central)        
                         hDiffXsec_exp.SetBinError(ieta,ipt,error)         
 
+                # now 1D stuff
+                for ieta in range(1,genBins.Neta+1):
+
+                    if etaBinIsBackground[ieta-1]: continue
+
+                    if icharge == 1:
+                        central = utilities.getDiffXsecAsymmetry1DFromHessianFast(channel,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=treeexp)
+                        error   = utilities.getDiffXsecAsymmetry1DFromHessianFast(channel,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=treeexp, getErr=True)
+                        hChAsymm1Deta_exp.SetBinContent(ieta,central)
+                        hChAsymm1Deta_exp.SetBinError(ieta,error)
+        
+                    central = utilities.getDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=treeexp)
+                    error   = utilities.getDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=treeexp, getErr=True)
+                    hDiffXsec_1Deta_exp.SetBinContent(ieta, central)
+                    hDiffXsec_1Deta_exp.SetBinError(ieta, error)
+
+                    central = utilities.getNormalizedDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=treeexp)
+                    error   = utilities.getNormalizedDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=treeexp, getErr=True)
+                    hDiffXsecNorm_1Deta_exp.SetBinContent(ieta, central)
+                    hDiffXsecNorm_1Deta_exp.SetBinError(ieta, error)
+
+
                 if options.normWidth:
                     hDiffXsec_exp.Scale(1.,"width")
                     hDiffXsecNorm_exp.Scale(1.,"width")
+                    hDiffXsec_1Deta_exp.Scale(1.,"width")
+                    hDiffXsecNorm_1Deta_exp.Scale(1.,"width")
+                    
 
                 if options.lumiNorm > 0:
                     scaleFactor = 1./options.lumiNorm
                     hDiffXsec_exp.Scale(scaleFactor)
+                    hDiffXsec_1Deta_exp.Scale(scaleFactor)
 
                 # # now drawing a TH1 unrolling TH2
 
@@ -674,7 +743,7 @@ if __name__ == "__main__":
                     h1D_pmaskedexp_exp = getTH1fromTH2(hDiffXsec_exp, h2Derr=None, unrollAlongX=unrollAlongEta)        
                     drawDataAndMC(h1D_pmaskedexp[unrollAlongEta], h1D_pmaskedexp_exp,xaxisTitle,"d^{2}#sigma/d|#eta|dp_{T} [pb/GeV]::0,220",
                                   "unrolledXsec_{var}_abs_{ch}_{fl}_dataAndExp".format(var=unrollVar,ch=charge,fl=channel),
-                                  outname,labelRatioTmp="Data/pred.::0.8,1.2",draw_both0_noLog1_onlyLog2=1,passCanvas=canvUnroll,lumi=options.lumiInt,
+                                  outname,labelRatioTmp="obs./exp.::0.8,1.2",draw_both0_noLog1_onlyLog2=1,passCanvas=canvUnroll,lumi=options.lumiInt,
                                   drawVertLines=vertLinesArg, textForLines=varBinRanges, lowerPanelHeight=0.35, moreText=additionalText,
                                   leftMargin=leftMargin, rightMargin=rightMargin)
 
@@ -683,27 +752,69 @@ if __name__ == "__main__":
                     drawDataAndMC(h1D_pmaskedexp_norm[unrollAlongEta], h1D_pmaskedexp_norm_exp,
                                   xaxisTitle,"d^{2}#sigma/d|#eta|dp_{T} / #sigma_{tot} [1/GeV]",
                                   "unrolledXsec_{var}_norm_{ch}_{fl}_dataAndExp".format(var=unrollVar,ch=charge,fl=channel),
-                                  outname,labelRatioTmp="Data/pred.::0.8,1.2",draw_both0_noLog1_onlyLog2=1,passCanvas=canvUnroll, lumi=options.lumiInt,
+                                  outname,labelRatioTmp="obs./exp.::0.8,1.2",draw_both0_noLog1_onlyLog2=1,passCanvas=canvUnroll, lumi=options.lumiInt,
                                   drawVertLines=vertLinesArg, textForLines=varBinRanges, lowerPanelHeight=0.35, moreText=additionalText,
                                   leftMargin=leftMargin, rightMargin=rightMargin)
 
 
                     # do also charge asymmetry (only once if running on both charges)
                     if icharge == 1:
-
-                        xaxisTitle = xaxisTitle.replace("cross section", "charge asymmetry")
+                        
                         additionalTextBackup = additionalText
                         additionalText = "W #rightarrow {lep}#nu::0.8,0.84,0.9,0.9".format(lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
 
                         h1D_chargeAsym_exp = getTH1fromTH2(hChargeAsym_exp, h2Derr=None, unrollAlongX=unrollAlongEta)        
-                        drawDataAndMC(h1D_chargeAsym[unrollAlongEta], h1D_chargeAsym_exp,xaxisTitle,"charge asymmetry",
-                                      "unrolledChargeAsym_{var}_{fl}_dataAndExp".format(var=unrollVar,fl=channel),
-                                      outname,labelRatioTmp="Data/pred.::0.8,1.2",draw_both0_noLog1_onlyLog2=1,passCanvas=canvUnroll,lumi=options.lumiInt,
+                        drawDataAndMC(h1D_chargeAsym[unrollAlongEta], h1D_chargeAsym_exp,xaxisTitle.replace("cross section", "charge asymmetry"),
+                                      "charge asymmetry::0,1.0", "unrolledChargeAsym_{var}_{fl}_dataAndExp".format(var=unrollVar,fl=channel),
+                                      outname,labelRatioTmp="obs./exp.::0.8,1.2",draw_both0_noLog1_onlyLog2=1,passCanvas=canvUnroll,lumi=options.lumiInt,
                                       drawVertLines=vertLinesArg, textForLines=varBinRanges, lowerPanelHeight=0.35, moreText=additionalText,
                                       leftMargin=leftMargin, rightMargin=rightMargin)
 
                         additionalText = additionalTextBackup
-                    
+
+                # now data/prediction for the 1D xsection and charge asymmetry
+                ###############
+                xaxisTitle = 'gen %s |#eta|' % lepton
+                additionalTextBackup = additionalText
+                #additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::0.45,0.8,0.75,0.9".format(chs=" "+chargeSign,lep="e" if channel == "el" else "#mu",
+                #                                                                                       pttext=ptRangeText) # pass x1,y1,x2,y2
+                texCoord = "0.45,0.85" if charge == "plus" else "0.45,0.5"
+                additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(chs=" "+chargeSign,lep="e" if channel == "el" else "#mu",
+                                                                                                     pttext=ptRangeText,
+                                                                                                     txc=texCoord) 
+                legendCoords = "0.2,0.4,0.75,0.85" if charge == "plus" else "0.2,0.4,0.4,0.5"
+                drawDataAndMC(hDiffXsec_1Deta,hDiffXsec_1Deta_exp,xaxisTitle,"d#sigma/d|#eta| [pb]",
+                              "xsec_eta_abs_{ch}_{fl}_dataAndExp".format(ch=charge,fl=channel),
+                              outname,labelRatioTmp="obs./exp.::0.8,1.2",legendCoords=legendCoords, draw_both0_noLog1_onlyLog2=1,
+                              passCanvas=canvas1D, lumi=options.lumiInt,
+                              lowerPanelHeight=0.35, moreTextLatex=additionalText
+                              )
+                drawDataAndMC(hDiffXsecNorm_1Deta,hDiffXsecNorm_1Deta_exp,xaxisTitle,"d#sigma/d|#eta| / #sigma_{tot}",
+                              "xsec_eta_norm_{ch}_{fl}_dataAndExp".format(ch=charge,fl=channel),
+                              outname,labelRatioTmp="obs./exp.::0.8,1.2",legendCoords=legendCoords, draw_both0_noLog1_onlyLog2=1,
+                              passCanvas=canvas1D, lumi=options.lumiInt,
+                              lowerPanelHeight=0.35, moreTextLatex=additionalText
+                              )
+                additionalText = additionalTextBackup
+
+                if icharge == 1:
+                                        
+                    additionalTextBackup = additionalText
+                    #additionalText = "W #rightarrow {lep}#nu;{pttext}::0.2,0.6,0.5,0.7".format(lep="e" if channel == "el" else "#mu",pttext=ptRangeText) # pass x1,y1,x2,y2
+                    texCoord = "0.2,0.65"
+                    additionalText = "W #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(lep="e" if channel == "el" else "#mu", 
+                                                                                               pttext=ptRangeText,
+                                                                                               txc=texCoord)
+                    legendCoords = "0.2,0.4,0.75,0.85"
+                    drawDataAndMC(hChAsymm1Deta, hChAsymm1Deta_exp, xaxisTitle, "charge asymmetry::0,1.0",
+                                  "chargeAsym1D_eta_{fl}_dataAndExp".format(fl=channel),
+                                  outname,labelRatioTmp="obs./exp.::0.8,1.2",draw_both0_noLog1_onlyLog2=1,
+                                  passCanvas=canvas1D,lumi=options.lumiInt,
+                                  lowerPanelHeight=0.35, moreTextLatex=additionalText
+                                  )
+
+                    additionalText = additionalTextBackup
+                
                 
                 if options.exptoyfile != "SAME": fexp.Close()
 

--- a/WMass/python/plotter/w-helicity-13TeV/skims.py
+++ b/WMass/python/plotter/w-helicity-13TeV/skims.py
@@ -56,6 +56,7 @@ if __name__ == "__main__":
     parser.add_option("--fo", "--friend-only",  dest="friendOnly", action="store_true", default=False,  help="Do not redo skim of the main trees, only of the friends")
     parser.add_option("--mo", "--main-only",  dest="mainOnly", action="store_true", default=False,  help="Do not make skim of the friend trees, only of the main")
     parser.add_option("--max-entries",     dest="maxEntries", default=1000000000, type="int", help="Max entries to process in each tree") 
+    #parser.add_option("-n", "--job-name", dest="jobName",   type="string", default=None, help="Name assigned to jobs (if not given, use the default of skimTrees.py and skimFTrees.py"); # already in skimTrees,  cannot be duplicated
     from CMGTools.WMass.plotter.skimTrees import addSkimTreesOptions
     addSkimTreesOptions(parser)
     (options, args) = parser.parse_args() 
@@ -96,6 +97,7 @@ if __name__ == "__main__":
     if options.pretend: BATCH_OPTS += ' --pretend '
     if options.queue: BATCH_OPTS += ' -q %s ' % options.queue
     if options.logdir: BATCH_OPTS += ' --log %s ' % options.logdir
+    if options.jobName != None: BATCH_OPTS += ' -n %s ' % options.jobName
 
     varsToKeep = []; DROPVARS = ''
     if options.varfile!=None:

--- a/WMass/python/plotter/w-helicity-13TeV/templateRolling.py
+++ b/WMass/python/plotter/w-helicity-13TeV/templateRolling.py
@@ -465,7 +465,8 @@ if __name__ == "__main__":
                 signalTitle = "W^{%s}#rightarrow%s#nu" % (chs, "e" if channel == "el" else "#mu")
                 titles.append(signalTitle)
 
-            fakesysts = ["CMS_We_FRe_slope", "CMS_We_FRe_continuous"] if channel == "el" else ["CMS_Wmu_FRmu_slope", "CMS_Wmu_FRmu_continuous"]
+            #fakesysts = ["CMS_We_FRe_slope", "CMS_We_FRe_continuous"] if channel == "el" else ["CMS_Wmu_FRmu_slope", "CMS_Wmu_FRmu_continuous"]
+            fakesysts = ["CMS_We_FRe_slope"] if channel == "el" else ["CMS_Wmu_FRmu_slope"]
             # for i in range(1,11):
             #     fakesysts.append("FakesEtaUncorrelated%d" % i)
 

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -449,6 +449,14 @@ class util:
         ret = self.getExprFromHessianFast('diffXsec1D_{var}'.format(var="eta" if isIeta else "pt"),expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
 
+    def getNormalizedDiffXsec1DFromHessianFast(self, channel, charge, ietaORipt, isIeta=True, nHistBins=1000, minHist=0., maxHist=1., tree=None, getErr=False, getGen=False):
+        expr = "W{c}_{ch}_i{var}_{ivar}_W{c}_{ch}_sumxsecnorm".format(c=charge,ch=channel,var="eta" if isIeta else "pt", ivar=ietaORipt)
+        if getErr: expr += "_err"
+        elif getGen: expr += "_gen"
+        ret = self.getExprFromHessianFast('diffXsec1D_{var}'.format(var="eta" if isIeta else "pt"),expr, nHistBins, minHist, maxHist, tree=tree)
+        return ret
+
+
     def getDiffXsecAsymmetry1DFromHessianFast(self, channel, ietaORipt, isIeta=True, 
                                               nHistBins=1000, minHist=0., maxHist=1., tree=None, getErr=False, getGen=False):
         expr = "W_{ch}_i{var}_{ivar}_W_{ch}_chargemetaasym".format(ch=channel,var="eta" if isIeta else "pt", ivar=ietaORipt)

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_forPlots.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X_forPlots.txt
@@ -232,3 +232,9 @@ W_lepeff_Dn   : WJetsToLNu_NLO* :  3.*20508.9 : genw_decayId == 12 && LepGood1_m
 W_elescale_Up: WJetsToLNu_NLO* :  3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kBlue, Label="W (scale Up)", NormSystematic=0.038, FakeRate="w-helicity-13TeV/wmass_e/fr-includes/doSyst_lepScaleUp_xsec.txt"
 
 W_elescale_Dn: WJetsToLNu_NLO* :  3.*20508.9 : genw_decayId == 12 && LepGood1_mcMatchId*LepGood1_charge!=-24; FillColor=ROOT.kBlack, Label="W (scale Dn)", NormSystematic=0.038, FakeRate="w-helicity-13TeV/wmass_e/fr-includes/doSyst_lepScaleDn_xsec.txt"
+
+
+#======================
+
+#Ztest    : DYJetsToLL_M50_NLO_part1 : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04
+Ztest    : DYJetsToLL_M50_ext2* : 2008.4*3; FillColor=ROOT.kAzure+2, Label="Z", NormSystematic=0.04

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/skimming/tests/mca-80X-skims_W.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/skimming/tests/mca-80X-skims_W.txt
@@ -1,2 +1,2 @@
 # signal from the weighted uncut sample should not be skimmed
-W    : WJetsToLNu_NLO* : 3.*20508.9  ; FillColor=ROOT.kGray+1   , Label="W"
+W    : WJetsToLNu_* : 3.*20508.9  ; FillColor=ROOT.kGray+1   , Label="W"

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/skimming/tests/wenu-80X-skim_fullsel.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/skimming/tests/wenu-80X-skim_fullsel.txt
@@ -2,7 +2,7 @@ alwaystrue: 1
 #genEle: abs(prefsrw_decayId) == 12
 HLT_SingleEL : HLT_BIT_HLT_Ele27_WPTight_Gsf_v == 1
 onelep : nLepGood == 1 && abs(LepGood1_pdgId)==11
-eleKin : ptElFull(LepGood1_calPt,LepGood1_eta) >= 30 && ptElFull(LepGood1_calPt,LepGood1_eta) < 45 && abs(LepGood1_eta)<2.5
+eleKin : ptElFull(LepGood1_calPt,LepGood1_eta) >= 25 && abs(LepGood1_eta)<2.5
 HLTid : LepGood1_hltId > 0
 numSel : LepGood1_customId == 1
 tightCharge : LepGood1_tightChargeFix == 2

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/test_plots.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/test_plots.txt
@@ -70,3 +70,7 @@ awayJetPt_ptl1: LepGood_awayJet_pt\:ptElFull(LepGood1_calPt,LepGood1_eta) : 50,3
 
 pfmt_wmass: mt_2(met_pt,met_phi,ptElFull(LepGood1_calPt,LepGood1_eta),LepGood1_phi) : 40,40,120 ; XTitle="m_{T} [GeV]", Legend='TL', IncludeOverflows=False
 ptl1_wmass: ptElFull(LepGood1_calPt,LepGood1_eta): 40,30,50 ; XTitle="lepton p_{T} [GeV]", Legend='TL', IncludeOverflows=False
+
+
+ptl1_large: ptElFull(LepGood1_calPt,LepGood1_eta): 25,30,55 ; XTitle="electron p_{T} [GeV]", Legend='TR', IncludeOverflows=False
+ptl1large__etal1: ptElFull(LepGood1_calPt,LepGood1_eta)\:LepGood1_eta: 50,-2.5,2.5,25,30,55; XTitle='reco electron #eta', YTitle='reco electron p_{T} [GeV]', Legend='TR'

--- a/WMass/python/postprocessing/scripts/copyDir.py
+++ b/WMass/python/postprocessing/scripts/copyDir.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import os, sys
+import re
+
+if __name__ == "__main__":
+    from optparse import OptionParser
+    parser = OptionParser(usage="%prog [options] inputDir outputDir")
+    parser.add_option("-p", "--pretend", dest="pretend",   action="store_true", default=False, help="Don't run anything");
+    parser.add_option("-v", "--verbose", dest="verbose",   action="store_true", default=False, help="Use option -v for cp");
+    parser.add_option("-m", "--match",   dest="match",     type="string", default=None, help="Select only folders matching this regular expression")
+    parser.add_option("-r", "--replace", dest="replace",   type="string", nargs=2, default=None, help="Replace first argument with second argument when copying folder or file")
+    (options, args) = parser.parse_args()
+
+if len(args)<2:
+    parser.print_help()
+    sys.exit(1)
+
+inputdir = args[0]
+outputDir = args[1]
+if inputdir == outputDir:
+    print "Error: input folder is the same as the output folder."
+    quit()
+
+print "-"*30
+print "Copying folders from inputdir %s to outputDir %s" % (inputdir, outputDir)
+if options.match != None:
+    print "Selecting folders matching '{reg}'".format(reg=options.match)
+if options.replace != None:
+    print "Changing name replacing '%s' with '%s'" % (options.replace[0], options.replace[1])
+print "-"*30
+
+if not os.path.exists(outputDir):
+    print "Warning: folder {out} does not exist".format(out=outputDir)
+    print "It will be created now"
+    os.makedirs(outputDir)
+
+folders = os.listdir(inputdir)
+for fld in folders:
+    if options.match == None or re.match(options.match,fld):
+        cmd = "cp -r{v} {ind}/{f} {out}/{newf}".format(v="v" if options.verbose else "", 
+                                                       ind=inputdir,f=fld, out=outputDir, 
+                                                       newf=fld if options.replace == None else fld.replace(options.replace[0], options.replace[1]))
+        if options.pretend:
+            print cmd
+        else:
+            os.system(cmd)
+            
+
+print "-"*30
+print "DONE"
+print "-"*30


### PR DESCRIPTION
**mergeCardComponentsAbsY.py**
I changed the names of Fakes*Uncorrelated so to contain (mu|el)(plus|minus), as we do for the efficiencies. in this way we decorrelate the two charges in the fit

**mcPlots.py**
Some fixes for 2D ratio plots, and legend. There were some hardcoded pieces, I added some options to manage them (N of columns in the legend, legend coordinates and so on)

Added option to skimming scripts to assign name to condor jobs (just useful for easier tracking, I needed that)

**w-helicity-13TeV/functionsWMass.cc**
Implemented charge-dependent trigger SF variations (I think I was the only one to still use that function, though)

**w-helicity-13TeV/impactPlots.py**
Some fixes for the plot (added title to identify type of variables being plotted, and slightly increased the y range). 
Also adding normalized cross section for 1D cross section
See example: 
http://mciprian.web.cern.ch/mciprian/wmass/13TeV/diffXsecAnalysis/muon/diffXsec_mu_2019_02_23_ptMax50_dressed/impactPlots/fakesPtEtaUncorr_noDYsigBkgNorm_dressed_bbb1_cxs1/etaxsecnorm/etaImpactsRel_Asimov_etaxsecnorm_minus.png

**w-helicity-13TeV/makeRatioTH2.py**
Added option to plot charge asymmetry of the inputs

**python/postprocessing/scripts/copyDir.py**
New script to copy folders or files, possibly filtering stuff with regular expressions and substituting some part of the name with another one. Useful when making skims, for example

The rest is mainly related to differential cross section