### PR TITLE
Fix for previous PR, and adding smalll fakes uncorrelated uncertainties in bins of eta

### DIFF
--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -8,17 +8,18 @@ skipMergeRoot=0
 skipSingleCard=0
 skipMergeCard=0
 
-folder = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/" # keep "/" at the end
-th3file = "cards/" + folder + "wel_pt56_L1prefire.root"
+#folder = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/" # keep "/" at the end
+#th3file = "cards/" + folder + "wel_pt56_L1prefire.root"
 
-#folder = "diffXsec_mu_2019_03_12_ptMax56_dressed/" # keep "/" at the end
-#th3file = "cards/" + folder + "wmu_pt56_L1prefire.root"
+folder = "diffXsec_mu_2019_03_12_ptMax56_dressed/" # keep "/" at the end
+th3file = "cards/" + folder + "wmu_pt56_L1prefire.root"
 
 uncorrelateFakesNuisancesByCharge = False # need to rerun the MergeRoot when changing this one
+# note that there is always a part of the uncertainty that is charge-uncorrelated
 
 optionsForRootMerger = " --etaBordersForFakesUncorr 0.5,1.0,1.6,2.0 " # use 0.5,1.0,1.5,2.0 for muons, where eta bins are 0.1 wide
 optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --tauChargeLnN 0.03 --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous'  " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta ### --uncorrelate-fakes-by-charge   # .*FakesPtNormUncorrelated.* --fakesChargeLnN 0.03
-optionsForCardMakerMerger = " --postfix corrNuisFakes --useSciPyMinimizer  "  # --no-text2hdf5
+optionsForCardMakerMerger = " --postfix corrNuisFakes_addEtaChargeUncorr0p02 --useSciPyMinimizer  "  # --no-text2hdf5
 
 if uncorrelateFakesNuisancesByCharge:
     optionsForRootMerger += " --uncorrelate-fakes-by-charge "

--- a/WMass/python/plotter/makeCardsFromTH1.py
+++ b/WMass/python/plotter/makeCardsFromTH1.py
@@ -484,6 +484,24 @@ if nFakesPtNormUncorrelated:
         allSystForGroups.append(syst)
         card.write(('%-16s shape' % syst) + " ".join([kpatt % ("1.0" if "fakes" in p else "-") for p in allprocesses]) +"\n")        
 
+# the following is charge-uncorrelated by definition
+ffile = options.indir + "FakesEtaChargeUncorrelated_{fl}_{ch}.root".format(ch=charge, fl=flavour)
+nFakesEtaCgargeUncorrelated = 0
+ff = ROOT.TFile.Open(ffile,"READ")
+if not ff or not ff.IsOpen():
+    raise RuntimeError('Unable to open file {fn}'.format(fn=ffile))
+else:
+    # count number of histograms and divide by 2 (there are up and down variations)
+    nFakesEtaChargeUncorrelated = ff.GetNkeys()/2
+ff.Close()
+if nFakesEtaChargeUncorrelated:
+    for i in range(1,nFakesEtaChargeUncorrelated+1):
+        syst = "FakesEtaChargeUncorrelated{d}{flch}".format(d=i, flch=flavour+charge)  #flch=postfixForFlavourAndCharge)
+        if isExcludedNuisance(excludeNuisances, syst): continue
+        allSystForGroups.append(syst)
+        card.write(('%-16s shape' % syst) + " ".join([kpatt % ("1.0" if "fakes" in p else "-") for p in allprocesses]) +"\n")        
+
+
 # fakes
 # (although these are currently excluded with regular expressions, since we now have all the uncorrelated uncertainties)
 fakeSysts = ["CMS_We_FRe_slope", "CMS_We_FRe_continuous"] if flavour == "el" else ["CMS_Wmu_FRmu_slope", "CMS_Wmu_FRmu_continuous"]

--- a/WMass/python/plotter/mergeRootComponentsDiffXsec.py
+++ b/WMass/python/plotter/mergeRootComponentsDiffXsec.py
@@ -351,19 +351,21 @@ print "-"*20
 print ""
 
 fileFakesEtaUncorr = "{od}FakesEtaUncorrelated_{fl}_{ch}.root".format(od=outdir, fl=flavour, ch=options.charge) 
