### PR TITLE
Small changes for the electron fakes scalings

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -227,6 +227,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
                     elif abs(etabins[borderBin]) < 0.41: scalings.append(0.025)
                     elif abs(etabins[borderBin]) < 1.01: scalings.append(0.04)
                     elif abs(etabins[borderBin]) < 1.51: scalings.append(0.06)
+                    elif abs(etabins[borderBin]) < 1.71: scalings.append(0.06)
                     elif abs(etabins[borderBin]) < 2.00: scalings.append(0.03)
                     else:                         scalings.append(0.06)
 
@@ -239,7 +240,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
                 borderBins.append(next( x[0] for x in enumerate(ptbins) if x[1] > i))
             borderBins.append(len(ptbins))
 
-            scalings = [0.30, 0.25, 0.15, 0.25, 0.30] if isMu else [0.30, 0.20, 0.10, 0.20, 0.30]
+            scalings = [0.30, 0.25, 0.15, 0.25, 0.30] if isMu else [0.20, 0.20, 0.10, 0.10, 0.20]
 
         ## loop over all eta bins of the 2d histogram
         for ib, borderBin in enumerate(borderBins[:-1]):


### PR DESCRIPTION
Adding the edge at 1.71 select the bins around the gap and use 6% variation, as it is more suited. It is also needed for 2D xsec, where the binning goes as 1.4, 1.6, 1.8... around the gap, otherwise the bin in [1.4-1.6] gets only 3% instead of 6%

For the PtNorm, I used more realistic values based on these plots [0]
Actually,  these numbers are not really constant versus eta, at least between EB and EE, but let's keep things simple.

[0] 
http://mciprian.web.cern.ch/mciprian/wmass/13TeV/test_fakesChargeAsym/electron_pol2/?match=_over_fa