### PR TITLE
Mu-el combination for 2D xsec

### DIFF
--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -3,12 +3,12 @@
 import ROOT, os, sys, re, array
 
 dryrun=0
-doMuons=0
+doMuons=1
 skipUnpack=1
-skipMergeRoot=1
-skipSingleCard=1
-skipMergeCard=1
-skipMergeCardFlavour=0 # requires both flavours, and the electron cards must have all signal bins considered as signal
+skipMergeRoot=0
+skipSingleCard=0
+skipMergeCard=0
+skipMergeCardFlavour=1 # requires both flavours, and the electron cards must have all signal bins considered as signal
 
 # el
 folder_el = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/" # keep "/" at the end
@@ -30,7 +30,7 @@ optionsForRootMerger = " --etaBordersForFakesUncorr " + ("0.5,1.0,1.6,2.0 " if d
 
 optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --tauChargeLnN 0.03 --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous'  " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta ### --uncorrelate-fakes-by-charge   # .*FakesPtNormUncorrelated.* --fakesChargeLnN 0.03
 
-optionsForCardMakerMerger = " --postfix combinedLep --useSciPyMinimizer --no-text2hdf5 --no-combinetf "  # --no-text2hdf5
+optionsForCardMakerMerger = " --postfix combinedLep --useSciPyMinimizer " #--no-text2hdf5 --no-combinetf " 
 
 optionsForCardMakerMergerFlavour = " --postfix combinedLep --useSciPyMinimizer " # --no-text2hdf5 --no-combinetf "  
 

--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -8,16 +8,16 @@ skipMergeRoot=0
 skipSingleCard=0
 skipMergeCard=0
 
-#folder = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/" # keep "/" at the end
-#th3file = "cards/" + folder + "wel_pt56_L1prefire.root"
+folder = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/" # keep "/" at the end
+th3file = "cards/" + folder + "wel_pt56_L1prefire.root"
 
-folder = "diffXsec_mu_2019_03_12_ptMax56_dressed/" # keep "/" at the end
-th3file = "cards/" + folder + "wmu_pt56_L1prefire.root"
+#folder = "diffXsec_mu_2019_03_12_ptMax56_dressed/" # keep "/" at the end
+#th3file = "cards/" + folder + "wmu_pt56_L1prefire.root"
 
 uncorrelateFakesNuisancesByCharge = False # need to rerun the MergeRoot when changing this one
 # note that there is always a part of the uncertainty that is charge-uncorrelated
 
-optionsForRootMerger = " --etaBordersForFakesUncorr 0.5,1.0,1.6,2.0 " # use 0.5,1.0,1.5,2.0 for muons, where eta bins are 0.1 wide
+optionsForRootMerger = " --etaBordersForFakesUncorr " + ("0.5,1.0,1.4,1.6,2.0 " if "_el_" in folder else "0.5,1.0,1.5,2.0 ")
 optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --tauChargeLnN 0.03 --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous'  " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta ### --uncorrelate-fakes-by-charge   # .*FakesPtNormUncorrelated.* --fakesChargeLnN 0.03
 optionsForCardMakerMerger = " --postfix corrNuisFakes_addEtaChargeUncorr0p02 --useSciPyMinimizer  "  # --no-text2hdf5
 

--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -3,38 +3,46 @@
 import ROOT, os, sys, re, array
 
 dryrun=0
+doMuons=0
 skipUnpack=1
-skipMergeRoot=0
-skipSingleCard=0
-skipMergeCard=0
+skipMergeRoot=1
+skipSingleCard=1
+skipMergeCard=1
+skipMergeCardFlavour=0 # requires both flavours, and the electron cards must have all signal bins considered as signal
 
-folder = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/" # keep "/" at the end
-th3file = "cards/" + folder + "wel_pt56_L1prefire.root"
+# el
+folder_el = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/" # keep "/" at the end
+th3file_el = "cards/" + folder_el + "wel_pt56_L1prefire.root"
+# mu
+folder_mu = "diffXsec_mu_2019_03_12_ptMax56_dressed/" # keep "/" at the end
+th3file_mu = "cards/" + folder_mu + "wmu_pt56_L1prefire.root"
 
-#folder = "diffXsec_mu_2019_03_12_ptMax56_dressed/" # keep "/" at the end
-#th3file = "cards/" + folder + "wmu_pt56_L1prefire.root"
+folder = folder_mu if doMuons else folder_el
+th3file = th3file_mu if doMuons else th3file_el
 
 uncorrelateFakesNuisancesByCharge = False # need to rerun the MergeRoot when changing this one
 # note that there is always a part of the uncertainty that is charge-uncorrelated
 
-optionsForRootMerger = " --etaBordersForFakesUncorr " + ("0.5,1.0,1.4,1.6,2.0 " if "_el_" in folder else "0.5,1.0,1.5,2.0 ")
+#================================
+# some more things are set below
+
+optionsForRootMerger = " --etaBordersForFakesUncorr " + ("0.5,1.0,1.6,2.0 " if doMuons else "0.5,1.0,1.4,1.6,2.0 ")
+
 optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --tauChargeLnN 0.03 --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous'  " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta ### --uncorrelate-fakes-by-charge   # .*FakesPtNormUncorrelated.* --fakesChargeLnN 0.03
-optionsForCardMakerMerger = " --postfix corrNuisFakes_addEtaChargeUncorr0p02 --useSciPyMinimizer  "  # --no-text2hdf5
+
+optionsForCardMakerMerger = " --postfix combinedLep --useSciPyMinimizer --no-text2hdf5 --no-combinetf "  # --no-text2hdf5
+
+optionsForCardMakerMergerFlavour = " --postfix combinedLep --useSciPyMinimizer " # --no-text2hdf5 --no-combinetf "  
+
+#================================
 
 if uncorrelateFakesNuisancesByCharge:
     optionsForRootMerger += " --uncorrelate-fakes-by-charge "
     optionsForCardMaker += " --uncorrelate-fakes-by-charge "
 
-# folder = "diffXsec_el_2018_12_16_onlyBkg_pt1GeV_eta0p2From1p3/"  # keep "/" at the end
-# th3file = "cards/" + folder + "wmass_varhists_ele_pt1GeV_eta0p2From1p3.root"
-# optionsForRootMerger = " --etaBordersForFakesUncorr 0.5,1.0,1.5,2.1 " # use 0.5,1.0,1.5,2.0 for muons, where eta bins are 0.1 wide
-# optionsForCardMaker = " --unbinned-QCDscale-Z --sig-out-bkg --exclude-nuisances 'CMS_DY' "
-# optionsForCardMakerMerger = " --postfix allSyst "  # --no-text2hdf5
-
-flavour = "el" if "_el_" in folder else "mu"
+flavour = "mu" if doMuons else "el"
 if flavour == "el":
-    optionsForCardMaker = optionsForCardMaker + " --pt-range-bkg 25.9 30.1  " #--eta-range-bkg 1.39 1.61 "
-
+    optionsForCardMaker = optionsForCardMaker  # + " --pt-range-bkg 25.9 30.1  " #--eta-range-bkg 1.39 1.61 "
 
 charges = ["plus", "minus"]
 
@@ -63,6 +71,13 @@ combineCards = "python makeCardsFromTH1.py -i cards/{fd} -f {fl} --comb-charge {
 if not skipMergeCard:
     print combineCards
     if not dryrun: os.system(combineCards)
+
+
+combineCardsFlavour = "python makeCardsFromTH1.py --indir-mu cards/{fdmu} --indir-el cards/{fdel} --comb-flavour".format(fdmu=folder_mu, fdel=folder_el) 
+combineCardsFlavour += " --comb-flavour {opt} -o cards/muElCombination/ ".format(opt=optionsForCardMakerMergerFlavour)
+if not skipMergeCardFlavour:
+    print combineCardsFlavour
+    if not dryrun: os.system(combineCardsFlavour)
 
 print ""
 print "DONE"

--- a/WMass/python/plotter/mergeRootComponentsDiffXsec.py
+++ b/WMass/python/plotter/mergeRootComponentsDiffXsec.py
@@ -207,7 +207,6 @@ if options.charge not in ["plus", "minus"]:
 
 charge = options.charge
 flavour = options.flavour
-#binname = options.bin if len(options.bin) else "W%s" % flavour
 
 if not len(options.indirBkg):
     print "Warning: you must specify a folder with data and background root files with option --indir-bkg"

--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -5,13 +5,13 @@ import ROOT, os, sys, re, array
 # to run plots from Asimov fit and data. For toys need to adapt this script
 
 doMuElComb = 1
-dryrun = 1
-skipData = 0
-onlyData = 1
+dryrun = 0
+skipData = 1
+onlyData = 0
 
-skipPlot = 0
+skipPlot = 1
 skipTemplate = 1
-skipDiffNuis = 1
+skipDiffNuis = 0
 skipPostfit = 1  # only for Data
 skipCorr = 1
 skipImpacts = 1
@@ -48,7 +48,8 @@ ptMinTemplate = "30" if flavour == "el" else "26"
 # if you want mu rejecting pmasked do _mu_mu or _el_mu (for electrons _mu works because it doesn't induce ambiguities with the flavour)
 diffNuisances_pois = ["pdf.*|alphaS|mW", 
                       "muR.*|muF.*", 
-                      "Fakes(Eta|Pt).*", 
+                      "Fakes(Eta|Pt).*[0-9]+mu.*", 
+                      "Fakes(Eta|Pt).*[0-9]+el.*", 
                       #"ErfPar0EffStat.*", 
                       #"ErfPar1EffStat.*", 
                       #"ErfPar2EffStat.*", 
@@ -70,7 +71,8 @@ correlationNuisRegexp = {# "allPDF"           : "pdf.*",
                          # "muR"              : "^muR[1-9]+", 
                          # "muF"              : "^muF[1-9]+", 
                          # "muRmuF"           : "^muRmuF[1-9]+", 
-                         "FakesEtaPtUncorr" : "Fakes(Eta|Pt).*", 
+                         "FakesEtaPtUncorr" : "Fakes(Eta|Pt).*[0-9]+mu.*",
+                         "FakesEtaPtUncorr" : "Fakes(Eta|Pt).*[0-9]+el.*", 
                          "CMSsyst"          : "CMS_.*",
                          # "ErfPar0EffStat"   : "ErfPar0EffStat.*",
                          # "ErfPar1EffStat"   : "ErfPar1EffStat.*",

--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -4,29 +4,37 @@ import ROOT, os, sys, re, array
 
 # to run plots from Asimov fit and data. For toys need to adapt this script
 
-dryrun = 0
-skipData = 1
-onlyData = 0
+doMuElComb = 1
+dryrun = 1
+skipData = 0
+onlyData = 1
 
-skipPlot = 1
+skipPlot = 0
 skipTemplate = 1
 skipDiffNuis = 1
 skipPostfit = 1  # only for Data
 skipCorr = 1
-skipImpacts = 0
+skipImpacts = 1
 
 
 seed = 123456789
 
 folder = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/"
 #folder = "diffXsec_mu_2019_03_12_ptMax56_dressed/"
+if doMuElComb:
+    folder = "muElCombination"
 
-#postfix = "corrNuisFakes"
 postfix = "corrNuisFakes_addEtaChargeUncorr0p02"
+if doMuElComb:
+    postfix = "combinedLep"
 postfix += "_bbb1_cxs1"
 
 flavour = "el" if "_el_" in folder else "mu"
 lepton = "electron" if flavour == "el"  else "muon"
+if doMuElComb:
+    flavour = "lep"
+    lepton = "lepton"
+
 fits = ["Asimov", "Data"]
 
 ptBinsSetting = " --pt-range-bkg 25.9 30.1 --pt-range '30,56' " if flavour == "el"  else ""  # " --eta-range-bkg 1.39 1.61 "
@@ -45,15 +53,15 @@ diffNuisances_pois = ["pdf.*|alphaS|mW",
                       #"ErfPar1EffStat.*", 
                       #"ErfPar2EffStat.*", 
                       "CMS_.*", 
-                      #"Wplus.*_ieta_.*_%s_mu"  % flavour,     
-                      #"Wminus.*_ieta_.*_%s_mu" % flavour
+                      #"Wplus.*_ieta_.*_mu",     
+                      #"Wminus.*_ieta_.*_mu"
                       ]
 
 # this is appended to nuis below
-#correlationSigRegexp = {"Wplus_ieta6ipt6" : ".*_ieta_6_ipt_6_Wplus_.*_mu"  
+#correlationSigRegexp = {"Wplus_ieta6ipt6" : ".*Wplus.*_ieta_6_ipt_6_.*mu"  
 #                        }
 # need to specify which matrix, by default the one for mu is chosen and the bin label looks like Wplus_el_ieta_1_ipt_0_Wplus_el, without ending mu
-correlationSigRegexp = {"Wplus_ieta6ipt8" : ".*_ieta_6_ipt_8_Wplus_.*"
+correlationSigRegexp = {"Wplus_ieta6ipt8" : ".*Wplus_.*_ieta_6_ipt_8_.*"
                         }
 
 correlationNuisRegexp = {# "allPDF"           : "pdf.*", 
@@ -104,7 +112,7 @@ impacts_nuis = ["GROUP"]     # this will do groups, I can filter some of them, b
 #groupnames = 'binByBinStat,stat,pdfs,wmodel,EffStat,scales,alphaS'
 groupnames = 'binByBinStat,stat,luminosity,pdfs,QCDTheo,Fakes,OtherBkg,OtherExp,EffStat,EffSyst,lepScale'
 
-# no longer used: for impacts in the form of graphs, use "W.*_ieta_.*" for pt-integrated stuff, and "W.*_ieta_.*_ipt_XX" for the rest, where XX is a given pt bin   x
+# no longer used: for impacts in the form of graphs, use "W.*_ieta_.*" for pt-integrated stuff, and "W.*_ieta_.*_ipt_XX" for the rest, where XX is a given pt bin 
 impacts_pois = [#"Wplus.*_ipt_2_.*" if flavour == "el" else "Wplus.*_ipt_0_.*",
                 #"Wplus.*_ipt_8_.*",
                 #"Wplus.*_ipt_11_.*",

--- a/WMass/python/plotter/plotUtils/utility.py
+++ b/WMass/python/plotter/plotUtils/utility.py
@@ -598,12 +598,13 @@ def drawSingleTH1(h1,
     h1.GetYaxis().SetTitleSize(0.05)
     h1.GetYaxis().SetLabelSize(0.04)
     h1.GetYaxis().SetRangeUser(ymin, ymax)
+    h1.GetYaxis().SetTickSize(0.01)
     if setXAxisRangeFromUser: h1.GetXaxis().SetRangeUser(xmin,xmax)
     h1.Draw("HIST")
     h1err = h1.Clone("h1err")
     h1err.SetFillColor(ROOT.kRed+2)
-    #h1err.SetFillStyle(3001)
-    h1err.SetFillStyle(3002)
+    h1err.SetFillStyle(3001)  # 3001 is better than 3002 for pdf, while 3002 is perfect for png
+    #h1err.SetFillStyle(3002)
     #h1err.SetFillStyle(3005)
     h1err.Draw("E2same")
     #h1.Draw("HIST same")
@@ -628,7 +629,7 @@ def drawSingleTH1(h1,
 
     vertline = ROOT.TLine(36,0,36,canvas.GetUymax())
     vertline.SetLineColor(ROOT.kBlack)
-    vertline.SetLineStyle(2)
+    vertline.SetLineStyle(3)
     bintext = ROOT.TLatex()
     #bintext.SetNDC()
     bintext.SetTextSize(0.025)  # 0.03
@@ -691,9 +692,18 @@ def drawSingleTH1(h1,
   #   pvtxt.Draw()
   # }
 
-    if lumi != None: CMS_lumi(canvas,lumi,True,False)
-    else:            CMS_lumi(canvas,"",True,False)
     setTDRStyle()
+    if leftMargin > 0.1:
+        if lumi != None: CMS_lumi(canvas,lumi,True,False)
+        else:            CMS_lumi(canvas,"",True,False)
+    else:
+        latCMS = ROOT.TLatex()
+        latCMS.SetNDC();
+        latCMS.SetTextFont(42)
+        latCMS.SetTextSize(0.045)
+        latCMS.DrawLatex(0.1, 0.95, '#bf{CMS} #it{Preliminary}')
+        if lumi != None: latCMS.DrawLatex(0.85, 0.95, '%s fb^{-1} (13 TeV)' % lumi)
+        else:            latCMS.DrawLatex(0.90, 0.95, '(13 TeV)' % lumi)
 
     if lowerPanelHeight:
         pad2.Draw()
@@ -729,7 +739,7 @@ def drawSingleTH1(h1,
     
         line = ROOT.TF1("horiz_line","1",ratio.GetXaxis().GetBinLowEdge(1),ratio.GetXaxis().GetBinLowEdge(ratio.GetNbinsX()+1))
         line.SetLineColor(ROOT.kRed)
-        line.SetLineWidth(2)
+        line.SetLineWidth(1)
         line.Draw("Lsame")
 
         if drawLineLowerPanel:
@@ -737,10 +747,10 @@ def drawSingleTH1(h1,
             line2 = ROOT.TF1("horiz_line_2",str(1+float(yline)),ratio.GetXaxis().GetBinLowEdge(1),ratio.GetXaxis().GetBinLowEdge(ratio.GetNbinsX()+1))
             line3 = ROOT.TF1("horiz_line_3",str(1-float(yline)),ratio.GetXaxis().GetBinLowEdge(1),ratio.GetXaxis().GetBinLowEdge(ratio.GetNbinsX()+1))
             line2.SetLineColor(ROOT.kBlue)
-            line2.SetLineWidth(2)
+            line2.SetLineWidth(1)
             line2.Draw("Lsame")
             line3.SetLineColor(ROOT.kBlue)
-            line3.SetLineWidth(2)
+            line3.SetLineWidth(1)
             line3.Draw("Lsame")
             x1leg2 = 0.2 if leftMargin > 0.1 else 0.07
             x2leg2 = 0.5 if leftMargin > 0.1 else 0.27
@@ -882,18 +892,18 @@ def drawDataAndMC(h1, h2,
     h1.GetYaxis().SetTitleSize(0.05)
     h1.GetYaxis().SetLabelSize(0.04)
     h1.GetYaxis().SetRangeUser(ymin, ymax)    
+    h1.GetYaxis().SetTickSize(0.01)
     if setXAxisRangeFromUser: h1.GetXaxis().SetRangeUser(xmin,xmax)
     h1.Draw("EP")
     #h1err = h1.Clone("h1err")
     #h1err.SetFillColor(ROOT.kRed+2)
-    h2.SetFillStyle(3002)
-    h2.SetLineColor(ROOT.kGreen)  #kRed+2
+    h2.SetFillStyle(3001)  # 3001 is better than 3002 for pdf, while 3002 is perfect for png
+    h2.SetLineColor(ROOT.kGreen+2)  #kRed+2
     h2.SetFillColor(ROOT.kGreen)
-    h2.SetLineWidth(2)
+    h2.SetLineWidth(1)
     h2.Draw("E2 SAME")
     h2line = h2.Clone("h2line")
     h2line.SetFillColor(0)
-    h2line.Draw("HIST SAME")
     h3 = None
     if histMCpartialUnc != None:
         h3 = histMCpartialUnc.Clone("histMCpartialUnc")
@@ -902,6 +912,7 @@ def drawDataAndMC(h1, h2,
         h3.Draw("E2 SAME")
         for i in range(1,1+h3.GetNbinsX()):
             print "PDF band: bin %d  val +/- error = %.3f +/- %.3f" % (i, h3.GetBinContent(i),h3.GetBinError(i))
+    h2line.Draw("HIST SAME")
     h1.Draw("EP SAME")
 
 
@@ -930,7 +941,7 @@ def drawDataAndMC(h1, h2,
 
     vertline = ROOT.TLine(36,0,36,canvas.GetUymax())
     vertline.SetLineColor(ROOT.kBlack)
-    vertline.SetLineStyle(2)
+    vertline.SetLineStyle(3) # 2 for denser hatches
     bintext = ROOT.TLatex()
     #bintext.SetNDC()
     bintext.SetTextSize(0.025)  # 0.03
@@ -993,9 +1004,18 @@ def drawDataAndMC(h1, h2,
   #   pvtxt.Draw()
   # }
 
-    if lumi != None: CMS_lumi(canvas,lumi,True,False)
-    else:            CMS_lumi(canvas,"",True,False)
     setTDRStyle()
+    if leftMargin > 0.1:
+        if lumi != None: CMS_lumi(canvas,lumi,True,False)
+        else:            CMS_lumi(canvas,"",True,False)
+    else:
+        latCMS = ROOT.TLatex()
+        latCMS.SetNDC();
+        latCMS.SetTextFont(42)
+        latCMS.SetTextSize(0.045)
+        latCMS.DrawLatex(0.1, 0.95, '#bf{CMS} #it{Preliminary}')
+        if lumi != None: latCMS.DrawLatex(0.85, 0.95, '%s fb^{-1} (13 TeV)' % lumi)
+        else:            latCMS.DrawLatex(0.90, 0.95, '(13 TeV)' % lumi)
 
     if lowerPanelHeight:
         pad2.Draw()
@@ -1054,7 +1074,8 @@ def drawDataAndMC(h1, h2,
             h3ratio = h3.Clone("h3ratio")
             h3ratio.Divide(den_noerr)
             h3ratio.SetFillStyle(3144) # 1001 for solid, 3144 instead of 3244, to have more dense hatches
-            h3ratio.SetFillColor(ROOT.kRed-7)
+            #h3ratio.SetFillStyle(3001) # 
+            h3ratio.SetFillColor(ROOT.kRed-4)  # -7
 
         frame.Draw()        
         if invertRatio:
@@ -1227,6 +1248,7 @@ def drawTH1dataMCstack(h1, thestack,
     h1.GetYaxis().SetTitleOffset(0.5 if wideCanvas else 1.5)
     h1.GetYaxis().SetTitleSize(0.05)
     h1.GetYaxis().SetLabelSize(0.04)
+    h1.GetYaxis().SetTickSize(0.01)
     ymaxBackup = 0
     if setYAxisRangeFromUser: 
         ymaxBackup = ymax
@@ -1241,7 +1263,7 @@ def drawTH1dataMCstack(h1, thestack,
 
     vertline = ROOT.TLine(36,0,36,canvas.GetUymax())
     vertline.SetLineColor(ROOT.kBlack)
-    vertline.SetLineStyle(2)
+    vertline.SetLineStyle(3) # 2 larger hatches
     bintext = ROOT.TLatex()
     #bintext.SetNDC()
     bintext.SetTextSize(0.03)
@@ -1273,9 +1295,19 @@ def drawTH1dataMCstack(h1, thestack,
     if h1.GetBinContent(h1.GetMaximumBin()) > 1000000:
         reduceSize = True
         offset = 0.1
-    if wideCanvas: offset = 0.1
-    if lumi != None: CMS_lumi(canvas,lumi,True,False, reduceSize, offset)
-    else:            CMS_lumi(canvas,"",True,False)
+    if wideCanvas: 
+        offset = 0.1
+        latCMS = ROOT.TLatex()
+        latCMS.SetNDC();
+        latCMS.SetTextFont(42)
+        latCMS.SetTextSize(0.045)
+        latCMS.DrawLatex(0.1, 0.95, '#bf{CMS} #it{Preliminary}')
+        if lumi != None: latCMS.DrawLatex(0.85, 0.95, '%s fb^{-1} (13 TeV)' % lumi)
+        else:            latCMS.DrawLatex(0.90, 0.95, '(13 TeV)' % lumi)
+    else:    
+        if lumi != None: CMS_lumi(canvas,lumi,True,False, reduceSize, offset)
+        else:            CMS_lumi(canvas,"",True,False)    
+
     setTDRStyle()
 
     pad2.Draw();
@@ -1321,7 +1353,7 @@ def drawTH1dataMCstack(h1, thestack,
 
     line = ROOT.TF1("horiz_line","1",ratio.GetXaxis().GetBinLowEdge(1),ratio.GetXaxis().GetBinLowEdge(ratio.GetNbinsX()+1))
     line.SetLineColor(ROOT.kRed)
-    line.SetLineWidth(2)
+    line.SetLineWidth(1)  # 1, not 2, which is too wide for canvas with large width
     line.Draw("Lsame")
 
     leg2 = ROOT.TLegend(0.2,0.25,0.4,0.30)

--- a/WMass/python/plotter/w-helicity-13TeV/getCorrelationLine.py
+++ b/WMass/python/plotter/w-helicity-13TeV/getCorrelationLine.py
@@ -1,0 +1,148 @@
+import ROOT, os, datetime, re, operator, math
+from array import array
+ROOT.gROOT.SetBatch(True)
+
+from make_diff_xsec_cards import get_ieta_ipt_from_process_name
+from subMatrix import niceName
+from operator import itemgetter
+
+import utilities
+utilities = utilities.util()
+
+
+
+if __name__ == "__main__":
+
+    ROOT.gStyle.SetOptStat(0)
+    ROOT.gStyle.SetPaintTextFormat('.3f')
+
+    date = datetime.date.today().isoformat()
+
+    from optparse import OptionParser
+    parser = OptionParser(usage='%prog toys.root [options] ')
+    parser.add_option('-o','--outdir', dest='outdir',    default='', type='string', help='outdput directory to save the matrix')
+    parser.add_option('-p','--param', dest='param',    default='', type='string', help='parameter for which you want to show the correlation matrix. Must be a single object')
+    parser.add_option('-t','--type'  , dest='type'  ,    default='hessian', type='string', help='which type of input file: toys or hessian (default)')
+    parser.add_option('-m','--matrix', dest='matrix',    default='', type='string', help='matrix to be used (name is correlation_matrix_<matrix>)')
+    parser.add_option(     '--suffix', dest='suffix',    default='', type='string', help='suffix for the correlation matrix')
+    parser.add_option(     '--vertical-labels-X', dest='verticalLabelsX',    default=False, action='store_true', help='Set labels on X axis vertically (sometimes they overlap if rotated)')
+    parser.add_option(     '--title'  , dest='title',    default='', type='string', help='Title for matrix. Use 0 to remove title. By default, string passed to option -p is used')
+    parser.add_option('-n','--show-N' , dest='showN',    default=10, type=int, help='Show the N nuisances more correlated (in absolute value) with the parameter given with --param.')
+    (options, args) = parser.parse_args()
+
+    ROOT.TColor.CreateGradientColorTable(3,
+                                      array ("d", [0.00, 0.50, 1.00]),
+                                      ##array ("d", [1.00, 1.00, 0.00]),
+                                      ##array ("d", [0.70, 1.00, 0.34]),
+                                      ##array ("d", [0.00, 1.00, 0.82]),
+                                      array ("d", [0.00, 1.00, 1.00]),
+                                      array ("d", [0.34, 1.00, 0.65]),
+                                      array ("d", [0.82, 1.00, 0.00]),
+                                      255,  0.95)
+
+
+    if not options.type in ['toys', 'hessian']:
+        print 'the given type needs to be either "toys", "scans", or "hessian"!!'
+        sys.exit()
+
+    if not options.matrix:
+        print "Need to specify which matrix with option -m (e.g. -m 'channelpmaskedexpnorm')"
+        quit()
+
+    if not options.param:
+        print "Need to specify a parameter with option -p"
+        quit()
+
+    if len(args) < 1:
+        print 'You have to pass a root file with the fit result, either for toys or hessian'
+        sys.exit()
+
+    if options.outdir:
+        if not os.path.exists(options.outdir):
+            os.makedirs(options.outdir)
+        os.system('cp {pf} {od}'.format(pf='/afs/cern.ch/user/g/gpetrucc/php/index.php',od=options.outdir))
+
+    param = options.param
+    print "Will do POI with the following name: ",param
+    
+
+    corr = {}
+    sign = {}
+    index = 0
+
+    ### GET LIST OF PARAMETERS THAT MATCH THE SPECIFIED OPTION IN THE TOYFILE
+    if options.type == 'toys':
+        print "Toys not implemented, sorry. Only hessian for now"
+        quit()
+    elif options.type == 'hessian':
+        hessfile = ROOT.TFile(args[0],'read')
+        suffix = options.matrix
+        corrmatrix = hessfile.Get('correlation_matrix_'+suffix)
+        covmatrix  = hessfile.Get('covariance_matrix_'+suffix)
+        for ib in range(1+corrmatrix.GetNbinsX()+1):
+            if re.match(param, corrmatrix.GetXaxis().GetBinLabel(ib)):
+                ## store mean and rms into the dictionaries from before
+                ## also keep a list of the parameter names, for sorting
+                index = ib
+            
+    ## construct the covariances and the correlations in one go.
+    for bin in range(1+corrmatrix.GetNbinsX()+1):
+        label = corrmatrix.GetXaxis().GetBinLabel(bin)
+        if label == param: continue
+        # save absolute value, but keep track of the sign
+        bincontent = corrmatrix.GetBinContent(index,bin)
+        corr[label] = abs(bincontent)
+        sign[label] = -1 if bincontent < 0 else 1
+
+    #sorted_keys = sorted(corr.items(), key=itemgetter(1), reverse=True)
+    sorted_keys = sorted(corr.items(), key=itemgetter(1), reverse=True)
+    inum = 1
+    hist = ROOT.TH1D("hist","",options.showN,0,options.showN)
+    for key, val in sorted_keys:
+        print "%s   %s" % (key, val*sign[key])
+        hist.GetXaxis().SetBinLabel(inum,niceName(key))
+        hist.SetBinContent(inum,val*sign[key])
+        inum += 1        
+        if inum > options.showN: break
+
+    c = ROOT.TCanvas("c","",1200,800)
+    c.SetTickx(1)
+    c.SetTicky(1)
+
+    c.SetLeftMargin(0.12)
+    c.SetRightMargin(0.05)
+    c.SetBottomMargin(0.3)
+
+    if options.verticalLabelsX: hist.LabelsOption("v","X")
+    if hist.GetNbinsX() >= 20: hist.LabelsOption("v","X")
+
+    hist.SetTitle("parameter: " + param + "    channel: " + options.matrix.replace("channel",""))
+    if len(options.title): 
+        if options.title == "0":
+            hist.SetTitle("")
+        else:
+            hist.SetTitle(options.title)
+
+    hist.GetYaxis().SetTitle("Correlation")
+    hist.SetLineWidth(2)
+    hist.SetLineColor(ROOT.kGreen+2)
+    hist.SetFillColor(ROOT.kGreen+1)
+    hist.SetFillColorAlpha(ROOT.kGreen+1, 0.35)
+    #hist.SetFillStyle(3001)
+    hist.Draw("B")
+    miny = hist.GetBinContent(hist.GetMinimumBin())
+    maxy = hist.GetBinContent(hist.GetMaximumBin())
+    maxval = max(abs(miny),abs(maxy))
+    maxval *= 1.1
+    hist.GetYaxis().SetRangeUser(-maxval, maxval)
+    c.SetGridx(1)
+    c.SetGridy(1)
+    c.RedrawAxis("sameaxis")
+
+    if options.outdir:
+        for i in ['pdf', 'png']:
+            suff = '' if not options.suffix else '_'+options.suffix
+            c.SaveAs(options.outdir+'/corrLine{suff}_{pn}_{ch}.{i}'.format(suff=suff,i=i,pn=param, ch=options.matrix.replace("channel","")))
+        os.system('cp {pf} {od}'.format(pf='/afs/cern.ch/user/g/gpetrucc/php/index.php',od=options.outdir))
+
+

--- a/WMass/python/plotter/w-helicity-13TeV/make_diff_xsec_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_diff_xsec_cards.py
@@ -68,6 +68,7 @@ def getArrayBinNumberFromValue(binEdgesArray,val):
 def get_ieta_ipt_from_process_name(name):
     # name is something like  Wplus_el_ieta_1_ipt_14_Wplus_el_group_18
     # group might not be present depending on how signal bins are made
+    # also, we might have removed the second occurrence of Wplus_el_
     if not all([x in name for x in ["ieta","ipt"]]):
         print "Error in get_ieta_ipt_from_process_name(): 'ieta' or 'ipt' not found in %s. Exit" % name
         quit()

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -225,7 +225,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
                 scalings = [0.02 for b in borderBins[:-1]]  # 2%, common for both mu and ele
             else:
                 if isMu: 
-                    factor = 0.03 # it used to be 0.05 for Eta, but now it is splitted in charge-correlated and charge-uncorrelated part
+                    factor = 0.046 # it used to be 0.05 for Eta, but now it is splitted in charge-correlated and charge-uncorrelated part
                     scalings = [factor for b in borderBins[:-1]]
                 else:
                     scalings = []
@@ -233,11 +233,11 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
                         # slightly reducing these numbers, as now we have a part that is uncorrelated between charges
                         if   abs(etabins[borderBin]) < 0.21: scalings.append(0.01)  # 0.01
                         elif abs(etabins[borderBin]) < 0.41: scalings.append(0.01)  # 0.025
-                        elif abs(etabins[borderBin]) < 1.01: scalings.append(0.02)  # 0.04
-                        elif abs(etabins[borderBin]) < 1.51: scalings.append(0.04)  # 0.06
-                        elif abs(etabins[borderBin]) < 1.71: scalings.append(0.04)  # 0.06
+                        elif abs(etabins[borderBin]) < 1.01: scalings.append(0.03)  # 0.04
+                        elif abs(etabins[borderBin]) < 1.51: scalings.append(0.05)  # 0.06
+                        elif abs(etabins[borderBin]) < 1.71: scalings.append(0.05)  # 0.06
                         elif abs(etabins[borderBin]) < 2.00: scalings.append(0.02)  # 0.03
-                        else:                                scalings.append(0.04)  # 0.06
+                        else:                                scalings.append(0.05)  # 0.06
 
         ## for ptnorm these are now pT borders, not eta borders
         elif doPtNorm:

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsDiffXsec.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsDiffXsec.py
@@ -18,7 +18,8 @@ from make_diff_xsec_cards import getDiffXsecBinning
 from make_diff_xsec_cards import get_ieta_ipt_from_process_name
 
 #from mergeCardComponentsAbsY import getXsecs    # for now it is reimplemented here
-def getXsecs_etaPt(processes, systs, etaPtBins, infile, usePreFSR = True):  # in my case here, the histograms already have the cross section in pb, no need to divide by lumi
+# in my case here, the histograms already have the cross section in pb, no need to divide by lumi
+def getXsecs_etaPt(processes, systs, etaPtBins, infile, usePreFSR = True):  
 
     #print "Inside getXsecs_etaPt"
     # etaPtBins is a list of 4 things: Netabins, etabins, Nptbins,ptbins

--- a/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
@@ -485,7 +485,10 @@ if __name__ == "__main__":
         if isMuElComb:
             hDiffXsec.Scale(0.5)
             hDiffXsecErr.Scale(0.5)
+            hDiffXsecNorm.Scale(0.5)
+            hDiffXsecNormErr.Scale(0.5)
             hDiffXsec_1Deta.Scale(0.5)
+            hDiffXsecNorm_1Deta.Scale(0.5)
 
         hDiffXsecRelErr = hDiffXsecErr.Clone(hDiffXsecErr.GetName().replace('XsecErr','XsecRelErr'))
         hDiffXsecRelErr.Divide(hDiffXsec)
@@ -798,6 +801,8 @@ if __name__ == "__main__":
                 if isMuElComb:
                     hDiffXsec_exp.Scale(0.5)
                     hDiffXsec_1Deta_exp.Scale(0.5)
+                    hDiffXsecNorm_exp.Scale(0.5)
+                    hDiffXsecNorm_1Deta_exp.Scale(0.5)
 
 
                 # # now drawing a TH1 unrolling TH2

--- a/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     #parser.add_option(     '--no-group-POI', dest='noGroupPOI', default=False , action='store_true', help='Specify that _group_<N>_ is not present in name of POI')
     parser.add_option('-o','--outdir', dest='outdir', default='', type='string', help='output directory to save things')
     parser.add_option('-t','--toyfile', dest='toyfile', default='.', type='string', help='Root file with toys.')
-    parser.add_option('-c','--channel', dest='channel', default='', type='string', help='name of the channel (mu or el)')
+    parser.add_option('-c','--channel', dest='channel', default='', type='string', help='name of the channel (mu or el). For combination, select lep')
     parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='charges to run')
     parser.add_option('-s','--suffix', dest='suffix', default='', type='string', help='Suffix added to output dir (i.e, either to hessian or toys in the path)')
     parser.add_option('-f','--friend', dest='friend', default='', type='string', help='Root file with friend tree containing total xsec (it does not include the outliers). Tree name is assumed to be "toyFriend"')
@@ -69,9 +69,12 @@ if __name__ == "__main__":
     ROOT.TH1.StatOverflows(True)
     
     channel = options.channel
-    if channel not in ["el","mu"]:
-        print "Error: unknown channel %s (select 'el' or 'mu')" % channel
+    if channel not in ["el","mu","lep"]:
+        print "Error: unknown channel %s (select 'el' or 'mu' or 'lep')" % channel
         quit()
+
+    isMuElComb = False
+    if channel == "lep": isMuElComb = True
 
     charges = [x for x in options.charge.split(',')]
     for c in charges:
@@ -197,9 +200,9 @@ if __name__ == "__main__":
     #     print "%d) %.3f +/- %.3f" % (i,htmpAsym.GetBinContent(i),htmpAsym.GetBinError(i))
     # print ">>> END OF TEST"
 
-    lepton = "electron" if channel == "el" else "muon"
-    Wchannel = "W #rightarrow %s#nu" % ("e" if channel == "el" else "#mu")
-    ptRangeText = "p_{{T}}^{{{l}}} #in [{ptmin:3g}, {ptmax:3g}] GeV".format(l="e" if channel == "el" else "#mu", 
+    lepton = "electron" if channel == "el" else "muon" if channel == "mu" else "lepton"
+    Wchannel = "W #rightarrow %s#nu" % ("e" if channel == "el" else "#mu" if channel == "mu" else "l")
+    ptRangeText = "p_{{T}}^{{{l}}} #in [{ptmin:3g}, {ptmax:3g}] GeV".format(l="e" if channel == "el" else "#mu" if channel == "mu" else "l", 
                                                                             ptmin=genBins.ptBins[firstPtSignalBin], ptmax=genBins.ptBins[-1])
     labelRatioDataExp = "exp./obs.::0.8,1.2" if options.invertRatio else "obs./exp.::0.8,1.2"
 
@@ -236,15 +239,15 @@ if __name__ == "__main__":
             binCount += 1
 
             if options.hessian: 
-                #central = utilities.getDiffXsecAsymmetryFromHessian(channel,ieta-1,ipt-1,options.toyfile)
-                central = utilities.getDiffXsecAsymmetryFromHessianFast(channel,ieta-1,ipt-1,
+                #central = utilities.getDiffXsecAsymmetryFromHessian(ieta-1,ipt-1,options.toyfile)
+                central = utilities.getDiffXsecAsymmetryFromHessianFast(ieta-1,ipt-1,
                                                                         nHistBins=2000, minHist=0., maxHist=1.0, tree=tree)
-                error = utilities.getDiffXsecAsymmetryFromHessianFast(channel,ieta-1,ipt-1,
+                error = utilities.getDiffXsecAsymmetryFromHessianFast(ieta-1,ipt-1,
                                                                       nHistBins=2000, minHist=0., maxHist=1.0, tree=tree, getErr=True)
             else:                
-                central,up,down = utilities.getDiffXsecAsymmetryFromToysFast(channel,ieta-1,ipt-1,
+                central,up,down = utilities.getDiffXsecAsymmetryFromToysFast(ieta-1,ipt-1,
                                                                              nHistBins=2000, minHist=0., maxHist=1.0, tree=tree)
-                #central,up,down = utilities.getDiffXsecAsymmetryFromToys(channel,ieta-1,ipt-1,options.toyfile)
+                #central,up,down = utilities.getDiffXsecAsymmetryFromToys(ieta-1,ipt-1,options.toyfile)
                 error = up - central
             hChAsymm.SetBinError(ieta,ipt,error)         
             hChAsymmErr.SetBinContent(ieta,ipt,error)
@@ -252,8 +255,8 @@ if __name__ == "__main__":
 
     for ieta in range(1,genBins.Neta+1):            
         if etaBinIsBackground[ieta-1]: continue
-        central = utilities.getDiffXsecAsymmetry1DFromHessianFast(channel,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=tree)
-        error   = utilities.getDiffXsecAsymmetry1DFromHessianFast(channel,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=tree, getErr=True)
+        central = utilities.getDiffXsecAsymmetry1DFromHessianFast(ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=tree)
+        error   = utilities.getDiffXsecAsymmetry1DFromHessianFast(ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=tree, getErr=True)
         hChAsymm1Deta.SetBinContent(ieta,central)
         hChAsymm1Deta.SetBinError(ieta,error)
 
@@ -308,10 +311,10 @@ if __name__ == "__main__":
                         "ForceTitle",outname,1,1,False,False,False,1, canvasSize="700,625",leftMargin=0.14,rightMargin=0.22,passCanvas=canvas,palette=options.palette)
 
 
-    #additionalText = "W #rightarrow {lep}#nu::0.2,0.5,0.4,0.6".format(lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
-    #additionalText = "W #rightarrow {lep}#nu;{pttext}::0.2,0.6,0.5,0.7".format(lep="e" if channel == "el" else "#mu", pttext=ptRangeText) # pass x1,y1,x2,y2
+    #additionalText = "W #rightarrow {lep}#nu::0.2,0.5,0.4,0.6".format(lep="e" if channel == "el" else "#mu" if channel == "mu" else "l") # pass x1,y1,x2,y2
+    #additionalText = "W #rightarrow {lep}#nu;{pttext}::0.2,0.6,0.5,0.7".format(lep="e" if channel == "el" else "#mu" if channel == "mu" else "l", pttext=ptRangeText) # pass x1,y1,x2,y2
     texCoord = "0.2,0.65"
-    additionalText = "W #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(lep="e" if channel == "el" else "#mu", 
+    additionalText = "W #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(lep="e" if channel == "el" else "#mu" if channel == "mu" else "l", 
                                                                                pttext=ptRangeText,
                                                                                txc=texCoord)
     legendCoords = "0.2,0.4,0.75,0.85"
@@ -374,8 +377,8 @@ if __name__ == "__main__":
                                     "cross section: {Wch}".format(Wch=Wchannel.replace('W','W{chs}'.format(chs=chargeSign))),
                                     genBins.Neta, array('d',genBins.etaBins))
 
-        #utilities.getPDFbandFromXsec(   hDiffXsecPDF,    charge, xsecChargefile[charge], channel, genBins.Neta, genBins.Npt, firstPtBin=firstPtSignalBin)
-        utilities.getPDFbandFromXsecEta(hDiffXsecPDF_1D, charge, xsecChargefile[charge], channel, genBins.Neta, genBins.Npt, firstPtBin=firstPtSignalBin)
+        #utilities.getPDFbandFromXsec(   hDiffXsecPDF,    charge, xsecChargefile[charge], genBins.Neta, genBins.Npt, firstPtBin=firstPtSignalBin)
+        utilities.getPDFbandFromXsecEta(hDiffXsecPDF_1D, charge, xsecChargefile[charge], genBins.Neta, genBins.Npt, firstPtBin=firstPtSignalBin)
 
 
         #nbins = genBins.Neta * (genBins.Npt - nPtBinsBkg)
@@ -389,7 +392,7 @@ if __name__ == "__main__":
             if options.friend != "":
                 denExpression = "totxsec_" + charge
             else:
-                denExpression = utilities.getDenExpressionForNormDiffXsec(channel, charge, genBins.Neta,genBins.Npt)
+                denExpression = utilities.getDenExpressionForNormDiffXsec(charge, genBins.Neta,genBins.Npt)
 
         central = 0
         error   = 0
@@ -405,12 +408,12 @@ if __name__ == "__main__":
 
                 # signal strength
                 if options.hessian:                    
-                    central = utilities.getSignalStrengthFromHessianFast(channel,charge,ieta-1,ipt-1,
+                    central = utilities.getSignalStrengthFromHessianFast(charge,ieta-1,ipt-1,
                                                                          nHistBins=100, minHist=0.5, maxHist=1.5, tree=tree)                    
-                    error = utilities.getSignalStrengthFromHessianFast(channel,charge,ieta-1,ipt-1,
+                    error = utilities.getSignalStrengthFromHessianFast(charge,ieta-1,ipt-1,
                                                                        nHistBins=200, minHist=0.0, maxHist=1., tree=tree, getErr=True)                    
                 else:
-                    central,up,down = utilities.getSignalStrengthFromToysFast(channel,charge,ieta-1,ipt-1, 
+                    central,up,down = utilities.getSignalStrengthFromToysFast(charge,ieta-1,ipt-1, 
                                                                               nHistBins=200, minHist=0.5, maxHist=1.5, tree=tree)
                     error = up - central
                 hMu.SetBinContent(ieta,ipt,central)        
@@ -419,12 +422,12 @@ if __name__ == "__main__":
                 
                 # normalized cross section
                 if options.hessian:                    
-                    central = utilities.getNormalizedDiffXsecFromHessianFast(channel,charge,ieta-1,ipt-1,
+                    central = utilities.getNormalizedDiffXsecFromHessianFast(charge,ieta-1,ipt-1,
                                                                              nHistBins=2000, minHist=0., maxHist=200., tree=tree)                    
-                    error = utilities.getNormalizedDiffXsecFromHessianFast(channel,charge,ieta-1,ipt-1,
+                    error = utilities.getNormalizedDiffXsecFromHessianFast(charge,ieta-1,ipt-1,
                                                                            nHistBins=2000, minHist=0., maxHist=10., tree=tree, getErr=True)                    
                 else:
-                    central,up,down = utilities.getNormalizedDiffXsecFromToysFast(channel,charge,ieta-1,ipt-1,
+                    central,up,down = utilities.getNormalizedDiffXsecFromToysFast(charge,ieta-1,ipt-1,
                                                                                   denExpression, nHistBins=1000, minHist=0., maxHist=0.1, tree=tree)
                     error = up - central
                 hDiffXsecNorm.SetBinContent(ieta,ipt,central)        
@@ -433,12 +436,12 @@ if __name__ == "__main__":
                 
                 # unnormalized cross section
                 if options.hessian:
-                    central = utilities.getDiffXsecFromHessianFast(channel,charge,ieta-1,ipt-1,
+                    central = utilities.getDiffXsecFromHessianFast(charge,ieta-1,ipt-1,
                                                                    nHistBins=2000, minHist=0., maxHist=200., tree=tree)                    
-                    error = utilities.getDiffXsecFromHessianFast(channel,charge,ieta-1,ipt-1,
+                    error = utilities.getDiffXsecFromHessianFast(charge,ieta-1,ipt-1,
                                                                  nHistBins=2000, minHist=0., maxHist=200., tree=tree, getErr=True)                    
                 else:                
-                    central,up,down = utilities.getDiffXsecFromToysFast(channel,charge,ieta-1,ipt-1,
+                    central,up,down = utilities.getDiffXsecFromToysFast(charge,ieta-1,ipt-1,
                                                                         nHistBins=2000, minHist=0., maxHist=200., tree=tree)
                     error = up - central
                 hDiffXsec.SetBinContent(ieta,ipt,central)        
@@ -447,13 +450,13 @@ if __name__ == "__main__":
                 
         for ieta in range(1,genBins.Neta+1):
             if etaBinIsBackground[ieta-1]: continue
-            central = utilities.getDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=tree)
-            error   = utilities.getDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=tree, getErr=True)
+            central = utilities.getDiffXsec1DFromHessianFast(charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=tree)
+            error   = utilities.getDiffXsec1DFromHessianFast(charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=tree, getErr=True)
             hDiffXsec_1Deta.SetBinContent(ieta, central)
             hDiffXsec_1Deta.SetBinError(ieta, error)
 
-            central = utilities.getNormalizedDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=tree)
-            error   = utilities.getNormalizedDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=tree, getErr=True)
+            central = utilities.getNormalizedDiffXsec1DFromHessianFast(charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=tree)
+            error   = utilities.getNormalizedDiffXsec1DFromHessianFast(charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=tree, getErr=True)
             hDiffXsecNorm_1Deta.SetBinContent(ieta, central)
             hDiffXsecNorm_1Deta.SetBinError(ieta, error)
 
@@ -478,6 +481,11 @@ if __name__ == "__main__":
             hDiffXsec_1Deta.Scale(scaleFactor)        
             hDiffXsecPDF.Scale(scaleFactor)
             hDiffXsecPDF_1D.Scale(scaleFactor)
+
+        if isMuElComb:
+            hDiffXsec.Scale(0.5)
+            hDiffXsecErr.Scale(0.5)
+            hDiffXsec_1Deta.Scale(0.5)
 
         hDiffXsecRelErr = hDiffXsecErr.Clone(hDiffXsecErr.GetName().replace('XsecErr','XsecRelErr'))
         hDiffXsecRelErr.Divide(hDiffXsec)
@@ -573,7 +581,8 @@ if __name__ == "__main__":
 
         # with only W -> munu, coordinates can be 0.45,0.8,0.65,0.9 with TPaveText
         texCoord = "0.45,0.85" if charge == "plus" else "0.45,0.5"
-        additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(chs=" "+chargeSign,lep="e" if channel == "el" else "#mu",
+        additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(chs=" "+chargeSign,
+                                                                                             lep="e" if channel == "el" else "#mu" if channel == "mu" else "l",
                                                                                              pttext=ptRangeText,
                                                                                              txc=texCoord) 
         legendCoords = "0.2,0.4,0.75,0.85" if charge == "plus" else "0.2,0.4,0.4,0.5"
@@ -604,7 +613,9 @@ if __name__ == "__main__":
 
         xaxisTitle = "template global bin"
         vertLinesArg = ""
-        additionalText = "W^{{{chs}}} #rightarrow {lep}#nu::0.8,0.84,0.9,0.9".format(chs=" "+chargeSign, lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
+        # pass x1,y1,x2,y2
+        additionalText = "W^{{{chs}}} #rightarrow {lep}#nu::0.8,0.84,0.9,0.9".format(chs=" "+chargeSign, 
+                                                                                     lep="e" if channel == "el" else "#mu" if channel == "mu" else "l") 
 
         h1D_chargeAsym = {}
         h1D_pmaskedexp = {}
@@ -648,7 +659,7 @@ if __name__ == "__main__":
 
                 xaxisTitle = xaxisTitle.replace("cross section", "charge asymmetry")
                 additionalTextBackup = additionalText
-                additionalText = "W #rightarrow {lep}#nu::0.8,0.84,0.9,0.9".format(lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
+                additionalText = "W #rightarrow {lep}#nu::0.8,0.84,0.9,0.9".format(lep="e" if channel == "el" else "#mu" if channel == "mu" else "l") # pass x1,y1,x2,y2
 
                 h1D_chargeAsym[unrollAlongEta] = getTH1fromTH2(hChAsymm, h2Derr=None, unrollAlongX=unrollAlongEta)        
                 drawSingleTH1(h1D_chargeAsym[unrollAlongEta], xaxisTitle,"charge asymmetry::0.0,1.0",
@@ -722,10 +733,10 @@ if __name__ == "__main__":
                         
                         if icharge == 2:
                             # charge asymmetry
-                            central = utilities.getDiffXsecAsymmetryFromHessianFast(channel,ieta-1,ipt-1,
+                            central = utilities.getDiffXsecAsymmetryFromHessianFast(ieta-1,ipt-1,
                                                                                    nHistBins=2000, minHist=0., maxHist=1., 
                                                                                    tree=treeexp, getGen=getExpFromGen)         
-                            error = utilities.getDiffXsecAsymmetryFromHessianFast(channel,ieta-1,ipt-1,
+                            error = utilities.getDiffXsecAsymmetryFromHessianFast(ieta-1,ipt-1,
                                                                                  nHistBins=2000, minHist=0., maxHist=1., 
                                                                                  tree=treeexp, getErr=True)                    
                             
@@ -734,18 +745,18 @@ if __name__ == "__main__":
 
 
                         # normalized cross section
-                        central = utilities.getNormalizedDiffXsecFromHessianFast(channel,charge,ieta-1,ipt-1,
+                        central = utilities.getNormalizedDiffXsecFromHessianFast(charge,ieta-1,ipt-1,
                                                                                  nHistBins=2000, minHist=0., maxHist=200., tree=treeexp, getGen=getExpFromGen)         
-                        error = utilities.getNormalizedDiffXsecFromHessianFast(channel,charge,ieta-1,ipt-1,
+                        error = utilities.getNormalizedDiffXsecFromHessianFast(charge,ieta-1,ipt-1,
                                                                                nHistBins=2000, minHist=0., maxHist=200., tree=treeexp, getErr=True)                    
 
                         hDiffXsecNorm_exp.SetBinContent(ieta,ipt,central)        
                         hDiffXsecNorm_exp.SetBinError(ieta,ipt,error)         
 
                         # unnormalized cross section
-                        central = utilities.getDiffXsecFromHessianFast(channel,charge,ieta-1,ipt-1,
+                        central = utilities.getDiffXsecFromHessianFast(charge,ieta-1,ipt-1,
                                                                        nHistBins=2000, minHist=0., maxHist=200., tree=treeexp, getGen=getExpFromGen)                    
-                        error = utilities.getDiffXsecFromHessianFast(channel,charge,ieta-1,ipt-1,
+                        error = utilities.getDiffXsecFromHessianFast(charge,ieta-1,ipt-1,
                                                                      nHistBins=2000, minHist=0., maxHist=200., tree=treeexp, getErr=True)                    
                         hDiffXsec_exp.SetBinContent(ieta,ipt,central)        
                         hDiffXsec_exp.SetBinError(ieta,ipt,error)         
@@ -756,18 +767,18 @@ if __name__ == "__main__":
                     if etaBinIsBackground[ieta-1]: continue
 
                     if icharge == 2:
-                        central = utilities.getDiffXsecAsymmetry1DFromHessianFast(channel,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=treeexp)
-                        error   = utilities.getDiffXsecAsymmetry1DFromHessianFast(channel,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=treeexp, getErr=True)
+                        central = utilities.getDiffXsecAsymmetry1DFromHessianFast(ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=treeexp)
+                        error   = utilities.getDiffXsecAsymmetry1DFromHessianFast(ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1.0, tree=treeexp, getErr=True)
                         hChAsymm1Deta_exp.SetBinContent(ieta,central)
                         hChAsymm1Deta_exp.SetBinError(ieta,error)
         
-                    central = utilities.getDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=treeexp)
-                    error   = utilities.getDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=treeexp, getErr=True)
+                    central = utilities.getDiffXsec1DFromHessianFast(charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=treeexp)
+                    error   = utilities.getDiffXsec1DFromHessianFast(charge,ieta-1,isIeta=True,nHistBins=5000, minHist=0., maxHist=5000., tree=treeexp, getErr=True)
                     hDiffXsec_1Deta_exp.SetBinContent(ieta, central)
                     hDiffXsec_1Deta_exp.SetBinError(ieta, error)
 
-                    central = utilities.getNormalizedDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=treeexp)
-                    error   = utilities.getNormalizedDiffXsec1DFromHessianFast(channel,charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=treeexp, getErr=True)
+                    central = utilities.getNormalizedDiffXsec1DFromHessianFast(charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=treeexp)
+                    error   = utilities.getNormalizedDiffXsec1DFromHessianFast(charge,ieta-1,isIeta=True,nHistBins=1000, minHist=0., maxHist=1., tree=treeexp, getErr=True)
                     hDiffXsecNorm_1Deta_exp.SetBinContent(ieta, central)
                     hDiffXsecNorm_1Deta_exp.SetBinError(ieta, error)
 
@@ -783,6 +794,11 @@ if __name__ == "__main__":
                     scaleFactor = 1./options.lumiNorm
                     hDiffXsec_exp.Scale(scaleFactor)
                     hDiffXsec_1Deta_exp.Scale(scaleFactor)
+
+                if isMuElComb:
+                    hDiffXsec_exp.Scale(0.5)
+                    hDiffXsec_1Deta_exp.Scale(0.5)
+
 
                 # # now drawing a TH1 unrolling TH2
 
@@ -826,7 +842,8 @@ if __name__ == "__main__":
                     if icharge == 2:
                         
                         additionalTextBackup = additionalText
-                        additionalText = "W #rightarrow {lep}#nu::0.8,0.84,0.9,0.9".format(lep="e" if channel == "el" else "#mu") # pass x1,y1,x2,y2
+                        # pass x1,y1,x2,y2
+                        additionalText = "W #rightarrow {lep}#nu::0.8,0.84,0.9,0.9".format(lep="e" if channel == "el" else "#mu" if channel == "mu" else "l") 
                         
                         labelRatioDataExp_asym = labelRatioDataExp
                         labelRatioDataExp_asym = str(labelRatioDataExp.split("::")[0]) + "::0.8,1.5"
@@ -844,10 +861,11 @@ if __name__ == "__main__":
                 ###############
                 xaxisTitle = 'gen %s |#eta|' % lepton
                 additionalTextBackup = additionalText
-                #additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::0.45,0.8,0.75,0.9".format(chs=" "+chargeSign,lep="e" if channel == "el" else "#mu",
+                #additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::0.45,0.8,0.75,0.9".format(chs=" "+chargeSign,lep="e" if channel == "el" else "#mu" if channel == "mu" else "l",
                 #                                                                                       pttext=ptRangeText) # pass x1,y1,x2,y2
                 texCoord = "0.45,0.85" if charge == "plus" else "0.45,0.5"
-                additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(chs=" "+chargeSign,lep="e" if channel == "el" else "#mu",
+                additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(chs=" "+chargeSign,
+                                                                                                     lep="e" if channel == "el" else "#mu" if channel == "mu" else "l",
                                                                                                      pttext=ptRangeText,
                                                                                                      txc=texCoord) 
                 legendCoords = "0.2,0.4,0.75,0.85" if charge == "plus" else "0.2,0.4,0.4,0.5" # does not include space for PDF line (created automatically inside)
@@ -871,7 +889,7 @@ if __name__ == "__main__":
                     additionalTextBackup = additionalText
                     #additionalText = "W #rightarrow {lep}#nu;{pttext}::0.2,0.6,0.5,0.7".format(lep="e" if channel == "el" else "#mu",pttext=ptRangeText) # pass x1,y1,x2,y2
                     texCoord = "0.2,0.68"
-                    additionalText = "W #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(lep="e" if channel == "el" else "#mu", 
+                    additionalText = "W #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(lep="e" if channel == "el" else "#mu" if channel == "mu" else "l", 
                                                                                                pttext=ptRangeText,
                                                                                                txc=texCoord)
                     legendCoords = "0.2,0.4,0.75,0.85"

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -70,7 +70,7 @@ class valueClass:
 
     def graphStyle(self):
         #fillstyles = {'left': 3017, 'right': 3018, 'long': 3016, 'unpolarized': 3020}
-        fillstyles = {'left': 3002, 'right': 3144, 'long': 3016, 'unpolarized': 3020}
+        fillstyles = {'left': 3244, 'right': 3001, 'long': 3016, 'unpolarized': 3002}
         if hasattr(self,'graph'):
             self.graph.SetLineColor(self.color)
             self.graph.SetFillColor(self.color)

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -69,7 +69,8 @@ class valueClass:
         self.mg.Add(self.graph_fit_rel)
 
     def graphStyle(self):
-        fillstyles = {'left': 3017, 'right': 3018, 'long': 3016, 'unpolarized': 3020}
+        #fillstyles = {'left': 3017, 'right': 3018, 'long': 3016, 'unpolarized': 3020}
+        fillstyles = {'left': 3002, 'right': 3144, 'long': 3016, 'unpolarized': 3020}
         if hasattr(self,'graph'):
             self.graph.SetLineColor(self.color)
             self.graph.SetFillColor(self.color)
@@ -344,6 +345,7 @@ if __name__ == "__main__":
     parser.add_option(      '--hessfile'    , dest='hessfile' , default=''            , type='string', help='file that contains the hessian errors in a dictionary')
     parser.add_option(      '--xsecfiles'    , dest='xsecfiles' , default=None          , type='string', help='files that contains the expected x sections with variations (one per charge,comma separated in the same order of the charges) ')
     parser.add_option('-C', '--charge'      , dest='charge'   , default='plus,minus'  , type='string', help='process given charge. default is both')
+    parser.add_option('-c', '--channel'     , dest='channel'   , default='mu'  , type='string', help='Channel (mu|el)')
     parser.add_option('-o', '--outdir'      , dest='outdir'   , default='.'           , type='string', help='outdput directory to save the plots')
     parser.add_option(      '--suffix'      , dest='suffix'   , default=''            , type='string', help='suffix for the correlation matrix')
     parser.add_option('-n', '--normxsec'    , dest='normxsec' , default=False         , action='store_true',   help='if given, plot the differential xsecs normalized to the total xsec')
@@ -378,7 +380,8 @@ if __name__ == "__main__":
         print 'ERROR: none of your types is supported. specify either "toys", "scans", or "hessian"'
         sys.exit()
 
-    channel = 'mu' if any(re.match('.*_mu_Ybin_.*', param) for param in valuesAndErrors.keys()) else 'el'
+    #channel = 'mu' if any(re.match('.*_mu_Ybin_.*', param) for param in valuesAndErrors.keys()) else 'el'
+    channel = options.channel
     print "From the list of parameters it seems that you are plotting results for channel ",channel
 
     ybinfile = open(ybinfile, 'r')

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -30,8 +30,8 @@ class valueClass:
         if 'asymmetry' in name:
             self.charge = self.ch = ''
 
-        self.color  = ROOT.kBlue-9 if self.isleft else ROOT.kOrange-4 if self.isright else ROOT.kGray+1
-        self.colorf = ROOT.kBlue-3 if self.isleft else ROOT.kOrange-3 if self.isright else ROOT.kGray+3
+        self.color  = ROOT.kBlue-7 if self.isleft else ROOT.kOrange+7 if self.isright else ROOT.kGray+1
+        self.colorf = ROOT.kBlue-4 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
         if self.isunpolarized: 
             self.color = ROOT.kSpring-6
             self.colorf = ROOT.kSpring-7
@@ -70,7 +70,7 @@ class valueClass:
 
     def graphStyle(self):
         #fillstyles = {'left': 3017, 'right': 3018, 'long': 3016, 'unpolarized': 3020}
-        fillstyles = {'left': 3244, 'right': 3001, 'long': 3016, 'unpolarized': 3002}
+        fillstyles = {'left': 3244, 'right': 3001, 'long': 3016, 'unpolarized': 3001}
         if hasattr(self,'graph'):
             self.graph.SetLineColor(self.color)
             self.graph.SetFillColor(self.color)
@@ -120,7 +120,7 @@ def plotValues(values,charge,channel,options):
         ## the four graphs exist now. now starting to draw them
         ## ===========================================================
         if sum(hasattr(values[pol],'graph') and hasattr(values[pol],'graph_fit') for pol in ['left','right','long'])==3:
-            leg = ROOT.TLegend(0.40, 0.80, 0.90, 0.90)
+            leg = ROOT.TLegend(0.43, 0.78, 0.93, 0.88)
             leg.SetFillStyle(0)
             leg.SetBorderSize(0)
             leg.AddEntry(values['left'] .graph     , 'W_{{L}} ({mc})'.format(mc=REFMC) , 'f')
@@ -171,10 +171,12 @@ def plotValues(values,charge,channel,options):
             pad2.SetTopMargin(0.65)
             pad2.SetRightMargin(0.04)
             pad2.SetLeftMargin(0.17)
+            pad2.SetBottomMargin(0.14)
             pad2.SetFillColor(0)
             pad2.SetGridy(0)
             pad2.SetFillStyle(0)
             pad2.SetTicky(1)
+            pad2.SetTickx(1)
 
             pad2.Draw()
             pad2.cd()
@@ -206,14 +208,14 @@ def plotValues(values,charge,channel,options):
                     values[hel].mg.GetYaxis().SetLabelSize(0.04)
                     values[hel].mg.GetYaxis().SetTitle(yaxtitle)
                     values[hel].mg.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
-                    values[hel].mg.GetYaxis().SetNdivisions(510)
+                    values[hel].mg.GetYaxis().SetNdivisions(4)
                     values[hel].mg.GetYaxis().CenterTitle()
             line.Draw("Lsame");
             c2.cd()
-            lat.DrawLatex(0.16, 0.92, '#bf{CMS} #it{Preliminary}')
-            lat.DrawLatex(0.62, 0.92, '35.9 fb^{-1} (13 TeV)')
+            lat.DrawLatex(0.16, 0.94, '#bf{CMS} #it{Preliminary}')
+            lat.DrawLatex(0.62, 0.94, '35.9 fb^{-1} (13 TeV)')
             lat.DrawLatex(0.20, 0.80,  'W^{{{ch}}} #rightarrow {lep}^{{{ch}}}{nu}'.format(ch=ch,lep="#mu" if channel == "mu" else "e",nu="#bar{#nu}" if charge=='minus' else "#nu"))
-            lat.DrawLatex(0.90, 0.03, '|Y_{W}|')
+            lat.DrawLatex(0.88, 0.03, '|Y_{W}|')
         for ext in ['png', 'pdf']:
             c2.SaveAs('{od}/genAbsY{norm}_pdfs_{ch}{suffix}_{t}.{ext}'.format(od=options.outdir, norm=normstr, ch=charge, suffix=options.suffix, ext=ext,t=options.type))
 
@@ -222,7 +224,7 @@ def plotUnpolarizedValues(values,charge,channel,options):
         c2 = ROOT.TCanvas('foo','', 800, 800)
         c2.GetPad(0).SetTopMargin(0.09)
         c2.GetPad(0).SetBottomMargin(0.35)
-        c2.GetPad(0).SetLeftMargin(0.15)
+        c2.GetPad(0).SetLeftMargin(0.17)
         c2.GetPad(0).SetRightMargin(0.04)
         c2.GetPad(0).SetTickx(1)
         c2.GetPad(0).SetTicky(1)
@@ -247,7 +249,7 @@ def plotUnpolarizedValues(values,charge,channel,options):
             mg.Add(values.graph_fit)
             mg.Draw('Pa')
             mg.GetXaxis().SetRangeUser(0., options.maxRapidity) # max would be 6.
-            mg.GetXaxis().SetTitle('|Y_{W}|')
+            mg.GetXaxis().SetTitle('')
             mg.GetXaxis().SetTitleOffset(5.5)
             mg.GetXaxis().SetLabelSize(0)
             if charge=='asymmetry':
@@ -264,9 +266,9 @@ def plotUnpolarizedValues(values,charge,channel,options):
                 else:
                     mg.GetYaxis().SetRangeUser(-0.05 if normstr=='A0' else -1,0.4 if normstr=='A0' else 2)
                     mg.GetYaxis().SetTitle('|A_{0}|' if normstr=='A0' else '|A_{4}|')
-            mg.GetYaxis().SetTitleSize(0.06)
+            mg.GetYaxis().SetTitleSize(0.04)
             mg.GetYaxis().SetLabelSize(0.04)
-            mg.GetYaxis().SetTitleOffset(1.)
+            mg.GetYaxis().SetTitleOffset(2.0)
      
             leg = ROOT.TLegend(legx1, legy1, legx2, legy2)
             leg.SetFillStyle(0)
@@ -275,9 +277,10 @@ def plotUnpolarizedValues(values,charge,channel,options):
             leg.AddEntry(values.graph     , REFMC, 'f')
 
             leg.Draw('same')
-            lat.DrawLatex(0.16, 0.92, '#bf{CMS} #it{Preliminary}')
-            lat.DrawLatex(0.62, 0.92, '35.9 fb^{-1} (13 TeV)')
-            lat.DrawLatex(0.20, 0.50,  'W^{{{ch}}} #rightarrow {lep}^{{{ch}}}{nu}'.format(ch=ch,lep="#mu" if channel == "mu" else "e",nu="#bar{#nu}" if charge=='minus' else "#nu"))
+            lat.DrawLatex(0.16, 0.94, '#bf{CMS} #it{Preliminary}')
+            lat.DrawLatex(0.62, 0.94, '35.9 fb^{-1} (13 TeV)')
+            lat.DrawLatex(0.20, 0.40,  'W^{{{ch}}} #rightarrow {lep}^{{{ch}}}{nu}'.format(ch=ch,lep="#mu" if channel == "mu" else "e",nu="#bar{#nu}" if charge=='minus' else "#nu"))
+            lat.DrawLatex(0.88, 0.03, '|Y_{W}|')
      
 
         ## now make the relative error plot:
@@ -287,10 +290,12 @@ def plotUnpolarizedValues(values,charge,channel,options):
             pad2 = ROOT.TPad("pad2","pad2",0,0.,1,0.9)
             pad2.SetTopMargin(0.65)
             pad2.SetRightMargin(0.04)
-            pad2.SetLeftMargin(0.15)
+            pad2.SetLeftMargin(0.17)
+            pad2.SetBottomMargin(0.14)
             pad2.SetFillColor(0)
             pad2.SetGridy(0)
             pad2.SetFillStyle(0)
+            pad2.SetTickx(1)
             pad2.SetTicky(1)
 
             pad2.Draw()
@@ -309,14 +314,13 @@ def plotUnpolarizedValues(values,charge,channel,options):
 
             values.mg.Draw('Pa')
             ## x axis fiddling
-            values.mg.GetXaxis().SetTitle('|Y_{W}|')
-            values.mg.GetXaxis().SetTitleOffset(1.)
+            values.mg.GetXaxis().SetTitle('')
             values.mg.GetXaxis().SetRangeUser(0., options.maxRapidity)
-            values.mg.GetXaxis().SetTitleSize(0.1)
+            values.mg.GetXaxis().SetTitleSize(0.14)
             values.mg.GetXaxis().SetLabelSize(0.04)
             ## y axis fiddling
-            values.mg.GetYaxis().SetTitleOffset(1.2)
-            values.mg.GetYaxis().SetTitleSize(0.06)
+            values.mg.GetYaxis().SetTitleOffset(1.8)
+            values.mg.GetYaxis().SetTitleSize(0.04)
             values.mg.GetYaxis().SetLabelSize(0.04)
             values.mg.GetYaxis().SetTitle(yaxtitle)
             values.mg.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])

--- a/WMass/python/plotter/w-helicity-13TeV/postFitPlots_xsec.py
+++ b/WMass/python/plotter/w-helicity-13TeV/postFitPlots_xsec.py
@@ -351,8 +351,10 @@ if __name__ == "__main__":
             suffix = prepost+options.suffix
             # doing signal
             canv = ROOT.TCanvas()
-            chfl = '{ch}_{fl}'.format(ch=charge,fl=channel)
-            keyplot = 'W'+chfl+'_'+prepost
+            #chfl = '{ch}_{fl}'.format(ch=charge,fl=channel)
+            chfl = '{ch}_lep'.format(ch=charge)
+            #keyplot = 'W'+chfl+'_'+prepost
+            keyplot = prepost
 
             print "-"*30
             print "doing " + prepost
@@ -444,7 +446,7 @@ if __name__ == "__main__":
      
      
             # do backgrounds now
-            procs=["W{chfl}_outliers_W{chfl}".format(chfl=chfl), "Flips","Z","Top","DiBosons","TauDecaysW","data_fakes","obs"]
+            procs=["W{chfl}_outliers".format(chfl=chfl), "Flips","Z","Top","DiBosons","TauDecaysW","data_fakes","obs"]
             titleOut = 'W{chs}: |#eta| > {etamax}; p_{{T}} #notin [{ptmin:3g},{ptmax:.3g})'.format(etamax=genBins.etaBins[-1],
                                                                                                     ptmin=genBins.ptBins[0],
                                                                                                     ptmax=genBins.ptBins[-1],

--- a/WMass/python/plotter/w-helicity-13TeV/subMatrix.py
+++ b/WMass/python/plotter/w-helicity-13TeV/subMatrix.py
@@ -70,17 +70,18 @@ def niceName(name):
         else:
             return name
       
-    elif re.match( "Fakes(Eta|PtNorm|PtSlope)Uncorrelated.*",name):
+    elif re.match( "Fakes(Eta|EtaCharge|PtNorm|PtSlope)Uncorrelated.*",name):
         num = re.findall(r'\d+', name) # get number
         pfx = name.split(num[0])[1]    # split on number and read what's on the right
         leptonCharge = ""
         if len(pfx):
             leptonCharge = "{lep}{chs}".format(lep="#mu" if "mu" in pfx else "e", chs = "+" if "plus" in pfx else "-" if "minus" in pfx else "")
         tmpvar = ""
-        if "FakesEta" in name: tmpvar = "#eta"
+        if "FakesEtaCharge" in name: tmpvar = "#eta-byCharge"
+        elif "FakesEta" in name: tmpvar = "#eta"
         elif "FakesPtNorm" in name: tmpvar = "p_{T}-norm"
-        elif "FakesPtSlope" in name: tmpvar = "p_{T}-slope"
-        return "Fakes {var}-uncorr.{n} {lepCh}".format(var=tmpvar, n=num[0], lepCh=leptonCharge)
+        elif "FakesPtSlope" in name: tmpvar = "p_{T}-slope"    
+        return "Fakes {var}-{n} {lepCh}".format(var=tmpvar, n=num[0], lepCh=leptonCharge)
 
     elif re.match(".*EffStat\d+.*",name):
         num = re.findall(r'\d+', name) # get number (there will be two of them, need the second)

--- a/WMass/python/plotter/w-helicity-13TeV/subMatrix.py
+++ b/WMass/python/plotter/w-helicity-13TeV/subMatrix.py
@@ -27,7 +27,7 @@ utilities = utilities.util()
 def niceName(name):
 
     if '_Ybin' in name:
-        nn  = '#mu: ' if '_mu_' in name else 'el: '
+        nn  = '#mu: ' if '_mu_' in name else 'el: ' if '_el_' in name else 'l:'
         if 'plus' in name: nn += 'W+ '
         elif 'minus' in name: nn += 'W- '
         else: nn += 'W '
@@ -42,34 +42,36 @@ def niceName(name):
         return nn
 
     elif '_ieta_' and '_ipt_' in name:
-        nn  = '#mu: ' if '_mu_' in name else 'el: '
+        nn  = '#mu: ' if '_mu_' in name else 'el: ' if '_el_' in name else 'l:'
         nn += 'W+ ' if 'plus' in name else 'W- ' if 'minus' in name else 'W '
         ieta,ipt = get_ieta_ipt_from_process_name(name)
         nn += "i#eta, ip_{{T}} = {neta}, {npt} ".format(neta=ieta,npt=ipt)
         return nn
 
     elif '_ieta_' in name:
-        nn  = '#mu: ' if '_mu_' in name else 'el: '
+        nn  = '#mu: ' if '_mu_' in name else 'el: ' if '_el_' in name else 'l:'
         nn += 'W+ ' if 'plus' in name else 'W- ' if 'minus' in name else 'W '
         ieta = int((name.split("_ieta_")[1]).split("_")[0])
         nn += "i#eta = {neta}".format(neta=ieta)
         return nn
 
     elif '_ipt_' in name:
-        nn  = '#mu: ' if '_mu_' in name else 'el: '
+        nn  = '#mu: ' if '_mu_' in name else 'el: ' if '_el_' in name else 'l:'
         nn += 'W+ ' if 'plus' in name else 'W- ' if 'minus' in name else 'W '
         ipt = int((name.split("_ipt_")[1]).split("_")[0])
         nn += "i#p_{{T}} = {npt}".format(npt=ipt)
         return nn
 
     elif "CMS_" in name:
-        if "CMS_Wmu" in name:
-            return name.replace("CMS_Wmu_","")
-        elif "CMS_We" in name:
-            return name.replace("CMS_We_","")
-        else:
-            return name
-      
+        # keep Wmu or We now that we do combination, they are different sources
+        # if "CMS_Wmu" in name:
+        #     return name.replace("CMS_Wmu_","")
+        # elif "CMS_We" in name:
+        #     return name.replace("CMS_We_","")        
+        #else:
+        #    return name
+        return name.replace("CMS_","")
+
     elif re.match( "Fakes(Eta|EtaCharge|PtNorm|PtSlope)Uncorrelated.*",name):
         num = re.findall(r'\d+', name) # get number
         pfx = name.split(num[0])[1]    # split on number and read what's on the right

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -108,7 +108,7 @@ class util:
         histo_file.Close()
         return values
 
-    def getPDFbandFromXsec(self, histoPDF, charge, infile, channel, netabins, nptbins, firstPtBin=0):
+    def getPDFbandFromXsec(self, histoPDF, charge, infile, netabins, nptbins, firstPtBin=0):
 
         print "Inside getPDFbandFromXsec() ..."
         histo_file = ROOT.TFile(infile, 'READ')            
@@ -116,7 +116,7 @@ class util:
         for ieta in range(netabins):
             for ipt in range(firstPtBin,nptbins):
 
-                nomi = "x_W{ch}_{fl}_ieta_{ie}_ipt_{ip}_W{ch}_{fl}".format(ch=charge, fl=channel, ie=ieta, ip=ipt)
+                nomi = "x_W{ch}_lep_ieta_{ie}_ipt_{ip}".format(ch=charge, ie=ieta, ip=ipt)
                 hnomi = histo_file.Get(nomi)
                 if not hnomi:
                     print "Error in getPDFbandFromXsec(): I couldn't find histogram " + nomi
@@ -142,7 +142,7 @@ class util:
         return 0
 
 
-    def getPDFbandFromXsecEta(self, histoPDF, charge, infile, channel, netabins, nptbins, firstPtBin=0):
+    def getPDFbandFromXsecEta(self, histoPDF, charge, infile, netabins, nptbins, firstPtBin=0):
 
         print "Inside getPDFbandFromXsecEta() ..."
         histo_file = ROOT.TFile(infile, 'READ')            
@@ -153,7 +153,7 @@ class util:
             xsecpdf = [0.0 for i in range(60)]
             for ipt in range(firstPtBin,nptbins):
 
-                nomi = "x_W{ch}_{fl}_ieta_{ie}_ipt_{ip}_W{ch}_{fl}".format(ch=charge, fl=channel, ie=ieta, ip=ipt)
+                nomi = "x_W{ch}_lep_ieta_{ie}_ipt_{ip}".format(ch=charge, ie=ieta, ip=ipt)
                 hnomi = histo_file.Get(nomi)
                 if not hnomi:
                     print "Error in getPDFbandFromXsecEta(): I couldn't find histogram " + nomi
@@ -390,32 +390,32 @@ class util:
         ret = self.getExprFromToys('chargeAsym',expr,infile)
         return ret
 
-    def getDiffXsecAsymmetryFromToys(self, channel, ieta, ipt, infile):
-        xplus  = "Wplus_{ch}_ieta_{ieta}_ipt_{ipt}_Wplus_{ch}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt)
-        xminus = "Wminus_{ch}_ieta_{ieta}_ipt_{ipt}_Wminus_{ch}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt)
+    def getDiffXsecAsymmetryFromToys(self, ieta, ipt, infile):
+        xplus  = "Wplus_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(ieta=ieta,ipt=ipt)
+        xminus = "Wminus_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(ieta=ieta,ipt=ipt)
         expr = '({pl}-{mn})/({pl}+{mn})'.format(pl=xplus,mn=xminus)
         ret = self.getExprFromToys('chargeAsym',expr,infile)
         return ret
 
-    def getDenExpressionForNormDiffXsec(self, channel, charge, netabins, nptbins):
+    def getDenExpressionForNormDiffXsec(self, charge, netabins, nptbins):
         binsToNormalize = []
         for ieta in range(netabins):
             for ipt in range(nptbins):
-                denChunk = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+                denChunk = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(c=charge,ieta=ieta,ipt=ipt)
                 binsToNormalize.append(denChunk)
         den = "+".join(x for x in binsToNormalize)
         den = "(" + den + ")"
         return den
 
-    def getNormalizedDiffXsecFromToys(self, channel, charge, ieta, ipt, infile, den, friendTree=""):
-        num = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getNormalizedDiffXsecFromToys(self, charge, ieta, ipt, infile, den, friendTree=""):
+        num = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(c=charge,ieta=ieta,ipt=ipt)
         expr = '{num}/{den}'.format(num=num,den=den)
         ret = self.getExprFromToys('normDiffXsec',expr,infile)
         return ret
 
 
-    def getDiffXsecFromToys(self, channel, charge, ieta, ipt, infile):
-        expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getDiffXsecFromToys(self, charge, ieta, ipt, infile):
+        expr = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(c=charge,ieta=ieta,ipt=ipt)
         ret = self.getExprFromToys('diffXsec',expr,infile)
         return ret
 
@@ -429,26 +429,26 @@ class util:
         err  = tmp_hist.GetRMS()
         return (mean, mean+err, mean-err)
 
-    def getNormalizedDiffXsecFromToysFast(self, channel, charge, ieta, ipt, den, nHistBins=1000, minHist=0., maxHist=0.1, tree=None):
-        num = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getNormalizedDiffXsecFromToysFast(self, charge, ieta, ipt, den, nHistBins=1000, minHist=0., maxHist=0.1, tree=None):
+        num = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(c=charge,ieta=ieta,ipt=ipt)
         expr = '{num}/{den}'.format(num=num,den=den)
         ret = self.getExprFromToysFast('normDiffXsec',expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
 
-    def getDiffXsecFromToysFast(self, channel, charge, ieta, ipt, nHistBins=2000, minHist=0., maxHist=200., tree=None):
-        expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getDiffXsecFromToysFast(self, charge, ieta, ipt, nHistBins=2000, minHist=0., maxHist=200., tree=None):
+        expr = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(c=charge,ieta=ieta,ipt=ipt)
         ret = self.getExprFromToysFast('diffXsec',expr,nHistBins, minHist, maxHist, tree=tree)
         return ret
 
     def getSignalStrengthFromToysFast(self, channel, charge, ieta, ipt, nHistBins=400, minHist=0., maxHist=2., tree=None):
-        expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_mu".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+        expr = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_mu".format(c=charge,ieta=ieta,ipt=ipt)
         ret = self.getExprFromToysFast('diffXsec',expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
 
 
-    def getDiffXsecAsymmetryFromToysFast(self, channel, ieta, ipt, nHistBins=2000, minHist=0., maxHist=1.0, tree=None):
-        xplus  = "Wplus_{ch}_ieta_{ieta}_ipt_{ipt}_Wplus_{ch}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt)
-        xminus = "Wminus_{ch}_ieta_{ieta}_ipt_{ipt}_Wminus_{ch}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt)
+    def getDiffXsecAsymmetryFromToysFast(self, ieta, ipt, nHistBins=2000, minHist=0., maxHist=1.0, tree=None):
+        xplus  = "Wplus_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(ieta=ieta,ipt=ipt)
+        xminus = "Wminus_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(ieta=ieta,ipt=ipt)
         expr = '({pl}-{mn})/({pl}+{mn})'.format(pl=xplus,mn=xminus)
         ret = self.getExprFromToysFast('chargeAsym',expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
@@ -462,22 +462,22 @@ class util:
         #err  = tmp_hist.GetRMS()  # not used in this context, (we are going to use this expression mainly for charge asymmetry, the uncertainty must be taken from toys)
         return mean
 
-    def getDiffXsecAsymmetryFromHessian(self, channel, ieta, ipt, infile):
-        xplus  = "Wplus_{ch}_ieta_{ieta}_ipt_{ipt}_Wplus_{ch}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt)
-        xminus = "Wminus_{ch}_ieta_{ieta}_ipt_{ipt}_Wminus_{ch}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt)
+    def getDiffXsecAsymmetryFromHessian(self, ieta, ipt, infile):
+        xplus  = "Wplus_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(ieta=ieta,ipt=ipt)
+        xminus = "Wminus_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(ieta=ieta,ipt=ipt)
         expr = '({pl}-{mn})/({pl}+{mn})'.format(pl=xplus,mn=xminus)
         ret = self.getExprFromHessian('chargeAsym',expr,infile)
         return ret
 
 
-    def getNormalizedDiffXsecFromHessian(self, channel, charge, ieta, ipt, infile,den):
-        num = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getNormalizedDiffXsecFromHessian(self, charge, ieta, ipt, infile,den):
+        num = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(c=charge,ieta=ieta,ipt=ipt)
         expr = '{num}/{den}'.format(num=num,den=den)
         ret = self.getExprFromHessian('normDiffXsec',expr,infile)
         return ret
 
-    def getDiffXsecFromHessian(self, channel, charge, ieta, ipt, infile):
-        expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getDiffXsecFromHessian(self, charge, ieta, ipt, infile):
+        expr = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(c=charge,ieta=ieta,ipt=ipt)
         ret = self.getExprFromHessian('diffXsec',expr,infile)
         return ret
 
@@ -490,26 +490,23 @@ class util:
         mean = tmp_hist.GetMean()  # if this is hessian and not toys, there is just one entry, so the mean is the entry
         return mean
 
-    def getDiffXsecAsymmetryFromHessianFast(self, channel, ieta, ipt, nHistBins=2000, minHist=0., maxHist=1.0, tree=None, getErr=False, getGen=False):
-        xplus  = "Wplus_{ch}_ieta_{ieta}_ipt_{ipt}_Wplus_{ch}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt)
-        xminus = "Wminus_{ch}_ieta_{ieta}_ipt_{ipt}_Wminus_{ch}_pmaskedexp".format(ch=channel,ieta=ieta,ipt=ipt)
-        expr = '({pl}-{mn})/({pl}+{mn})'.format(pl=xplus,mn=xminus)
-        expr = "W_{ch}_ieta_{ieta}_ipt_{ipt}_W_{ch}_chargeasym".format(ch=channel,ieta=ieta,ipt=ipt)
+    def getDiffXsecAsymmetryFromHessianFast(self, ieta, ipt, nHistBins=2000, minHist=0., maxHist=1.0, tree=None, getErr=False, getGen=False):
+        expr = "W_lep_ieta_{ieta}_ipt_{ipt}_chargeasym".format(ieta=ieta,ipt=ipt)
         if getErr: expr += "_err"
         elif getGen: expr += "_gen"
         ret = self.getExprFromHessianFast('chargeAsym',expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
 
 
-    def getNormalizedDiffXsecFromHessianFast(self, channel, charge, ieta, ipt, nHistBins=1000, minHist=0., maxHist=0.1, tree=None, getErr=False, getGen=False):
-        expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexpnorm".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getNormalizedDiffXsecFromHessianFast(self, charge, ieta, ipt, nHistBins=1000, minHist=0., maxHist=0.1, tree=None, getErr=False, getGen=False):
+        expr = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexpnorm".format(c=charge,ieta=ieta,ipt=ipt)
         if getErr: expr += "_err"
         elif getGen: expr += "_gen"
         ret = self.getExprFromHessianFast('normDiffXsec',expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
 
-    def getDiffXsecFromHessianFast(self, channel, charge, ieta, ipt,  nHistBins=2000, minHist=0., maxHist=200., tree=None, getErr=False, getGen=False):
-        expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_pmaskedexp".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getDiffXsecFromHessianFast(self, charge, ieta, ipt,  nHistBins=2000, minHist=0., maxHist=200., tree=None, getErr=False, getGen=False):
+        expr = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_pmaskedexp".format(c=charge,ieta=ieta,ipt=ipt)
         if getErr: expr += "_err"
         elif getGen: expr += "_gen"
         ret = self.getExprFromHessianFast('diffXsec',expr, nHistBins, minHist, maxHist, tree=tree)
@@ -517,32 +514,32 @@ class util:
 
 
     # this is for single charge
-    def getDiffXsec1DFromHessianFast(self, channel, charge, ietaORipt, isIeta=True, nHistBins=5000, minHist=0., maxHist=5000., tree=None, getErr=False, getGen=False):
-        expr = "W{c}_{ch}_i{var}_{ivar}_W{c}_{ch}_sumxsec".format(c=charge,ch=channel,var="eta" if isIeta else "pt", ivar=ietaORipt)
+    def getDiffXsec1DFromHessianFast(self, charge, ietaORipt, isIeta=True, nHistBins=5000, minHist=0., maxHist=5000., tree=None, getErr=False, getGen=False):
+        expr = "W{c}_lep_i{var}_{ivar}_sumxsec".format(c=charge,var="eta" if isIeta else "pt", ivar=ietaORipt)
         if getErr: expr += "_err"
         elif getGen: expr += "_gen"
         ret = self.getExprFromHessianFast('diffXsec1D_{var}'.format(var="eta" if isIeta else "pt"),expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
 
-    def getNormalizedDiffXsec1DFromHessianFast(self, channel, charge, ietaORipt, isIeta=True, nHistBins=1000, minHist=0., maxHist=1., tree=None, getErr=False, getGen=False):
-        expr = "W{c}_{ch}_i{var}_{ivar}_W{c}_{ch}_sumxsecnorm".format(c=charge,ch=channel,var="eta" if isIeta else "pt", ivar=ietaORipt)
+    def getNormalizedDiffXsec1DFromHessianFast(self, charge, ietaORipt, isIeta=True, nHistBins=1000, minHist=0., maxHist=1., tree=None, getErr=False, getGen=False):
+        expr = "W{c}_lep_i{var}_{ivar}_sumxsecnorm".format(c=charge,var="eta" if isIeta else "pt", ivar=ietaORipt)
         if getErr: expr += "_err"
         elif getGen: expr += "_gen"
         ret = self.getExprFromHessianFast('diffXsec1D_{var}'.format(var="eta" if isIeta else "pt"),expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
 
 
-    def getDiffXsecAsymmetry1DFromHessianFast(self, channel, ietaORipt, isIeta=True, 
+    def getDiffXsecAsymmetry1DFromHessianFast(self, ietaORipt, isIeta=True, 
                                               nHistBins=1000, minHist=0., maxHist=1., tree=None, getErr=False, getGen=False):
-        expr = "W_{ch}_i{var}_{ivar}_W_{ch}_chargemetaasym".format(ch=channel,var="eta" if isIeta else "pt", ivar=ietaORipt)
+        expr = "W_lep_i{var}_{ivar}_chargemetaasym".format(var="eta" if isIeta else "pt", ivar=ietaORipt)
         if getErr: expr += "_err"
         elif getGen: expr += "_gen"
         ret = self.getExprFromHessianFast('chargeAsym1D_{var}'.format(var="eta" if isIeta else "pt"),expr, nHistBins, minHist, maxHist, tree=tree)
         return ret
 
 
-    def getSignalStrengthFromHessianFast(self, channel, charge, ieta, ipt, nHistBins=200, minHist=0.5, maxHist=1.5, tree=None, getErr=False, getGen=False):
-        expr = "W{c}_{ch}_ieta_{ieta}_ipt_{ipt}_W{c}_{ch}_mu".format(c=charge,ch=channel,ieta=ieta,ipt=ipt)
+    def getSignalStrengthFromHessianFast(self, charge, ieta, ipt, nHistBins=200, minHist=0.5, maxHist=1.5, tree=None, getErr=False, getGen=False):
+        expr = "W{c}_lep_ieta_{ieta}_ipt_{ipt}_mu".format(c=charge,ieta=ieta,ipt=ipt)
         if getErr: expr += "_err"
         elif getGen: expr += "_gen"
         ret = self.getExprFromHessianFast('normDiffXsec',expr, nHistBins, minHist, maxHist, tree=tree)


### PR DESCRIPTION
Among the other things for 2D xsec, I slightly modified **w-helicity-13TeV/plotYW.py**.
The current fill style for expected band is a first attempt that should have a better appearance when saving in PDF format (note that the PNG always appears differently than PDF in a significant way, so what is visible and nice for the PNG preview might be awful for the PDF)

See an example here (you need to look at the PDF) [0]. Actually, I would also suggest we should probably use a darker orange for WR

[0] 
http://mciprian.web.cern.ch/mciprian/wmass/13TeV/helicityAnalysis/muon/fromMarc/helicity_2019_03_06_withPrefireWeights/rapiditySpectra/