+fileFakesEtaChargeUncorr = "{od}FakesEtaChargeUncorrelated_{fl}_{ch}.root".format(od=outdir, fl=flavour, ch=options.charge) 
 fileFakesPtSlopeUncorr  = "{od}FakesPtSlopeUncorrelated_{fl}_{ch}.root".format( od=outdir, fl=flavour, ch=options.charge) 
 fileFakesPtNormUncorr  = "{od}FakesPtNormUncorrelated_{fl}_{ch}.root".format( od=outdir, fl=flavour, ch=options.charge) 
 # these names are used inside putUncorrelatedFakes (do not change them outside here)
-print "Now adding FakesEtaUncorrelated and FakesPtSlopeUncorrelated and FakesPtNormUncorrelated systematics to x_data_fakes process"
+print "Now adding Fakes*Uncorrelated systematics to x_data_fakes process"
 print "Will create file --> {of}".format(of=fileFakesEtaUncorr)
+print "Will create file --> {of}".format(of=fileFakesEtaChargeUncorr)
 print "Will create file --> {of}".format(of=fileFakesPtSlopeUncorr)
 print "Will create file --> {of}".format(of=fileFakesPtNormUncorr)
 etaBordersForFakes = [float(x) for x in options.etaBordersForFakesUncorr.split(',')]
 if not options.dryrun: 
     putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, etaBordersTmp=etaBordersForFakes, 
                          doType='eta', uncorrelateCharges=options.uncorrelateFakesByCharge)
