### PR TITLE
Updates for postfit plots and correlation matrix

### DIFF
--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -3,20 +3,20 @@
 import ROOT, os, sys, re, array
 
 dryrun=0
-skipUnpack=0
+skipUnpack=1
 skipMergeRoot=0
 skipSingleCard=0
 skipMergeCard=0
 
-#folder = "diffXsec_el_2019_02_22_ptMax50_dressed/" # keep "/" at the end
-#th3file = "cards/" + folder + "wenu_histo_ptMax50.root"
+folder = "diffXsec_el_2019_02_22_ptMax50_dressed/" # keep "/" at the end
+th3file = "cards/" + folder + "wenu_histo_ptMax50.root"
 
-folder = "diffXsec_mu_2019_02_23_ptMax50_dressed/" # keep "/" at the end
-th3file = "cards/" + folder + "wmunu_histo_ptMax50.root"
+#folder = "diffXsec_mu_2019_02_23_ptMax50_dressed/" # keep "/" at the end
+#th3file = "cards/" + folder + "wmunu_histo_ptMax50.root"
 
 optionsForRootMerger = " --etaBordersForFakesUncorr 0.5,1.0,1.6,2.0 " # use 0.5,1.0,1.5,2.0 for muons, where eta bins are 0.1 wide
 optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous' " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta
-optionsForCardMakerMerger = " --postfix fakesPtEtaUncorr_noDYsigBkgNorm_dressed  "  # --no-text2hdf5
+optionsForCardMakerMerger = " --postfix fakesPtEtaUncorr0p05_noDYsigBkgNorm_dressed  "  # --no-text2hdf5
 
 # folder = "diffXsec_el_2018_12_16_onlyBkg_pt1GeV_eta0p2From1p3/"  # keep "/" at the end
 # th3file = "cards/" + folder + "wmass_varhists_ele_pt1GeV_eta0p2From1p3.root"

--- a/WMass/python/plotter/mergeRootComponentsDiffXsec.py
+++ b/WMass/python/plotter/mergeRootComponentsDiffXsec.py
@@ -349,8 +349,8 @@ if not options.dryrun:
 print "-"*20
 print ""
 
-fileFakesEtaUncorr = "{od}FakesEtaUncorrelated_{ch}.root".format(od=outdir, ch=options.charge) 
-fileFakesPtUncorr  = "{od}FakesPtUncorrelated_{ch}.root".format(od=outdir, ch=options.charge) 
+fileFakesEtaUncorr = "{od}FakesEtaUncorrelated_{fl}_{ch}.root".format(od=outdir, fl=flavour, ch=options.charge) 
+fileFakesPtUncorr  = "{od}FakesPtUncorrelated_{fl}_{ch}.root".format( od=outdir, fl=flavour, ch=options.charge) 
 # these names are used inside putUncorrelatedFakes (do not change them outside here)
 print "Now adding FakesEtaUncorrelated and FakesPtUncorrelated systematics to x_data_fakes process"
 print "Will create file --> {of}".format(of=fileFakesEtaUncorr)
@@ -358,9 +358,9 @@ print "Will create file --> {of}".format(of=fileFakesPtUncorr)
 etaBordersForFakes = [float(x) for x in options.etaBordersForFakesUncorr.split(',')]
 if not options.dryrun: 
     putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, 
-                         etaBordersTmp=etaBordersForFakes, uncorrelateCharges=True)
+                         etaBordersTmp=etaBordersForFakes)
     putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, etaBordersTmp=etaBordersForFakes, 
-                         doPt = 'x_data_fakes_.*slope.*', uncorrelateCharges=True)
+                         doPt = 'x_data_fakes_.*slope.*')
 
 print "Now merging signal + Z + data + other backgrounds + FakesEtaUncorrelated + ZEffStat"
 sigfile = "{osig}W{fl}_{ch}_shapes_signal.root".format(osig=options.indirSig, fl=flavour, ch=charge)

--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -5,23 +5,24 @@ import ROOT, os, sys, re, array
 # to run plots from Asimov fit and data. For toys need to adapt this script
 
 dryrun = 0
-skipData = 0
+skipData = 1
 onlyData = 0
 
-skipPlot = 0
-skipTemplate = 0
+skipPlot = 1
+skipTemplate = 1
 skipDiffNuis = 1
