### PR TITLE
Some updates for the merger for helicity

### DIFF
--- a/WMass/python/plotter/resultPlots.py
+++ b/WMass/python/plotter/resultPlots.py
@@ -27,6 +27,7 @@ if __name__ == '__main__':
     if options.runtoys:
         toysHessian += ['toys']
 
+    charges = ['plus','minus']
     ## plot syst ratios
     ## ================================
     if options.make in ['all', 'syst']:
@@ -43,10 +44,13 @@ if __name__ == '__main__':
         systs += ['CMS_Wmu_FR_norm']
         systs += ['CMS_Wmu_FRmu_slope']
         systs += ['CMS_Wmu_muscale']
-        systs += [','+','.join(['FakesEtaUncorrelated%d'%i for i in xrange(1,11)])]
-        systs += [','+','.join(['FakesPtUncorrelated%d' %i for i in xrange(1,11)])]
+        nEtaUnc = 10 if muEl=='mu' else 26
+        systs += [','+','.join(['FakesEtaUncorrelated{idx}{flav}{charge}'.format(idx=i,flav=muEl,charge=charge) for i in xrange(1,nEtaUnc+1) for charge in charges])]
+        systs += [','+','.join(['FakesPtUncorrelated{idx}{flav}{charge}'.format(idx=i,flav=muEl,charge=charge) for i in xrange(1,nEtaUnc+1) for charge in charges])]
         for nuis in systs:
-            os.system('python w-helicity-13TeV/systRatios.py --unrolled --outdir {od} -s {p} {d} {ch}'.format(od=tmp_outdir, p=nuis, d=results['cardsdir'], ch=muEl))
+            cmd = 'python w-helicity-13TeV/systRatios.py --unrolled --outdir {od} -s {p} {d} {ch}'.format(od=tmp_outdir, p=nuis, d=results['cardsdir'], ch=muEl)
+            print "Running: ",cmd
+            os.system(cmd)
 
     ## plot correlation matrices
     ## ================================

--- a/WMass/python/plotter/w-helicity-13TeV/runAllFits.py
+++ b/WMass/python/plotter/w-helicity-13TeV/runAllFits.py
@@ -7,20 +7,20 @@ if channel not in ['mu','el']:
     print "Channel must be either mu or el. Exiting."
     sys.exit()
 
-pois = [' --POIMode none ','']
-expected = [' -t 0 ',' -t -1 ']
-BBBs = ['',' --binByBinStat --correlateXsecStat ']
+pois = [('poim1',''),('poim0',' --POIMode none ')]
+expected = [('exp1',' -t -1 '),('exp0',' -t 0 ')]
+BBBs = [('bbb1',' --binByBinStat --correlateXsecStat '),('bbb0','')]
 
-for ipm,POImode in enumerate(pois):
-    card = cardsdir+"/W{chan}_card_withXsecMask.hdf5".format(chan=channel) if len(POImode)==0 else cardsdir+'/W{chan}_card.hdf5'.format(chan=channel)
-    doImpacts = ' --doImpacts ' if ipm==1 else ''
-    for iexp,exp in enumerate(expected):
-        saveHist = ' --saveHists --computeHistErrors ' #if (iexp==0 and ipm==1) else ''
-        for ibbb,bbb in enumerate(BBBs):
-            cmd = 'combinetf.py {poimode} {exp} {bbb} {saveh} {imp} {card}'.format(poimode=POImode, exp=exp, bbb=bbb, saveh=saveHist, imp=doImpacts, card=card)
+for ipm,POImode in pois:
+    card = cardsdir+"/W{chan}_card_withXsecMask.hdf5".format(chan=channel) if ipm=='poim1' else cardsdir+'/W{chan}_card.hdf5'.format(chan=channel)
+    doImpacts = ' --doImpacts ' if ipm=='poim1' else ''
+    for iexp,exp in expected:
+        saveHist = ' --saveHists --computeHistErrors '
+        for ibbb,bbb in BBBs:
+            cmd = 'combinetf.py {poimode} {exp} {bbb} {saveh} {imp} {card} --fitverbose 9'.format(poimode=POImode, exp=exp, bbb=bbb, saveh=saveHist, imp=doImpacts, card=card)
             print "running ",cmd
             os.system(cmd)
-            os.system('mv fitresults_123456789.root fitresults_poim{ipm}_exp{iexp}_bbb{ibbb}.root'.format(ipm=ipm, iexp=iexp, ibbb=ibbb))
+            os.system('mv fitresults_123456789.root fitresults_{ipm}_{iexp}_{ibbb}.root'.format(ipm=ipm, iexp=iexp, ibbb=ibbb))
             print "fit done. Moving to the next one."
 
             


### PR DESCRIPTION
- make the binning for the eta unc. syst for electron fakes = 0.2 with a better magnitude vs eta
- putting apart the "CMS_We_sig_lepeff" (@cippy this is important above all for 2d xsec, since the OtherExp group is dominating and presumably it comes from the correlated sig_lepeff)
EffSyst group = CMS_We_sig_lepeff
OtherExp group = CMS_We_lepVeto CMS_We_bkg_lepeff
- some changes for fixing the longW as a bkg