-    #putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, etaBordersTmp=etaBordersForFakes, 
-    #                     doType='eta', uncorrelateCharges=True)
+    putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, etaBordersTmp=etaBordersForFakes, 
+                        doType='etacharge', uncorrelateCharges=True) # this is always true
     putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, etaBordersTmp=etaBordersForFakes, 
                          doType='ptslope', uncorrelateCharges=options.uncorrelateFakesByCharge)
     putUncorrelatedFakes(dataAndBkgFileTmp, 'x_data_fakes', charge, outdir, isMu=True if flavour=="mu" else False, etaBordersTmp=etaBordersForFakes, 
@@ -372,14 +374,15 @@ if not options.dryrun:
 print "Now merging signal + Z + data + other backgrounds + Fakes*Uncorrelated + ZEffStat"
 sigfile = "{osig}W{fl}_{ch}_shapes_signal.root".format(osig=options.indirSig, fl=flavour, ch=charge)
 
-cmdFinalMerge="hadd -f -k -O {of} {sig} {zf} {bkg} {fakesEta} {fakesPtSlope} {fakesPtNorm} {zEffStat}".format(of=shapename, 
-                                                                                                              sig=sigfile, 
-                                                                                                              zf=Zfile, 
-                                                                                                              bkg=dataAndBkgFileTmp, 
-                                                                                                              fakesEta=fileFakesEtaUncorr,
-                                                                                                              fakesPtSlope=fileFakesPtSlopeUncorr,
-                                                                                                              fakesPtNorm=fileFakesPtNormUncorr,
-                                                                                                              zEffStat=fileZeffStat)
+cmdFinalMerge="hadd -f -k -O {of} {sig} {zf} {bkg} {fakesEta} {fakesEtaCharge} {fakesPtSlope} {fakesPtNorm} {zEffStat}".format(of=shapename, 
+                                                                                                                               sig=sigfile, 
+                                                                                                                               zf=Zfile, 
+                                                                                                                               bkg=dataAndBkgFileTmp, 
+                                                                                                                               fakesEta=fileFakesEtaUncorr,
+                                                                                                                               fakesEtaCharge=fileFakesEtaChargeUncorr,
+                                                                                                                               fakesPtSlope=fileFakesPtSlopeUncorr,
+                                                                                                                               fakesPtNorm=fileFakesPtNormUncorr,
+                                                                                                                               zEffStat=fileZeffStat)
 print "Final merging ..."
 print cmdFinalMerge
 if not options.dryrun: os.system(cmdFinalMerge)

--- a/WMass/python/plotter/w-helicity-13TeV/impactPlots.py
+++ b/WMass/python/plotter/w-helicity-13TeV/impactPlots.py
@@ -383,14 +383,7 @@ if __name__ == "__main__":
             else:
                 fitErrors[new_x] = 100*abs((valuesAndErrors[x][1]-valuesAndErrors[x][0])/valuesAndErrors[x][0])
 
-        # get file with binning from path in args[0], assuming it is in /foo/bar/cards/<folder>/binningPtEta.txt
-        # might be better to explicitely pass an option (for 1D xsec it is already done because I don't take the rapidity file
-        foldernames = args[0].split("/")
-        ifolder = -1
-        for i,f in enumerate(foldernames):
-            if f == "cards": ifolder = i+1
-        etaptbinfile = "/".join(f for f in foldernames[:ifolder]) + "/binningPtEta.txt"
-        if args[0].startswith("/"): etaptbinfile = "/" + etaptbinfile 
+        etaptbinfile = options.ybinfile.replace("binningYW.txt","binningPtEta.txt")
         etaPtBinningVec = getDiffXsecBinning(etaptbinfile, "reco")
         recoBins = templateBinning(etaPtBinningVec[0],etaPtBinningVec[1])
         ptRangeText = "p_{T}^{%s} #in [%.3g, %.3g] GeV" % (flavour, recoBins.ptBins[0], recoBins.ptBins[-1])
@@ -601,6 +594,6 @@ if __name__ == "__main__":
                 cs.SetLogy()
                 cs.SaveAs(options.outdir+'/etaImpacts{rel}{suff}_{target}_{ptbin}{ch}.{i}'.format(rel='Abs' if options.absolute else 'Rel',
                                                                                                   suff=suff,target=options.target,i=i,
-                                                                                                  ptbin=(str(theptbin)+"_") if isSinglePtStrip else "",
+                                                                                                  ptbin=("ipt"+str(theptbin)+"_") if isSinglePtStrip else "",
                                                                                                   ch=charge))
 

--- a/WMass/python/plotter/w-helicity-13TeV/impactPlots.py
+++ b/WMass/python/plotter/w-helicity-13TeV/impactPlots.py
@@ -383,7 +383,15 @@ if __name__ == "__main__":
             else:
                 fitErrors[new_x] = 100*abs((valuesAndErrors[x][1]-valuesAndErrors[x][0])/valuesAndErrors[x][0])
 
-        etaPtBinningVec = getDiffXsecBinning(options.etaptbinfile, "reco")
+        # get file with binning from path in args[0], assuming it is in /foo/bar/cards/<folder>/binningPtEta.txt
+        # might be better to explicitely pass an option (for 1D xsec it is already done because I don't take the rapidity file
+        foldernames = args[0].split("/")
+        ifolder = -1
+        for i,f in enumerate(foldernames):
+            if f == "cards": ifolder = i+1
+        etaptbinfile = "/".join(f for f in foldernames[:ifolder]) + "/binningPtEta.txt"
+        if args[0].startswith("/"): etaptbinfile = "/" + etaptbinfile 
+        etaPtBinningVec = getDiffXsecBinning(etaptbinfile, "reco")
         recoBins = templateBinning(etaPtBinningVec[0],etaPtBinningVec[1])
         ptRangeText = "p_{T}^{%s} #in [%.3g, %.3g] GeV" % (flavour, recoBins.ptBins[0], recoBins.ptBins[-1])
 
@@ -476,7 +484,7 @@ if __name__ == "__main__":
                 lbl = th2_sub.GetXaxis().GetBinLabel(i+1)
                 # we expect something like "el: W+ i#eta, ip_T = 3, 5" we need to get 3 
                 etabin = int(((lbl.split('=')[-1]).split(',')[0]).rstrip().lstrip())
-                # print "lbl = %s   bineta = %s" % (lbl, str(etabin))
+                #print "lbl = %s   bineta = %s" % (lbl, str(etabin))
                 if 'W+' in lbl: charge='plus'
                 elif 'W-' in lbl: charge='minus'
                 else: charge='allcharges' 
@@ -494,8 +502,36 @@ if __name__ == "__main__":
             else:
                 fitErrors[new_x] = 100*abs((valuesAndErrors[x][1]-valuesAndErrors[x][0])/valuesAndErrors[x][0])
 
-        ptRangeText = "p_{T}^{%s} #in [%.3g, %.3g] GeV" % (flavour, genBins.ptBins[0] if options.ptMinSignal < 0 else options.ptMinSignal, genBins.ptBins[-1])
-
+        ptmin = genBins.ptBins[0] if options.ptMinSignal < 0 else options.ptMinSignal
+        ptmax = genBins.ptBins[-1]
+        # this will be for strips at constant pt (if the proper options were passed)
+        isSinglePtStrip = False
+        if options.target not in ["etaxsec", "etaxsecnorm", "etaasym"]:
+            print "Going to draw a strip at constant pt"
+            isSinglePtStrip = True
+            ptbin_hasChanged = False
+            theptbin = 0
+            for i in xrange(th2_sub.GetNbinsX()):
+                lbl = th2_sub.GetXaxis().GetBinLabel(i+1)
+                # we expect something like "el: W+ i#eta, ip_T = 3, 5" we need to get 5 
+                ptbin = int(((lbl.split('=')[-1]).split(',')[1]).rstrip().lstrip())
+                if i == 0: 
+                    theptbin = ptbin  # for the first item, assign the value
+                else: 
+                    if theptbin != ptbin:
+                        ptbin_hasChanged = True                        
+                        theptbin = ptbin
+                #print "lbl = %s   binpt = %s" % (lbl, str(ptbin))
+            if ptbin_hasChanged:
+                print "Warning: based on the options, you wanted to select a strip along eta at constant pt"
+                print "However, I see that you are selecting more pt bins, check the option for the regular expression to select POIs"
+                quit()
+            #print "theptbin = " + str(theptbin)
+            ptmin = genBins.ptBins[theptbin]
+            ptmax = genBins.ptBins[theptbin+1]
+            print "Plot for pt-bin %d: ptmin, ptmax = %.3g, %.3g " % (theptbin, ptmin, ptmax)
+        ptRangeText = "p_{T}^{%s} #in [%.3g, %.3g] GeV" % (flavour, ptmin, ptmax)
+        #print ptRangeText
         #for key in fitErrors:
         #    print "fitErrors: key = " + key
 
@@ -563,5 +599,8 @@ if __name__ == "__main__":
             for i in ['pdf', 'png']:
                 suff = '' if not options.suffix else '_'+options.suffix
                 cs.SetLogy()
-                cs.SaveAs(options.outdir+'/etaImpacts{rel}{suff}_{target}_{ch}.{i}'.format(rel='Abs' if options.absolute else 'Rel',suff=suff,target=options.target,i=i,ch=charge))
+                cs.SaveAs(options.outdir+'/etaImpacts{rel}{suff}_{target}_{ptbin}{ch}.{i}'.format(rel='Abs' if options.absolute else 'Rel',
+                                                                                                  suff=suff,target=options.target,i=i,
+                                                                                                  ptbin=(str(theptbin)+"_") if isSinglePtStrip else "",
+                                                                                                  ch=charge))
 

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -245,7 +245,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
             #ptBorders = [26, 32, 38, 45, 50, 56] if isMu else [30, 35, 40, 45, 50, 56]  # last pt bin for 2D xsec might be 56 or 55, now I am using 56
             ptBorders = [26, 32, 38, 45] if isMu else [30, 35, 40, 45]
             if ptbins[-1] > ptBorders[-1]:
-                ptBorders.extend([50, 56]
+                ptBorders.extend([50, 56])
             borderBins = []
             for i in ptBorders[:-1]:
                 borderBins.append(next( x[0] for x in enumerate(ptbins) if x[1] > i))

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -154,8 +154,10 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
     doPt     = doType == 'ptslope' ## keep that from before
     doEta    = doType == 'eta'
     doPtNorm = doType == 'ptnorm'
+    doUncorrChargeEta = doType == 'etacharge'
+    if doUncorrChargeEta: uncorrelateCharges = True  # just in case one forgets
 
-    typeName = 'PtSlope' if doPt else 'Eta' if doEta else 'PtNorm' if doPtNorm else ''
+    typeName = 'PtSlope' if doPt else 'Eta' if doEta else 'PtNorm' if doPtNorm else 'EtaCharge' if doUncorrChargeEta else ''
     if not typeName:
         print 'YOU GAVE A WRONG OPTION TO THE UNCORRELATED FAKES FUNCTION'
         sys.exit()
@@ -206,7 +208,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
             tmp_dn_2d = dressed2D(tmp_dn,binning, var_dn+'backrolled')
 
         ## get the border bins in eta for the uncorrelated nuisances in eta
-        if doPt or doEta:
+        if doPt or doEta or doUncorrChargeEta:
             deltaEtaUnc = 0.5 if isMu else 0.2
             ## absolute eta borders:        
             etaBorders = etaBordersTmp if len(etaBordersTmp) else [round(deltaEtaUnc*(i+1),1) for i in xrange(int(max(etabins)/deltaEtaUnc))] #+[max(etabins)]
@@ -219,18 +221,23 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
                 borderBins.append(next(x[0] for x in enumerate(etabins) if x[1] > i))
             borderBins += [len(etabins)]
 
-            if isMu: 
-                scalings = [0.05 for b in borderBins[:-1]]
+            if doUncorrChargeEta:
+                scalings = [0.02 for b in borderBins[:-1]]  # 2%, common for both mu and ele
             else:
-                scalings = []
-                for ib, borderBin in enumerate(borderBins[:-1]):
-                    if   abs(etabins[borderBin]) < 0.21: scalings.append(0.01)
-                    elif abs(etabins[borderBin]) < 0.41: scalings.append(0.025)
-                    elif abs(etabins[borderBin]) < 1.01: scalings.append(0.04)
-                    elif abs(etabins[borderBin]) < 1.51: scalings.append(0.06)
-                    elif abs(etabins[borderBin]) < 1.71: scalings.append(0.06)
-                    elif abs(etabins[borderBin]) < 2.00: scalings.append(0.03)
-                    else:                         scalings.append(0.06)
+                if isMu: 
+                    factor = 0.03 # it used to be 0.05 for Eta, but now it is splitted in charge-correlated and charge-uncorrelated part
+                    scalings = [factor for b in borderBins[:-1]]
+                else:
+                    scalings = []
+                    for ib, borderBin in enumerate(borderBins[:-1]):
+                        # slightly reducing these numbers, as now we have a part that is uncorrelated between charges
+                        if   abs(etabins[borderBin]) < 0.21: scalings.append(0.01)  # 0.01
+                        elif abs(etabins[borderBin]) < 0.41: scalings.append(0.01)  # 0.025
+                        elif abs(etabins[borderBin]) < 1.01: scalings.append(0.02)  # 0.04
+                        elif abs(etabins[borderBin]) < 1.51: scalings.append(0.04)  # 0.06
+                        elif abs(etabins[borderBin]) < 1.71: scalings.append(0.04)  # 0.06
+                        elif abs(etabins[borderBin]) < 2.00: scalings.append(0.02)  # 0.03
+                        else:                                scalings.append(0.04)  # 0.06
 
         ## for ptnorm these are now pT borders, not eta borders
         elif doPtNorm:
@@ -238,7 +245,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
             #ptBorders = [26, 32, 38, 45, 50, 56] if isMu else [30, 35, 40, 45, 50, 56]  # last pt bin for 2D xsec might be 56 or 55, now I am using 56
             ptBorders = [26, 32, 38, 45] if isMu else [30, 35, 40, 45]
             if ptbins[-1] > ptBorders[-1]:
-                ptBorders.extend(50, 56)
+                ptBorders.extend([50, 56]
             borderBins = []
             for i in ptBorders[:-1]:
                 borderBins.append(next( x[0] for x in enumerate(ptbins) if x[1] > i))
@@ -255,11 +262,11 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
             tmp_scaledHisto_up = copy.deepcopy(tmp_nominal_2d.Clone(outname_2d+'Up'))
             tmp_scaledHisto_dn = copy.deepcopy(tmp_nominal_2d.Clone(outname_2d+'Down'))
             
-            if doPt or doEta:
+            if doPt or doEta or doUncorrChargeEta:
                 for ieta in range(borderBin,borderBins[ib+1]):
                     ## loop over all pT bins in that bin of eta (which is ieta)
                     for ipt in range(1,tmp_scaledHisto_up.GetNbinsY()+1):
-                        if doEta:
+                        if doEta or doUncorrChargeEta:
                             tmp_bincontent = tmp_scaledHisto_up.GetBinContent(ieta, ipt)
                             scaling = scalings[ib]
                             ## scale up and down with what we got from the histo


### PR DESCRIPTION
…x for PtNorm

fix for PtNorm when extending binning: ptBorders.extend(50, 56) -->ptBorders.extend([50, 56])

Then, adding possibility for charge-uncorrelated uncertainty on fakes, currently 2% based on these plots for muons [0] and electrons [1]. It works just as for "Eta", but it is named EtaCharge. One could make it binned in pt as well (so globally binned in pt-eta), but let's keep that simpler.

**Given that its definition is equivalent to the current "Eta"  nuisances, I reduced a little bit the magnitude for the latter.** If you don't want to use that for the moment, it is enough not to call the function at all, but the Eta uncertainties will be lower than before. 

If you don't merge for the moment, you have to fix the PtNorm bug manually, or the merger will exit.

[0] http://mciprian.web.cern.ch/mciprian/wmass/13TeV/test_fakesChargeAsym/muon_MarcFR_coarseBin_testptbin/dataSubEWKoverFakes_ratioPlusOverMinus.png

[1] http://mciprian.web.cern.ch/mciprian/wmass/13TeV/test_fakesChargeAsym/electron_pol2_noLumiXsecUnc_1ptbin/dataSubEWKoverFakes_ratioPlusOverMinus.png