-skipCorr = 1
-skipImpacts = 0
+skipPostfit = 1  # only for Data
+skipCorr = 0
+skipImpacts = 1
 
 
 seed = 123456789
 #folder = "diffXsec_el_2018_12_31_pt2from26to30_pt1p5from30to45_recoPtFrom30_recoGenEta0p2from1p2to2p4/"
 #folder = "diffXsec_el_2018_12_27_pt2from26to30_pt1p5from30to45_eta0p2From1p2/"
-folder = "diffXsec_el_2019_02_22_ptMax50_dressed/"
+#folder = "diffXsec_el_2019_02_22_ptMax50_dressed/"
 
 #folder = "diffXsec_mu_2019_01_24_pt2from26to30_pt1p5from30to45_eta0p2From1p2_dressed/"
-#folder = "diffXsec_mu_2019_02_23_ptMax50_dressed/"
+folder = "diffXsec_mu_2019_02_23_ptMax50_dressed/"
 
 #postfix = "allSyst_eosSkim_noZandWoutNorm_bbb1_cxs1"
 #postfix = "eosSkim_noZandWoutNorm_ZshapeEffAndScaleSyst_bbb1_cxs1"
@@ -57,17 +58,17 @@ diffNuisances_pois = ["pdf.*|alphaS|mW",
 correlationSigRegexp = {"Wplus_ieta6ipt8" : ".*_ieta_6_ipt_8_Wplus_.*"
                         }
 
-correlationNuisRegexp = {"allPDF"           : "pdf.*", 
-                         "somePDFandAlphaS" : "^pdf([1-9]|1[0-9]|20)$,alphaS", 
-                         "QCDscales"        : "muR.*|muF.*", 
-                         "muR"              : "^muR[1-9]+", 
-                         "muF"              : "^muF[1-9]+", 
-                         "muRmuF"           : "^muRmuF[1-9]+", 
-                         "FakesEtaUncorr"   : "FakesEta.*", 
-                         "CMSsyst"          : "CMS_.*",
-                         "ErfPar0EffStat"   : "ErfPar0EffStat.*",
-                         "ErfPar1EffStat"   : "ErfPar1EffStat.*",
-                         "ErfPar2EffStat"   : "ErfPar2EffStat.*"
+correlationNuisRegexp = {# "allPDF"           : "pdf.*", 
+                         # "somePDFandAlphaS" : "^pdf([1-9]|1[0-9]|20)$,alphaS", 
+                         # "QCDscales"        : "muR.*|muF.*", 
+                         # "muR"              : "^muR[1-9]+", 
+                         # "muF"              : "^muF[1-9]+", 
+                         # "muRmuF"           : "^muRmuF[1-9]+", 
+                         "FakesEtaPtUncorr" : "Fakes(Eta|Pt).*", 
+                         # "CMSsyst"          : "CMS_.*",
+                         # "ErfPar0EffStat"   : "ErfPar0EffStat.*",
+                         # "ErfPar1EffStat"   : "ErfPar1EffStat.*",
+                         # "ErfPar2EffStat"   : "ErfPar2EffStat.*"
                          }
 
 correlationMatrixTitle = {"allPDF"           : "all PDFs", 
@@ -76,7 +77,7 @@ correlationMatrixTitle = {"allPDF"           : "all PDFs",
                           "muR"              : "#mu_{R} QCD scales", 
                           "muF"              : "#mu_{F} QCD scales", 
                           "muRmuF"           : "#mu_{R}#mu_{F} QCD scales", 
-                          "FakesEtaUncorr"   : "fakes #eta normalizations", 
+                          "FakesEtaPtUncorr" : "fakes #eta normalizations and p_{T} slopes", 
                           "CMSsyst"          : "some experimental systematics",
                           "ErfPar0EffStat"   : "signal efficiency (uncorr. par 0)",
                           "ErfPar1EffStat"   : "signal efficiency (uncorr. par 1)",
@@ -183,6 +184,24 @@ for fit in fits:
             print tmpcommand
             if not dryrun:
                 os.system(tmpcommand)
+
+    print ""
+    print "="*30
+    print "POSTFIT PLOTS"
+    print ""
+
+    ## POSTFIT PLOTS
+    command = "python w-helicity-13TeV/postFitPlots_xsec.py"
+    command += " cards/{fd}/fit/{typedir}/fitresults_{s}_{fit}_{pf}.root cards/{fd}/ ".format(fd=folder,typedir=typedir,s=seed,fit=fit,pf=postfix)
+    command += " -o plots/diffXsecAnalysis/{lep}/{fd}/postFitPlots_xsec/{pf}/".format(lep=lepton,fd=folder, pf=postfix)
+    command += " --no2Dplot-signal-bin -n  ".format(fit=fit)
+    if fit == "Data":
+        if not skipPostfit:
+            print ""    
+            print command
+            if not dryrun:
+                os.system(command)
+
 
     print ""
     print "="*30

--- a/WMass/python/plotter/plotUtils/utility.py
+++ b/WMass/python/plotter/plotUtils/utility.py
@@ -1266,14 +1266,6 @@ def drawTH1dataMCstack(h1, thestack,
     stackErr = stackCopy
     if hErrStack != None:
         stackErr = copy.deepcopy(hErrStack.Clone("stackErr"))
-    # else:
-    #     isFirst = True
-    #     for hist in thestack.GetHists():        
-    #         if isFirst:
-    #             stackErr = copy.deepcopy(hist.Clone("stackErr"))
-    #             isFirst = False
-    #         else:
-    #             stackErr.Add(hist.Clone())
 
     print "drawTH1dataMCstack():  integral(data):  " + str(h1.Integral()) 
     print "drawTH1dataMCstack():  integral(stack): " + str(stackCopy.Integral()) 

--- a/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
@@ -586,7 +586,7 @@ if __name__ == "__main__":
                 additionalText = "W #rightarrow {lep}#nu::0.8,0.84,0.9,0.9".format(lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
 
                 h1D_chargeAsym[unrollAlongEta] = getTH1fromTH2(hChAsymm, h2Derr=None, unrollAlongX=unrollAlongEta)        
-                drawSingleTH1(h1D_chargeAsym[unrollAlongEta], xaxisTitle,"charge asymmetry",
+                drawSingleTH1(h1D_chargeAsym[unrollAlongEta], xaxisTitle,"charge asymmetry::0.0,1.0",
                               "unrolledChargeAsym_{var}_{fl}".format(var=unrollVar,fl=channel),
                               outname,labelRatioTmp=ratioYaxis,draw_both0_noLog1_onlyLog2=1,drawLineLowerPanel="", 
                               passCanvas=canvUnroll,lumi=options.lumiInt,
@@ -806,7 +806,7 @@ if __name__ == "__main__":
                                                                                                pttext=ptRangeText,
                                                                                                txc=texCoord)
                     legendCoords = "0.2,0.4,0.75,0.85"
-                    drawDataAndMC(hChAsymm1Deta, hChAsymm1Deta_exp, xaxisTitle, "charge asymmetry::0,1.0",
+                    drawDataAndMC(hChAsymm1Deta, hChAsymm1Deta_exp, xaxisTitle, "charge asymmetry",
                                   "chargeAsym1D_eta_{fl}_dataAndExp".format(fl=channel),
                                   outname,labelRatioTmp="obs./exp.::0.8,1.2",draw_both0_noLog1_onlyLog2=1,
                                   passCanvas=canvas1D,lumi=options.lumiInt,

--- a/WMass/python/plotter/w-helicity-13TeV/postFitPlots.py
+++ b/WMass/python/plotter/w-helicity-13TeV/postFitPlots.py
@@ -4,6 +4,9 @@ import ROOT, os, re
 from array import array
 from rollingFunctions import roll1Dto2D, unroll2Dto1D
 
+from make_diff_xsec_cards import getDiffXsecBinning
+from make_diff_xsec_cards import templateBinning
+
 import utilities
 utilities = utilities.util()
 
@@ -59,7 +62,7 @@ def chargeUnrolledBinShifts(infile,channel,nCharges=2,nMaskedCha=2):
 def singleChargeUnrolled(h1d,shift,nCharges=2,nMaskedCha=2):
     extrabins = 0 if 'obs' in h1d.GetName() else nCharges*nMaskedCha
     nbins = int((h1d.GetNbinsX()-extrabins)/2)
-    h1d_shifted = ROOT.TH1D('shift','',nbins,1,nbins)
+    h1d_shifted = ROOT.TH1D('shift','',nbins,0,nbins) # from 0 to nbins, not from 1
     for b in xrange(nbins):
         h1d_shifted.SetBinContent(b+1,h1d.GetBinContent(b+shift+1))
         h1d_shifted.SetBinError(b+1,h1d.GetBinError(b+shift+1))
@@ -78,13 +81,17 @@ def prepareLegend(legWidth=0.50,textSize=0.035,xmin=0.75):
     leg.SetTextSize(textSize)
     return leg
 
-def plotOne(charge,channel,stack,htot,hdata,legend,outdir,prefix,suffix,veryWide=False):
+def plotOne(charge,channel,stack,htot,hdata,legend,outdir,prefix,suffix,veryWide=False, 
+            drawVertLines="", # "12,36": format --> N of sections (e.g: 12 pt bins), and N of bins in each section (e.g. 36 eta bins), assuming uniform bin width
+            textForLines=[]  # text in each panel                       
+            ):
+
     ## Prepare split screen
     plotformat = (2400,600) if veryWide else (600,750)
     c1 = ROOT.TCanvas("c1", "c1", plotformat[0], plotformat[1]); c1.Draw()
     c1.SetWindowSize(plotformat[0] + (plotformat[0] - c1.GetWw()), (plotformat[1] + (plotformat[1] - c1.GetWh())));
     ROOT.gStyle.SetPadLeftMargin(0.07 if veryWide else 0.18)
-    ROOT.gStyle.SetPadRightMargin(0.07 if veryWide else 0.13)
+    ROOT.gStyle.SetPadRightMargin(0.02 if veryWide else 0.13)
     p1 = ROOT.TPad("pad1","pad1",0,0.29,1,0.99);
     p1.SetBottomMargin(0.03);
     p1.Draw();
@@ -114,8 +121,30 @@ def plotOne(charge,channel,stack,htot,hdata,legend,outdir,prefix,suffix,veryWide
     else:
         x1 = 0.16; x2 = 0.65
     lat.DrawLatex(x1, 0.92, '#bf{CMS} #it{Preliminary}')
-    lat.DrawLatex(x2, 0.92, '36 fb^{-1} (13 TeV)')
+    lat.DrawLatex(x2, 0.92, '35.9 fb^{-1} (13 TeV)')
     
+
+    # set Y range a little above the current value
+    ymaxBackup = htot.GetMaximum()
+    vertline = ROOT.TLine(36,0,36,c1.GetUymax())
+    vertline.SetLineColor(ROOT.kBlack)
+    vertline.SetLineStyle(2)
+    bintext = ROOT.TLatex()
+    #bintext.SetNDC()
+    bintext.SetTextSize(0.04)
+    bintext.SetTextFont(42)
+
+    if len(drawVertLines):
+        #print "drawVertLines = " + drawVertLines
+        nptBins = int(drawVertLines.split(',')[0])
+        etarange = float(drawVertLines.split(',')[1])        
+        for i in range(1,nptBins): # do not need line at canvas borders
+            vertline.DrawLine(etarange*i,0,etarange*i,ymaxBackup)
+        if len(textForLines):
+            for i in range(0,len(textForLines)): # we need nptBins texts
+                bintext.DrawLatex(etarange*i + etarange/6., 0.7 *ymaxBackup, textForLines[i])
+
+
     p2.cd()
     maxrange = [0.95,1.05] if prepost == 'postfit' else [0.90,1.10]
     rdata,rnorm,rline = doRatioHists(hdata, htot, maxRange=maxrange, fixRange=True, doWide=veryWide)
@@ -126,7 +155,12 @@ def plotOne(charge,channel,stack,htot,hdata,legend,outdir,prefix,suffix,veryWide
 
 def doRatioHists(data,total,maxRange,fixRange=False,ylabel="Data/pred.",yndiv=505,doWide=False,showStatTotLegend=False,textSize=0.035):
     ratio = data.Clone("data_div"); 
-    ratio.Divide(total)
+    #ratio.Divide(total)  # this combines the uncertainty on data with the one on total. 
+    # Since the uncertainty on total is already in the band centered around 1, it is better to divide the data by a clone of total with 0 uncertainty
+    total_noErr = total.Clone("total_noErr")
+    for i in range (0,2+total_noErr.GetNbinsX()):
+        total_noErr.SetBinError(i, 0)
+    ratio.Divide(total_noErr)
 
     unity = total.Clone("sim_div");
     
@@ -189,16 +223,17 @@ def doRatioHists(data,total,maxRange,fixRange=False,ylabel="Data/pred.",yndiv=50
 
     return (ratio, unity, line)
 
-def plotPostFitRatio(charge,channel,hratio,outdir,prefix,suffix):
+def plotPostFitRatio(charge,channel,hratio,outdir,prefix,suffix, drawVertLines="", textForLines=[]):
     ROOT.gStyle.SetPadLeftMargin(0.13)
-    ROOT.gStyle.SetPadRightMargin(0.07)
+    ROOT.gStyle.SetPadRightMargin(0.02)
     ROOT.gStyle.SetPadBottomMargin(0.3);
 
     plotformat = (2400,600)
     c1 = ROOT.TCanvas("c1", "c1", plotformat[0], plotformat[1]); c1.Draw()
     c1.SetWindowSize(plotformat[0] + (plotformat[0] - c1.GetWw()), (plotformat[1] + (plotformat[1] - c1.GetWh())));
 
-    rmin = max(0.1, histo.GetMinimum()); rmax = min(10., histo.GetMaximum())
+    ydiff = hratio.GetBinContent(hratio.GetMaximumBin()) - hratio.GetBinContent(hratio.GetMinimumBin())
+    rmin = max(0.1, hratio.GetBinContent(hratio.GetMinimumBin())); rmax = min(10., ydiff*0.2 + hratio.GetBinContent(hratio.GetMaximumBin()))
     ROOT.gStyle.SetErrorX(0.5);
     hratio.GetYaxis().SetRangeUser(rmin,rmax);
     hratio.GetXaxis().SetTitleFont(42)
@@ -227,6 +262,33 @@ def plotPostFitRatio(charge,channel,hratio,outdir,prefix,suffix):
     lat.SetNDC(); lat.SetTextFont(42)
     lat.DrawLatex(0.15, 0.92, '#bf{CMS} #it{Preliminary}')
     lat.DrawLatex(0.85, 0.92, '36 fb^{-1} (13 TeV)')
+
+    # draw vertical lines to facilitate reading of plot
+    vertline = ROOT.TLine(36,0,36,c1.GetUymax())
+    vertline.SetLineColor(ROOT.kBlack)
+    vertline.SetLineStyle(2)
+    bintext = ROOT.TLatex()
+    #bintext.SetNDC()
+    bintext.SetTextSize(0.025)  # 0.03
+    bintext.SetTextFont(42)
+    if len(textForLines): bintext.SetTextAngle(45 if "#eta" in textForLines[0] else 10)
+
+    if len(drawVertLines):
+        #print "drawVertLines = " + drawVertLines
+        nptBins = int(drawVertLines.split(',')[0])
+        etarange = float(drawVertLines.split(',')[1])        
+        offsetXaxisHist = hratio.GetXaxis().GetBinLowEdge(0)
+        sliceLabelOffset = 6. if "#eta" in textForLines[0] else 6.
+        for i in range(1,nptBins): # do not need line at canvas borders
+            vertline.DrawLine(etarange*i-offsetXaxisHist,rmin,etarange*i-offsetXaxisHist,rmax)
+        if len(textForLines):
+            for i in range(0,len(textForLines)): # we need nptBins texts
+                #texoffset = 0.1 * (4 - (i%4))
+                #ytext = (1. + texoffset)*ymax/2.  
+                ytext = rmax - 0.1*(rmax - rmin)
+                bintext.DrawLatex(etarange*i + etarange/sliceLabelOffset, ytext, textForLines[i])
+
+
     for ext in ['pdf', 'png']:
         c1.SaveAs('{odir}/{pfx}_{ch}_{flav}_PFMT40_absY_{sfx}.{ext}'.format(odir=outdir,pfx=prefix,ch=charge,flav=channel,sfx=suffix,ext=ext))
 
@@ -251,11 +313,13 @@ if __name__ == "__main__":
     parser = OptionParser(usage="%prog [options] fitresults.root cards_dir")
     parser.add_option('-o','--outdir', dest='outdir', default='.', type='string', help='output directory to save the matrix')
     parser.add_option(     '--no2Dplot', dest="no2Dplot", default=False, action='store_true', help="Do not plot templates (but you can still save them in a root file with option -s)");
+    parser.add_option('-m','--n-mask-chan', dest='nMaskedChannel', default=2, type='int', help='Number of masked channels in the fit for each charge')
     parser.add_option(     '--suffix', dest="suffix", default='', type='string', help="define suffix for each plot");
-    groupJobs=5 # used in make_helicity_cards.py
-    nCharges = 2; nMaskedChanPerCharge = 2; # edm hardcoded, but to be guessed 
-    
     (options, args) = parser.parse_args()
+
+    groupJobs=5 # used in make_helicity_cards.py
+    nCharges = 2; nMaskedChanPerCharge = options.nMaskedChannel; 
+    
     if len(args) < 1:
         parser.print_usage()
         quit()
@@ -286,14 +350,18 @@ if __name__ == "__main__":
     print "Will save 2D templates in file --> " + full_outfileName
 
     ## get the pT and eta binning from the file in the directory
-    binninPtEtaFile = open(args[1]+'/binningPtEta.txt','r')
-    bins = binninPtEtaFile.readlines()[1].split()[1]
-    ## hack. easier
-    etabins = list( float(i) for i in bins.replace(' ','').split('*')[0].replace('[','').replace(']','').split(',') )
-    ptbins  = list( float(i) for i in bins.replace(' ','').split('*')[1].replace('[','').replace(']','').split(',') )
-    nbinseta = len(etabins)-1
-    nbinspt  = len( ptbins)-1
-    binning = [nbinseta, etabins, nbinspt, ptbins]
+    etaPtBinningFile = args[1]+"/binningPtEta.txt"
+    # get eta-pt binning for reco
+    etaPtBinningVec = getDiffXsecBinning(etaPtBinningFile, "reco")
+    recoBins = templateBinning(etaPtBinningVec[0],etaPtBinningVec[1])
+
+    binning = [recoBins.Neta, recoBins.etaBins, recoBins.Npt, recoBins.ptBins]
+
+    # to draw panels in the unrolled plots
+    ptBinRanges = []
+    for ipt in range(0,recoBins.Npt):
+        ptBinRanges.append("p_{{T}} #in [{ptmin:3g}, {ptmax:.3g}]".format(ptmin=recoBins.ptBins[ipt], ptmax=recoBins.ptBins[ipt+1]))
+
 
     shifts = chargeUnrolledBinShifts(infile,channel,nCharges,nMaskedChanPerCharge)
 
@@ -457,7 +525,8 @@ if __name__ == "__main__":
             htot_unrolled.GetYaxis().SetRangeUser(0, 1.8*max(htot_unrolled.GetMaximum(), hdata_unrolled.GetMaximum()))
             htot_unrolled.GetYaxis().SetTitle('Events')
             htot_unrolled.GetXaxis().SetTitle('unrolled lepton (#eta,p_{T}) bin')
-            plotOne(charge,channel,stack_unrolled,htot_unrolled,hdata_unrolled,leg_unrolled,outname,'unrolled',suffix,True)
+            plotOne(charge,channel,stack_unrolled,htot_unrolled,hdata_unrolled,leg_unrolled,outname,'unrolled',suffix,True, 
+                    drawVertLines="{a},{b}".format(a=recoBins.Npt,b=recoBins.Neta), textForLines=ptBinRanges)
             hdata_unrolled.Write(); htot_unrolled.Write()
 
         # plot the postfit/prefit ratio
@@ -465,7 +534,8 @@ if __name__ == "__main__":
         for key,histo in ratios_unrolled.iteritems():
             print "Making unrolled ratio for ",key
             outdir = outnamesub if key.startswith('Y') else outname
-            plotPostFitRatio(charge,channel,histo,outdir,'postfit2prefit_'+key,options.suffix)
+            plotPostFitRatio(charge,channel,histo,outdir,'postfit2prefit_'+key,options.suffix, 
+                             drawVertLines="{a},{b}".format(a=recoBins.Npt,b=recoBins.Neta), textForLines=ptBinRanges)
                 
     outfile.Close()
 

--- a/WMass/python/plotter/w-helicity-13TeV/subMatrix.py
+++ b/WMass/python/plotter/w-helicity-13TeV/subMatrix.py
@@ -70,6 +70,23 @@ def niceName(name):
         else:
             return name
       
+    elif re.match( "Fakes(Eta|Pt)Uncorrelated.*",name):
+        num = re.findall(r'\d+', name) # get number
+        pfx = name.split(num[0])[1]    # split on number and read what's on the right
+        leptonCharge = ""
+        if len(pfx):
+            leptonCharge = "{lep}{chs}".format(lep="#mu" if "mu" in pfx else "e", chs = "+" if "plus" in pfx else "-" if "minus" in pfx else "")
+        return "Fakes {var}-uncorr.{n} {lepCh}".format(var="#eta" if "FakesEta" in name else "p_{T}", n=num[0], lepCh=leptonCharge)
+
+    elif re.match(".*EffStat.*",name):
+        num = re.findall(r'\d+', name) # get number (there will be two of them, need the second)
+        pfx = name.split(num[1])[1]    # split on second number and read what's on the right
+        leptonCharge = ""
+        if len(pfx):
+            leptonCharge = "{lep}{chs}".format(lep="#mu" if "mu" in pfx else "e", chs = "+" if "plus" in pfx else "-" if "minus" in pfx else "")
+        return "Eff. uncorr. {n1}-{n2} {lepCh}".format(n1=num[0],n2=num[1],lepCh=leptonCharge)
+
+
     else:  
         return name
         
@@ -88,7 +105,7 @@ if __name__ == "__main__":
     parser.add_option('-t','--type'  , dest='type'  ,    default='toys', type='string', help='which type of input file: toys(default),scans, or hessian')
     parser.add_option(     '--suffix', dest='suffix',    default='', type='string', help='suffix for the correlation matrix')
     parser.add_option(     '--parNameCanvas', dest='parNameCanvas',    default='', type='string', help='The canvas name is built using the parameters selected with --params. If they are many, better to pass a name, like QCDscales or PDF for example')
-    parser.add_option(     '--nContours', dest='nContours',    default=0, type=int, help='Number of contours in palette. Default is 20')
+    parser.add_option(     '--nContours', dest='nContours',    default=51, type=int, help='Number of contours in palette. Default is 51 (keep it odd: no correlation is white with our palette)')
     parser.add_option(     '--palette'  , dest='palette',      default=0, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
     parser.add_option(     '--vertical-labels-X', dest='verticalLabelsX',    default=False, action='store_true', help='Set labels on X axis vertically (sometimes they overlap if rotated)')
     parser.add_option(     '--title'  , dest='title',    default='', type='string', help='Title for matrix ("small correlation matrix" is used as default). Use 0 to remove title')
@@ -195,15 +212,26 @@ if __name__ == "__main__":
 
     ## sort the floatParams. alphabetically, except for pdfs, which are sorted by number
     ## for mu* QCD scales, distinguish among muR and muRXX with XX in 1-10
+    
+    # why is this commented? Isn't it nice that different charge and polarizations are grouped together?
+    # see old example here: 
+    # http://mciprian.web.cern.ch/mciprian/wmass/13TeV/helicityAnalysis/electron/fromEmanuele/13-12-18/fitresults_poim1_exp1_bbb1/subMatrix/smallCorrelation_Wplusminus_leftrightYbin_2-5.png
     #params = sorted(params, key= lambda x: (int(chargeSorted[x.split('_')[0]]),int(helSorted[x.split('_')[1]]),int(x.split('_')[-1])) if '_Ybin_' in x else 0)
+    # one might want to invert the order of charge and helicity for the sorting
+
     params = sorted(params, key= lambda x: utilities.getNFromString(x) if '_Ybin_' in x else 0)
     params = sorted(params, key= lambda x: get_ieta_ipt_from_process_name(x) if ('_ieta_' in x and '_ipt_' in x) else 0)
     params = sorted(params, key= lambda x: int(x.replace('pdf','')) if 'pdf' in x else 0)
     params = sorted(params, key= lambda x: int(x.replace('muRmuF','')) if ('muRmuF' in x and x != "muRmuF")  else 0)
     params = sorted(params, key= lambda x: int(x.replace('muR','')) if (''.join([j for j in x if not j.isdigit()]) == 'muR' and x != "muR") else 0)
     params = sorted(params, key= lambda x: int(x.replace('muF','')) if (''.join([j for j in x if not j.isdigit()]) == 'muF' and x != "muF") else 0)
-    params = sorted(params, key= lambda x: utilities.getNEffStat(x) if 'EffStat' in x else 0)            
-    params = sorted(params, key= lambda x: int(x.split('FakesEtaUncorrelated')[1]) if 'FakesEtaUncorrelated' in x else 0)            
+    params = sorted(params, key= lambda x: utilities.getNFromString(x) if 'EffStat' in x else 0)            
+    params = sorted(params, key= lambda x: utilities.getNFromString(x) if 'FakesEtaUncorrelated' in x else 0)            
+    params = sorted(params, key= lambda x: utilities.getNFromString(x) if 'FakesPtUncorrelated' in x else 0)            
+
+    # sort by charge if needed     
+    # I think it is useful that different charges are separated in the matrix, it is easier to read it 
+    params = sorted(params, key = lambda x: 0 if "plus" in x else 1 if "minus" in x else 2)
     print "sorted params = ", params
 
     c = ROOT.TCanvas("c","",1200,800)

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_plots.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/wenu_plots.txt
@@ -47,6 +47,8 @@ wplus_abswy    : abs(prefsrw_y)                                         : 120,0.
 wplus_wpt      : prefsrw_pt                                             : 100,0.,100. ; XTitle="p_{T}^{W} (W^{+})"
 wplus_abswygap : abs(prefsrw_y)                                         : 60,0.,3. ; XTitle="|Y_{W}| (W^{+})"
 
+wplus_abswy_coarse    : abs(prefsrw_y)                                         : 30,0.,6. ; XTitle="Y_{W} (W^{+})"
+
 #etaPt   : ptElFull(LepGood1_calPt,LepGood1_eta)\:LepGood1_eta : 48,-2.5,2.5,20,30.,50. ; XTitle="#eta^{e}", YTitle="p_{T}^{e} [GeV]"
 #etaPt   : ptElFull(LepGood1_calPt,LepGood1_eta)\:LepGood1_eta : 24,-2.5,2.5,20,30.,50. ; XTitle="#eta^{e}", YTitle="p_{T}^{e} [GeV]"
 etaPt   : ptElFull(LepGood1_calPt,LepGood1_eta)\:LepGood1_eta : [-2.5,-2.25,-2.0,-1.8,-1.566,-1.4442,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4442,1.566,1.8,2.0,2.25,2.5]*[30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 45] ; XTitle="#eta^{e}", YTitle="p_{T}^{e} [GeV]"


### PR DESCRIPTION
**w-helicity-13TeV/subMatrix.py**
Small fixes for correlation matrices, add nice names for Fakes*Uncorrelated and EffStat

**w-helicity-13TeV/postFitPlots.py**
Improve a bit the unrolled plots for helicity. Example here [0], and also adding vertical lines to plots like this one [1]

I didn't make the style uniform with those ones I do for diff.xsec.(example [2]) because I use a different script (and different functions) and I didn't want to upset you script, but it can be done easily if you want.

The rest of commits is about stuff for differential cross section.

**Links:**
[0] 
http://mciprian.web.cern.ch/mciprian/wmass/13TeV/helicityAnalysis/electron/fromEmanuele/testPostfitPlots/22-02-19/unrolled_minus_el_PFMT40_absY_prefit.png

[1]
http://mciprian.web.cern.ch/mciprian/wmass/13TeV/helicityAnalysis/electron/fromEmanuele/testPostfitPlots/22-02-19/postfit2prefit_Wminus_long_ratio_minus_el_PFMT40_absY_.png

[2] 
http://mciprian.web.cern.ch/mciprian/wmass/13TeV/diffXsecAnalysis/electron/diffXsec_el_2019_02_22_ptMax50_dressed/postFitPlots_xsec/fakesPtEtaUncorr_noDYsigBkgNorm_dressed_bbb1_cxs1/unrolled_minus_el_diffXsec_prefit.png

