### PR TITLE
Adding plotting of the combination el/mu and compatibility for YW

### DIFF
--- a/WMass/python/plotter/resultPlots.py
+++ b/WMass/python/plotter/resultPlots.py
@@ -81,16 +81,25 @@ if __name__ == '__main__':
         os.system('mkdir -p {od}'.format(od=tmp_outdir))
         os.system('cp /afs/cern.ch/user/m/mdunser/public/index.php {od}'.format(od=tmp_outdir))
         for t in toysHessian:
-            for tmp_file in [i for i in results.keys() if 'both_floatingPOIs_'+t in i]:
+            for tmp_file in [i for i in results.keys() if 'both_floatingPOIs_'+t in i and not i.endswith('_el') and not i.endswith('_mu')]:
+                fitflavor = os.path.splitext(os.path.basename(options.config.split('_')[-1]))[0]
                 tmp_suffix = '_'.join(tmp_file.split('_')[1:])
                 cmd  = 'python w-helicity-13TeV/plotYW.py '
                 cmd += ' -C plus,minus --xsecfiles {xp},{xm} -y {cd}/binningYW.txt '.format(xp=results['xsecs_plus'],xm=results['xsecs_minus'],cd=results['cardsdir'])
-                cmd += ' --infile {inf} --outdir {od} --type {t} --suffix {suf} --nolong'.format(od=tmp_outdir, t=t, suf=tmp_suffix, inf=results[tmp_file])
-                os.system(cmd)
+                cmd += ' --infile {inf} --outdir {od} --type {t} --suffix {suf} --nolong'.format(od=tmp_outdir, t=t, suf=tmp_suffix+'_'+fitflavor, inf=results[tmp_file])
+                print cmd
+                #os.system(cmd)
                 print "===> plotting normalized xsecs..."
                 cmd += ' --normxsec '
-                print cmd
-                os.system(cmd)
+                #os.system(cmd)
+                if sum(tmp_file+'_'+lepflav in results.keys() for lepflav in ['el','mu'])==2:
+                    print 'NOW plotting combined YW...'
+                    cmd  = 'python w-helicity-13TeV/plotYWCompatibility.py '
+                    cmd += ' -C plus,minus --xsecfiles {xp},{xm} -y {cd}/binningYW.txt '.format(xp=results['xsecs_plus'],xm=results['xsecs_minus'],cd=results['cardsdir'])
+                    cmd += ' --infile-lep {infl} --infile-mu {infmu} --infile-el {infel} --outdir {od} --suffix {suf} --nolong'.format(od=tmp_outdir, t=t, suf=tmp_suffix+'_'+fitflavor+'_comp', infl=results[tmp_file],infmu=results[tmp_file+'_el'],infel=results[tmp_file+'_mu'])
+                    normstr = [' ', ' --normxsec ']
+                    for norm in normstr:
+                        os.system(cmd+norm)
 
     ## plot postfit plots
     ## ================================

--- a/WMass/python/plotter/results_config_lep.txt
+++ b/WMass/python/plotter/results_config_lep.txt
@@ -1,23 +1,16 @@
-basedir = '/afs/cern.ch/work/e/emanuele/wmass/heppy/CMSSW_8_0_25/src/CMGTools/WMass/python/plotter/w-helicity-13TeV'
 cardsdir = '/afs/cern.ch/work/e/emanuele/wmass/heppy/CMSSW_8_0_25/src/CMGTools/WMass/python/plotter/w-helicity-13TeV/cards_lep'
-fitsdir = basedir+'/fits/tf/2019-03-25-lep'
-toysdir = basedir+'/toys/tf/21-11-18'
+fitsdir = '/afs/cern.ch/work/e/emanuele/wmass/heppy/CMSSW_8_0_25/src/CMGTools/WMass/python/plotter/w-helicity-13TeV/fits/tf/2019-03-25-lep'
+fitsdir_el = '/afs/cern.ch/work/e/emanuele/wmass/heppy/CMSSW_8_0_25/src/CMGTools/WMass/python/plotter/w-helicity-13TeV/fits/tf/2019-03-22'
+fitsdir_mu = '/afs/cern.ch/work/m/mdunser/public/cmssw/w-helicity-13TeV/CMSSW_8_0_25/src/CMGTools/WMass/python/plotter/cards/helicity_2019_03_06_withPrefireWeights'
 
 ### FLOATING POIS ###
-both_floatingPOIs_hessian_exp1_bbb1 = fitsdir+'/fitresults_poim1_exp1_bbb1.root'
-#both_floatingPOIs_hessian_exp1_bbb0 = fitsdir+'/fitresults_poim1_exp1_bbb0.root'
-both_floatingPOIs_hessian_exp0_bbb1 = fitsdir+'/fitresults_poim1_exp0_bbb1.root'
-#both_floatingPOIs_hessian_exp0_bbb0 = fitsdir+'/fitresults_poim1_exp0_bbb0.root'
+#both_floatingPOIs_hessian_exp1_bbb1    = fitsdir+   '/fitresults_poim1_exp1_bbb1.root'
+#both_floatingPOIs_hessian_exp1_bbb1_el = fitsdir_el+'/fitresults_poim1_exp1_bbb1.root'
+#both_floatingPOIs_hessian_exp1_bbb1_mu = fitsdir_mu+'/fitresults_poim1_exp1_bbb1.root'
 
-both_floatingPOIs_toys    = toysdir+'/floatPOIs/bbb/toys_floatPOIs.root'
-
-### FIXED POIS ###
-#both_fixedPOIs_hessian_exp1_bbb1 = fitsdir+'/fitresults_poim0_exp1_bbb1.root'
-#both_fixedPOIs_hessian_exp1_bbb0 = fitsdir+'/fitresults_poim0_exp1_bbb0.root'
-#both_fixedPOIs_hessian_exp0_bbb1 = fitsdir+'/fitresults_poim0_exp0_bbb1.root'
-#both_fixedPOIs_hessian_exp0_bbb0 = fitsdir+'/fitresults_poim0_exp0_bbb0.root'
-
-both_fixedPOIs_toys          = toysdir+'/fixPOIs/bbb/toys_fixPOIs_bbb.root'
+both_floatingPOIs_hessian_exp0_bbb1    = fitsdir+   '/fitresults_poim1_exp0_bbb1.root'
+both_floatingPOIs_hessian_exp0_bbb1_el = fitsdir_el+'/fitresults_poim1_exp0_bbb1.root'
+both_floatingPOIs_hessian_exp0_bbb1_mu = fitsdir_mu+'/fitresults_poim1_exp0_bbb1.root'
 
 xsecs_plus  = cardsdir+'/Wlep_plus_shapes_xsec.root'
 xsecs_minus = cardsdir+'/Wlep_minus_shapes_xsec.root'

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -30,8 +30,8 @@ class valueClass:
         if 'asymmetry' in name:
             self.charge = self.ch = ''
 
-        self.color  = ROOT.kBlue-9 if self.isleft else ROOT.kOrange-4 if self.isright else ROOT.kGray+1
-        self.colorf = ROOT.kBlue-3 if self.isleft else ROOT.kOrange-3 if self.isright else ROOT.kGray+3
+        self.color  = ROOT.kBlue+2 if self.isleft else ROOT.kRed+1 if self.isright else ROOT.kGray+1
+        self.colorf = ROOT.kAzure+1 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
         if self.isunpolarized: 
             self.color = ROOT.kSpring-6
             self.colorf = ROOT.kSpring-7
@@ -47,35 +47,40 @@ class valueClass:
         if len(self.val):
             self.graph = ROOT.TGraphAsymmErrors(len(self.val), self.rap, self.val, self.rlo, self.rhi, self.elo, self.ehi)
             self.graph.SetName('graph'+self.pol)
+            self.graph.SetTitle('')
         if len(self.relv): 
             self.graph_rel= ROOT.TGraphAsymmErrors(len(self.relv), self.rap, self.relv, self.rlo, self.rhi, self.rello, self.relhi)
             self.graph_rel.SetName('graph'+self.pol+'_rel')
+            self.graph_rel.SetTitle('')
         if len(self.val_fit):
             self.graph_fit = ROOT.TGraphAsymmErrors(len(self.val_fit), self.rap, self.val_fit, self.rlo, self.rhi, self.elo_fit, self.ehi_fit)
             self.graph_fit.SetName('graph'+self.pol+'_fit')
+            self.graph_fit.SetTitle('')
         zeros = array.array('f',[0 for i in xrange(len(self.rlo))])
         if len(self.relv_fit):
             self.graph_fit_rel = ROOT.TGraphAsymmErrors(len(self.relv_fit), self.rap, self.relv_fit, zeros, zeros, self.rello_fit, self.relhi_fit)
             self.graph_fit_rel.SetName('graph'+self.pol+'_fit_rel')
-        
+            self.graph_fit_rel.SetTitle('')
+
         self.graphStyle()
         if len(self.relv) and len(self.relv_fit): self.makeMultiGraphRel()
 
     def makeMultiGraphRel(self):
         self.mg = ROOT.TMultiGraph()
         self.mg.SetTitle() ## no title 'W^{{{ch}}}: {p}'.format(ch=self.ch,p=self.pol))
-        self.shiftPoints(self.graph_fit_rel)
+        #self.shiftPoints(self.graph_fit_rel)
         self.mg.Add(self.graph_rel,'P2')
         self.mg.Add(self.graph_fit_rel)
 
     def graphStyle(self):
-        fillstyles = {'left': 3017, 'right': 3018, 'long': 3016, 'unpolarized': 3020}
+        fillstyles = {'left': 3244, 'right': 3244, 'long': 3244, 'unpolarized': 3244}
+        fillstyles_rel = {'left': 3444, 'right': 3444, 'long': 3444, 'unpolarized': 3244}
         if hasattr(self,'graph'):
             self.graph.SetLineColor(self.color)
-            self.graph.SetFillColor(self.color)
+            self.graph.SetFillColor(self.colorf)
             self.graph.SetFillStyle(fillstyles[self.pol])
         if hasattr(self,'graph_fit'):
-            self.graph_fit.SetLineWidth(2)
+            self.graph_fit.SetLineWidth(3)
             self.graph_fit.SetMarkerSize(1.0)
             self.graph_fit.SetMarkerStyle(ROOT.kFullCircle)
             self.graph_fit.SetMarkerColor(self.color)
@@ -83,14 +88,16 @@ class valueClass:
         if hasattr(self,'graph_rel'):
             self.graph_rel.SetLineWidth(5)
             self.graph_rel.SetLineColor(self.color)
-            self.graph_rel.SetFillColor(self.color)
-            self.graph_rel.SetFillStyle(fillstyles[self.pol])
+            self.graph_rel.SetFillColor(self.colorf)
+            self.graph_rel.SetFillStyle(fillstyles_rel[self.pol])
         if hasattr(self,'graph_fit_rel'):
             self.graph_fit_rel.SetLineWidth(2)
             self.graph_fit_rel.SetMarkerSize(1.0)
             self.graph_fit_rel.SetMarkerStyle(ROOT.kFullCircle)
             self.graph_fit_rel.SetLineColor(self.color)
             self.graph_fit_rel.SetMarkerColor(self.color)
+            self.graph_fit_rel.SetFillColor(ROOT.kGreen+3)
+            self.graph_fit_rel.SetFillStyle(3001)
 
     def shiftPoints(self, graph):
         shifts = {'left': -0.01, 'right': 0.01, 'long': 0.0, 'unpolarized': 0.0}

--- a/WMass/python/plotter/w-helicity-13TeV/plotYWCompatibility.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYWCompatibility.py
@@ -22,17 +22,26 @@ def removeErrX(graph):
         graph.SetPointEXhigh(p,0); graph.SetPointEXlow(p,0)
 
 def applyChannelStyles(values):
-    markerStyles = {'mu': ROOT.kOpenSquare, 'el': ROOT.kOpenCircle, 'lep': ROOT.kFullCircle}
+    markerStyles = {'mu': ROOT.kOpenSquare, 'el': ROOT.kOpenCircle, 'lep': ROOT.kFullTriangleDown}
     markerSizes = {'mu': 2, 'el': 2, 'lep': 2}
     for flav in ['lep','mu','el']:
         for pol in ['left','right','long']:
             # remove the x error bars for the single channels
             if flav!='lep': removeErrX(values[(flav,pol)].graph_fit)
+            values[(flav,pol)].graph.SetLineStyle(1)
+            values[(flav,pol)].graph.SetLineWidth(2)
+            values[(flav,pol)].graph.SetLineColor(values[(flav,pol)].color)
             values[(flav,pol)].graph_fit.SetMarkerStyle(markerStyles[flav])
-            values[(flav,pol)].graph_fit_rel.SetMarkerStyle(markerStyles[flav])
             values[(flav,pol)].graph_fit.SetMarkerSize(markerSizes[flav])
+            values[(flav,pol)].graph_fit_rel.SetMarkerStyle(markerStyles[flav])
             values[(flav,pol)].graph_fit_rel.SetMarkerSize(markerSizes[flav])
-            #values[(flav,pol)].graph_fit_rel.SetFillColor(ROOT.kGreen+3)
+            values[(flav,pol)].graph_fit_rel.SetLineColor(ROOT.kBlack)
+            values[(flav,pol)].graph_fit_rel.SetLineWidth(2)
+            values[(flav,pol)].graph_fit_rel.SetFillColor(ROOT.kYellow-9)
+            values[(flav,pol)].graph_fit_rel.SetFillStyle(1001)
+            for p in xrange(values[(flav,pol)].graph_fit_rel.GetN()):
+                values[(flav,pol)].graph_fit_rel.SetPointEXhigh(p,values[(flav,pol)].rhi[p])
+                values[(flav,pol)].graph_fit_rel.SetPointEXlow(p,values[(flav,pol)].rlo[p])
 
 def makeUncorrRatio(gr1,gr2):
     ratio = ROOT.TGraphAsymmErrors(gr1.GetN())
@@ -63,14 +72,14 @@ def makeUncorrDiff(gr1,gr2):
 def makeFullLegend(values):
     legs = []
     # expected values
-    legExp = ROOT.TLegend(0.15, 0.80, 0.90, 0.90)
+    legExp = ROOT.TLegend(0.25, 0.75, 0.90, 0.85)
     legExp.SetFillStyle(0)
     legExp.SetBorderSize(0)
     legExp.AddEntry(values[('lep','left')] .graph     , '#sigma_{L} (Theory)', 'f')
     legExp.AddEntry(values[('lep','right')].graph     , '#sigma_{R} (Theory)', 'f')
     legs.append(legExp)
     # data Left
-    legLeft = ROOT.TLegend(0.15, 0.60, 0.90, 0.80)
+    legLeft = ROOT.TLegend(0.25, 0.60, 0.90, 0.75)
     legLeft.SetFillStyle(0)
     legLeft.SetBorderSize(0)
     legLeft.AddEntry(values[('mu','left')] .graph_fit     , ' ', 'p')
@@ -78,7 +87,7 @@ def makeFullLegend(values):
     legLeft.AddEntry(values[('lep','left')].graph_fit     , ' ', 'p')
     legs.append(legLeft)
     # data Right
-    legRight = ROOT.TLegend(0.25, 0.60, 0.90, 0.80)
+    legRight = ROOT.TLegend(0.35, 0.60, 0.90, 0.75)
     legRight.SetFillStyle(0)
     legRight.SetBorderSize(0)
     legRight.AddEntry(values[('mu','right')] .graph_fit     , 'data #mu', 'p')
@@ -88,16 +97,41 @@ def makeFullLegend(values):
     return legs
 
 def plotValues(values,charge,channel,options):
-        c2 = ROOT.TCanvas('foo','', 800, 1600)
-        c2.SetLeftMargin(0.05)
-        c2.SetRightMargin(1)
-        leftMargin = 0.1
+        c2 = ROOT.TCanvas('foo','', 1500, 3000)
+        
+        c2.Range(0,0,1,1);
+        c2.SetFillColor(0);
+        c2.SetBorderMode(0);
+        c2.SetBorderSize(2);
+        c2.SetTickx(1);
+        c2.SetTicky(1);
+        c2.SetLeftMargin(0.05);
+        c2.SetRightMargin(0.05);
+        c2.SetTopMargin(0.05);
+        c2.SetBottomMargin(0.16);
+        c2.SetFrameFillStyle(0);
+        c2.SetFrameBorderMode(0);
+
+
+        ROOT.gStyle.SetHatchesLineWidth(2)
+        leftMargin = 0
         rightMargin = 1.
-        subpadsYLow = [0.5, 0.38, 0.26, 0.14, 0.02]
-        subpadsYUp = [0.99, 0.5, 0.38, 0.26, 0.14]
+        subpadsYLow = [0.5, 0.38, 0.26, 0.16, 0.06]
+        subpadsYUp = [0.99, 0.5, 0.38, 0.26, 0.16]
         pads = []
         for ip in xrange(len(subpadsYLow)):
             pad = ROOT.TPad("pad{ip}".format(ip=ip),"",leftMargin,subpadsYLow[ip],rightMargin,subpadsYUp[ip])
+            pad.SetFillColor(0);
+            pad.SetBorderMode(0);
+            pad.SetBorderSize(2);
+            pad.SetTickx(1);
+            pad.SetTicky(1);
+            pad.SetLeftMargin(0.2);
+            pad.SetRightMargin(0.05);
+            pad.SetFrameFillStyle(0);
+            pad.SetFrameBorderMode(0);
+            pad.SetFrameFillStyle(0);
+            pad.SetFrameBorderMode(0);
             pads.append(pad)
 
         flavors = ['mu','el','lep']; polarizations = ['left','right','long']
@@ -150,6 +184,7 @@ def plotValues(values,charge,channel,options):
                 leg.Draw("same")
 
         lines = {}
+        subpadLegends = {}
         if sum(hasattr(values[(flav,pol)],'mg') for pol in polarizations for flav in flavors)==9:
 
             ## now make the relative error plot for combination:
@@ -160,31 +195,39 @@ def plotValues(values,charge,channel,options):
                 pads[isubpad].Draw(); pads[isubpad].cd(); ROOT.gPad.SetBottomMargin(0); ROOT.gPad.SetTopMargin(0)
 
                 if charge=='asymmetry':
-                    yaxtitle = 'A_{Theory}-A_{Data}'
+                    yaxtitle = 'Theory-Data'
                     yaxrange = (-0.1, 0.1)
                 else:
-                    yaxtitle = '#sigma_{Theory}/#sigma_{Data}'
+                    yaxtitle = 'Theory/Data'
                     yaxrange = (0.82, 1.18)
      
-                values[('lep',pol)].graph_rel.Draw("A2")
-                values[('lep',pol)].graph_fit_rel.Draw("2")
-                values[('lep',pol)].graph_fit_rel.Draw("P")
+                values[('lep',pol)].graph_fit_rel.Draw("A2")
+                values[('lep',pol)].graph_fit_rel.Draw("pe")
+                values[('lep',pol)].graph_rel.Draw("2")
                 ## x axis fiddling
-                values[('lep',pol)].graph_rel.GetXaxis().SetRangeUser(0., options.maxRapidity)
-                values[('lep',pol)].graph_rel.GetXaxis().SetLabelSize(0.04)
+                values[('lep',pol)].graph_fit_rel.GetXaxis().SetRangeUser(0., options.maxRapidity)
+                values[('lep',pol)].graph_fit_rel.GetXaxis().SetLabelSize(0.04)
                 ## y axis fiddling
-                values[('lep',pol)].graph_rel.GetYaxis().SetTitleOffset(0.4)
-                values[('lep',pol)].graph_rel.GetYaxis().SetTitleSize(0.18)
-                values[('lep',pol)].graph_rel.GetYaxis().SetLabelSize(0.12)
-                values[('lep',pol)].graph_rel.GetYaxis().SetTitle(yaxtitle)
-                values[('lep',pol)].graph_rel.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
-                values[('lep',pol)].graph_rel.GetYaxis().CenterTitle()
+                values[('lep',pol)].graph_fit_rel.GetYaxis().SetTitleOffset(0.4)
+                values[('lep',pol)].graph_fit_rel.GetYaxis().SetTitleSize(0.18)
+                values[('lep',pol)].graph_fit_rel.GetYaxis().SetLabelSize(0.12)
+                values[('lep',pol)].graph_fit_rel.GetYaxis().SetTitle(yaxtitle)
+                values[('lep',pol)].graph_fit_rel.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
+                values[('lep',pol)].graph_fit_rel.GetYaxis().CenterTitle()
+                values[('lep',pol)].graph_fit_rel.GetYaxis().SetDecimals()
 
                 lines["horiz_line_comb"+pol] = ROOT.TF1("horiz_line_comb"+pol,"0" if charge=='asymmetry' else '1',0.0,3.0);
                 lines["horiz_line_comb"+pol].SetLineColor(ROOT.kRed);
                 lines["horiz_line_comb"+pol].SetLineWidth(2);
                 lines["horiz_line_comb"+pol].SetLineStyle(ROOT.kDashed);
                 lines["horiz_line_comb"+pol].Draw("Lsame");
+                
+                subpadLegends["leg_lep_"+pol] = ROOT.TLegend(0.25, 0.8, 0.5, 0.9); subpadLegends["leg_lep_"+pol].SetFillStyle(0); subpadLegends["leg_lep_"+pol].SetBorderSize(0)
+                subpadLegends["leg_lep_"+pol].SetNColumns(2)
+                subpadLegends["leg_lep_"+pol].AddEntry(values[('lep',pol)].graph_fit_rel,'Data','fpl')
+                labels_pol = {'left':'L','right':'R','long':'0'} 
+                subpadLegends["leg_lep_"+pol].AddEntry(values[('lep',pol)].graph_rel,'Theory (W_{{{pol}}})'.format(pol=labels_pol[pol]),'f')
+                subpadLegends["leg_lep_"+pol].Draw('same')
 
                 isubpad+=1
 
@@ -195,6 +238,7 @@ def plotValues(values,charge,channel,options):
                 print "SUB PAD ",isubpad," printing ",pol
                 pads[isubpad].Draw(); pads[isubpad].cd(); ROOT.gPad.SetTopMargin(0)
                 if isubpad<4: ROOT.gPad.SetBottomMargin(0)
+                else: ROOT.gPad.SetBottomMargin(-0.3)
 
                 if charge=='asymmetry':
                     yaxtitle = 'A_{#mu}-A_{e}'
@@ -208,13 +252,13 @@ def plotValues(values,charge,channel,options):
                 comps["comp_"+pol].SetMarkerColor(values[('mu',pol)].color)
                 comps["comp_"+pol].SetLineColor(values[('mu',pol)].color)
                 comps["comp_"+pol].SetFillColor(values[('mu',pol)].color)
-                comps["comp_"+pol].SetMarkerStyle(ROOT.kFullTriangleUp)
+                comps["comp_"+pol].SetMarkerStyle(ROOT.kFullCircle)
                 comps["comp_"+pol].SetMarkerSize(2)
 
                 comps["comp_"+pol].Draw('Pa')
                 ## x axis fiddling
                 comps["comp_"+pol].GetXaxis().SetRangeUser(0., options.maxRapidity)
-                comps["comp_"+pol].GetXaxis().SetLabelSize(0.04)
+                comps["comp_"+pol].GetXaxis().SetLabelSize(0.1)
                 ## y axis fiddling
                 comps["comp_"+pol].GetYaxis().SetTitleOffset(0.4)
                 comps["comp_"+pol].GetYaxis().SetTitleSize(0.18)
@@ -222,24 +266,27 @@ def plotValues(values,charge,channel,options):
                 comps["comp_"+pol].GetYaxis().SetTitle(yaxtitle)
                 comps["comp_"+pol].GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
                 comps["comp_"+pol].GetYaxis().CenterTitle()
-                if isubpad==4:
-                    comps["comp_"+pol].GetXaxis().SetLabelSize(0.12)
-                    comps["comp_"+pol].GetXaxis().SetTitleSize(0.2)
-                    comps["comp_"+pol].GetXaxis().SetTitleOffset(0.4)
-                    comps["comp_"+pol].GetXaxis().SetTitle("|Y_{W}|")
+                comps["comp_"+pol].GetYaxis().SetDecimals()
                 lines["horiz_line_comp_"+pol] = ROOT.TF1("horiz_line_comp_"+pol,"0" if charge=='asymmetry' else '1',0.0,3.0);
                 lines["horiz_line_comp_"+pol].SetLineColor(ROOT.kRed);
                 lines["horiz_line_comp_"+pol].SetLineWidth(2);
                 lines["horiz_line_comp_"+pol].SetLineStyle(ROOT.kDashed);
                 lines["horiz_line_comp_"+pol].Draw("Lsame");
+
+                subpadLegends["comp_lep_"+pol] = ROOT.TLegend(0.25, 0.8, 0.5, 0.9); subpadLegends["comp_lep_"+pol].SetFillStyle(0); subpadLegends["comp_lep_"+pol].SetBorderSize(0)
+                subpadLegends["comp_lep_"+pol].SetNColumns(2)
+                labels_pol = {'left':'L','right':'R','long':'0'} 
+                subpadLegends["comp_lep_"+pol].AddEntry(comps["comp_"+pol],'Data #sigma_{{#mu}}/#sigma_{{e}} (W_{{{pol}}})'.format(pol=labels_pol[pol]),'pl')
+                subpadLegends["comp_lep_"+pol].Draw('same')
+
                 isubpad+=1
 
         c2.cd()
         lat.DrawLatex(0.2, 0.95, '#bf{CMS} #it{Preliminary}')
         lat.DrawLatex(0.62, 0.95, '35.9 fb^{-1} (13 TeV)')
         lat.DrawLatex(0.25, 0.60,  'W^{{{ch}}} #rightarrow l^{{{ch}}}{nu}'.format(ch=ch,nu="#bar{#nu}" if charge=='minus' else "#nu"))
-        #lat.DrawLatex(0.90, 0.03, '|Y_{W}|')
-        for ext in ['png', 'pdf']:
+        lat.DrawLatex(0.85, 0.025, '|Y_{W}|')
+        for ext in ['png', 'pdf', 'C']:
             c2.SaveAs('{od}/genAbsY{norm}_pdfs_{ch}{suffix}.{ext}'.format(od=options.outdir, norm=normstr, ch=charge, suffix=options.suffix, ext=ext))
 
 
@@ -326,10 +373,10 @@ def plotUnpolarizedValues(values,charge,channel,options):
             line.SetLineWidth(2);
             yaxrange = (0,0)
             if charge=='asymmetry':
-                yaxtitle = 'A_{Theory}-A_{Data}'
+                yaxtitle = 'Theory-Data'
                 yaxrange = (-0.2, 0.2)
             else:
-                yaxtitle = '#sigma_{Theory}/#sigma_{Data}'
+                yaxtitle = 'Theory/Data'
                 yaxrange = (0.70, 1.30) if normstr=='xsec' else (-1.5, 3.5)
 
             values.mg.Draw('Pa')
@@ -347,6 +394,7 @@ def plotUnpolarizedValues(values,charge,channel,options):
             values.mg.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
             values.mg.GetYaxis().SetNdivisions(5)
             values.mg.GetYaxis().CenterTitle()
+            values.mg.GetYaxis().SetDecimals()
 
             line.Draw("Lsame");
 

--- a/WMass/python/plotter/w-helicity-13TeV/plotYWCompatibility.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYWCompatibility.py
@@ -1,0 +1,666 @@
+#!/bin/env python
+# USAGE: python plotYW.py --type toys --infile toys_wplus.root -y cards_el/binningYW.txt -C plus -o plots --xsecfiles Wel_plus_shapes_xsec.root [--normxsec]
+#
+# When run on the W+ W- combined fit it also makes charge asymmetry plot:
+# python plotYW.py --type toys --infile toys_wboth.root -y cards_el/binningYW.txt -C plus,minus -o plots --xsecfiles Wel_plus_shapes_xsec.root,Wel_minus_shapes_xsec.root
+
+import ROOT, datetime, array, os, math, re
+ROOT.gROOT.SetBatch(True)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gSystem.Load("libHiggsAnalysisCombinedLimit")
+from plotYW import valueClass
+
+import utilities
+utilities = utilities.util()
+
+REFMC = 'MC@NLO'
+
+def removeErrX(graph):
+    for p in xrange(graph.GetN()):
+        x = ROOT.Double(0); y = ROOT.Double(0)
+        graph.GetPoint(p,x,y)
+        graph.SetPointEXhigh(p,0); graph.SetPointEXlow(p,0)
+
+def applyChannelStyles(values):
+    markerStyles = {'mu': ROOT.kOpenSquare, 'el': ROOT.kOpenCircle, 'lep': ROOT.kFullCircle}
+    markerSizes = {'mu': 2, 'el': 2, 'lep': 2}
+    for flav in ['lep','mu','el']:
+        for pol in ['left','right','long']:
+            # remove the x error bars for the single channels
+            if flav!='lep': removeErrX(values[(flav,pol)].graph_fit)
+            values[(flav,pol)].graph_fit.SetMarkerStyle(markerStyles[flav])
+            values[(flav,pol)].graph_fit_rel.SetMarkerStyle(markerStyles[flav])
+            values[(flav,pol)].graph_fit.SetMarkerSize(markerSizes[flav])
+            values[(flav,pol)].graph_fit_rel.SetMarkerSize(markerSizes[flav])
+            #values[(flav,pol)].graph_fit_rel.SetFillColor(ROOT.kGreen+3)
+
+def makeUncorrRatio(gr1,gr2):
+    ratio = ROOT.TGraphAsymmErrors(gr1.GetN())
+    ratio.SetName('graph_ratio')
+    for p in xrange(gr1.GetN()):
+        x = ROOT.Double(0); y1 = ROOT.Double(0); y2 = ROOT.Double(0)
+        gr1.GetPoint(p,x,y1); gr2.GetPoint(p,x,y2)
+        r = y2/y1
+        # consider el and mu mostly uncorrelated (since dominated by the MC stat)
+        erhi = r*math.hypot(gr1.GetErrorYhigh(p)/y1,gr2.GetErrorYhigh(p)/y2); erlo=erhi
+        ratio.SetPoint(p,x,r)
+        ratio.SetPointError(p,gr1.GetErrorXlow(p),gr1.GetErrorXhigh(p),erlo,erhi)
+    return ratio
+
+def makeUncorrDiff(gr1,gr2):
+    diff = ROOT.TGraphAsymmErrors(gr1.GetN())
+    diff.SetName('graph_diff')
+    for p in xrange(gr1.GetN()):
+        x = ROOT.Double(0); y1 = ROOT.Double(0); y2 = ROOT.Double(0);
+        gr2.GetPoint(p,x,y2); gr1.GetPoint(p,x,y1)
+        diff = gr2-gr1; 
+        # consider el and mu mostly uncorrelated (since dominated by the MC stat)
+        erhi = math.hypot(gr1.GetErrorYhigh(p),gr2.GetErrorYhigh(p)); erlo=erhi
+        diff.SetPoint(p,x,r)
+        diff.SetPointError(p,gr1.GetErrorXlow(p),gr1.GetErrorXhigh(p),erlo,erhi)
+    return diff
+
+def makeFullLegend(values):
+    legs = []
+    # expected values
+    legExp = ROOT.TLegend(0.15, 0.80, 0.90, 0.90)
+    legExp.SetFillStyle(0)
+    legExp.SetBorderSize(0)
+    legExp.AddEntry(values[('lep','left')] .graph     , '#sigma_{L} (Theory)', 'f')
+    legExp.AddEntry(values[('lep','right')].graph     , '#sigma_{R} (Theory)', 'f')
+    legs.append(legExp)
+    # data Left
+    legLeft = ROOT.TLegend(0.15, 0.60, 0.90, 0.80)
+    legLeft.SetFillStyle(0)
+    legLeft.SetBorderSize(0)
+    legLeft.AddEntry(values[('mu','left')] .graph_fit     , ' ', 'p')
+    legLeft.AddEntry(values[('el','left')].graph_fit     , ' ', 'p')
+    legLeft.AddEntry(values[('lep','left')].graph_fit     , ' ', 'p')
+    legs.append(legLeft)
+    # data Right
+    legRight = ROOT.TLegend(0.25, 0.60, 0.90, 0.80)
+    legRight.SetFillStyle(0)
+    legRight.SetBorderSize(0)
+    legRight.AddEntry(values[('mu','right')] .graph_fit     , 'data #mu', 'p')
+    legRight.AddEntry(values[('el','right')].graph_fit     , 'data e', 'p')
+    legRight.AddEntry(values[('lep','right')].graph_fit     , 'data comb', 'p')
+    legs.append(legRight)
+    return legs
+
+def plotValues(values,charge,channel,options):
+        c2 = ROOT.TCanvas('foo','', 800, 1600)
+        c2.SetLeftMargin(0.05)
+        c2.SetRightMargin(1)
+        leftMargin = 0.1
+        rightMargin = 1.
+        subpadsYLow = [0.5, 0.38, 0.26, 0.14, 0.02]
+        subpadsYUp = [0.99, 0.5, 0.38, 0.26, 0.14]
+        pads = []
+        for ip in xrange(len(subpadsYLow)):
+            pad = ROOT.TPad("pad{ip}".format(ip=ip),"",leftMargin,subpadsYLow[ip],rightMargin,subpadsYUp[ip])
+            pads.append(pad)
+
+        flavors = ['mu','el','lep']; polarizations = ['left','right','long']
+        ch = '#plus' if charge == 'plus' else '#minus'
+        if charge == 'asymmetry': ch = ''
+        date = datetime.date.today().isoformat()
+        normstr = 'norm' if (options.normxsec and charge!='asymmetry') else ''
+
+        applyChannelStyles(values)
+
+        lat = ROOT.TLatex()
+        lat.SetNDC(); lat.SetTextFont(42)
+        ## the four graphs exist now. now starting to draw them
+        ## ===========================================================
+        if sum(hasattr(values[(flav,pol)],'graph') and hasattr(values[(flav,pol)],'graph_fit') for pol in polarizations for flav in flavors)==9:
+            c2.cd()
+            pads[0].Draw(); pads[0].cd(); ROOT.gPad.SetBottomMargin(0);
+
+            values[('lep','left')].graph.SetTitle('W {ch}: Y_{{W}}'.format(ch=ch))
+                
+            mg = ROOT.TMultiGraph()
+            mg.Add(values[('lep','left')] .graph,'P2')
+            mg.Add(values[('lep','right')].graph,'P2')
+            if not options.nolong: mg.Add(values['lep','long'] .graph,'P2')
+            for flav in flavors:
+                mg.Add(values[(flav,'left')] .graph_fit)
+                mg.Add(values[(flav,'right')].graph_fit)
+                if not options.nolong: mg.Add(values[(flav,'long')] .graph_fit)
+     
+            mg.Draw('Pa')
+            mg.GetXaxis().SetRangeUser(0., options.maxRapidity) # max would be 6.
+            mg.GetXaxis().SetTitle('|Y_{W}|')
+            mg.GetXaxis().SetLabelSize(0)
+            if charge=='asymmetry':
+                mg.GetYaxis().SetTitle('Charge asymmetry')
+                mg.GetYaxis().SetRangeUser(-0.1,0.4)
+            else:
+                if options.normxsec: 
+                    mg.GetYaxis().SetTitle('#frac{d#sigma}{#sigma_{tot}^{fit}} / d|Y_{W}|')
+                    mg.GetYaxis().SetRangeUser(-0.05,0.8 if options.maxRapidity > 2.9 else 0.4)
+                else: 
+                    mg.GetYaxis().SetTitle('d#sigma (pb) / d|Y_{W}|')
+                    mg.GetYaxis().SetRangeUser(-200,3500)
+            mg.GetYaxis().SetTitleSize(0.05)
+            mg.GetYaxis().SetLabelSize(0.04)
+            mg.GetYaxis().SetTitleOffset(1.5)
+
+            legs = makeFullLegend(values)     
+            for leg in legs:
+                leg.Draw("same")
+
+        lines = {}
+        if sum(hasattr(values[(flav,pol)],'mg') for pol in polarizations for flav in flavors)==9:
+
+            ## now make the relative error plot for combination:
+            ## ======================================
+            isubpad=1
+            for ipol,pol in enumerate(['left','right']):
+                c2.cd()
+                pads[isubpad].Draw(); pads[isubpad].cd(); ROOT.gPad.SetBottomMargin(0); ROOT.gPad.SetTopMargin(0)
+
+                if charge=='asymmetry':
+                    yaxtitle = 'A_{Theory}-A_{Data}'
+                    yaxrange = (-0.1, 0.1)
+                else:
+                    yaxtitle = '#sigma_{Theory}/#sigma_{Data}'
+                    yaxrange = (0.82, 1.18)
+     
+                values[('lep',pol)].graph_rel.Draw("A2")
+                values[('lep',pol)].graph_fit_rel.Draw("2")
+                values[('lep',pol)].graph_fit_rel.Draw("P")
+                ## x axis fiddling
+                values[('lep',pol)].graph_rel.GetXaxis().SetRangeUser(0., options.maxRapidity)
+                values[('lep',pol)].graph_rel.GetXaxis().SetLabelSize(0.04)
+                ## y axis fiddling
+                values[('lep',pol)].graph_rel.GetYaxis().SetTitleOffset(0.4)
+                values[('lep',pol)].graph_rel.GetYaxis().SetTitleSize(0.18)
+                values[('lep',pol)].graph_rel.GetYaxis().SetLabelSize(0.12)
+                values[('lep',pol)].graph_rel.GetYaxis().SetTitle(yaxtitle)
+                values[('lep',pol)].graph_rel.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
+                values[('lep',pol)].graph_rel.GetYaxis().CenterTitle()
+
+                lines["horiz_line_comb"+pol] = ROOT.TF1("horiz_line_comb"+pol,"0" if charge=='asymmetry' else '1',0.0,3.0);
+                lines["horiz_line_comb"+pol].SetLineColor(ROOT.kRed);
+                lines["horiz_line_comb"+pol].SetLineWidth(2);
+                lines["horiz_line_comb"+pol].SetLineStyle(ROOT.kDashed);
+                lines["horiz_line_comb"+pol].Draw("Lsame");
+
+                isubpad+=1
+
+            # now the compatibility plots
+            comps = {}
+            for ipol,pol in enumerate(['left','right']):
+                c2.cd()
+                print "SUB PAD ",isubpad," printing ",pol
+                pads[isubpad].Draw(); pads[isubpad].cd(); ROOT.gPad.SetTopMargin(0)
+                if isubpad<4: ROOT.gPad.SetBottomMargin(0)
+
+                if charge=='asymmetry':
+                    yaxtitle = 'A_{#mu}-A_{e}'
+                    yaxrange = (-0.1, 0.1)
+                    comps["comp_"+pol] = makeUncorrDiff(values[('el',pol)].graph_fit, values[('mu',pol)].graph_fit)
+                else:
+                    yaxtitle = '#sigma_{#mu}/#sigma_{e}'
+                    yaxrange = (0.65, 1.35)
+                    comps["comp_"+pol] = makeUncorrRatio(values[('el',pol)].graph_fit, values[('mu',pol)].graph_fit)
+                comps["comp_"+pol].SetName("comp_"+pol); comps["comp_"+pol].SetTitle("")
+                comps["comp_"+pol].SetMarkerColor(values[('mu',pol)].color)
+                comps["comp_"+pol].SetLineColor(values[('mu',pol)].color)
+                comps["comp_"+pol].SetFillColor(values[('mu',pol)].color)
+                comps["comp_"+pol].SetMarkerStyle(ROOT.kFullTriangleUp)
+                comps["comp_"+pol].SetMarkerSize(2)
+
+                comps["comp_"+pol].Draw('Pa')
+                ## x axis fiddling
+                comps["comp_"+pol].GetXaxis().SetRangeUser(0., options.maxRapidity)
+                comps["comp_"+pol].GetXaxis().SetLabelSize(0.04)
+                ## y axis fiddling
+                comps["comp_"+pol].GetYaxis().SetTitleOffset(0.4)
+                comps["comp_"+pol].GetYaxis().SetTitleSize(0.18)
+                comps["comp_"+pol].GetYaxis().SetLabelSize(0.12)
+                comps["comp_"+pol].GetYaxis().SetTitle(yaxtitle)
+                comps["comp_"+pol].GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
+                comps["comp_"+pol].GetYaxis().CenterTitle()
+                if isubpad==4:
+                    comps["comp_"+pol].GetXaxis().SetLabelSize(0.12)
+                    comps["comp_"+pol].GetXaxis().SetTitleSize(0.2)
+                    comps["comp_"+pol].GetXaxis().SetTitleOffset(0.4)
+                    comps["comp_"+pol].GetXaxis().SetTitle("|Y_{W}|")
+                lines["horiz_line_comp_"+pol] = ROOT.TF1("horiz_line_comp_"+pol,"0" if charge=='asymmetry' else '1',0.0,3.0);
+                lines["horiz_line_comp_"+pol].SetLineColor(ROOT.kRed);
+                lines["horiz_line_comp_"+pol].SetLineWidth(2);
+                lines["horiz_line_comp_"+pol].SetLineStyle(ROOT.kDashed);
+                lines["horiz_line_comp_"+pol].Draw("Lsame");
+                isubpad+=1
+
+        c2.cd()
+        lat.DrawLatex(0.2, 0.95, '#bf{CMS} #it{Preliminary}')
+        lat.DrawLatex(0.62, 0.95, '35.9 fb^{-1} (13 TeV)')
+        lat.DrawLatex(0.25, 0.60,  'W^{{{ch}}} #rightarrow l^{{{ch}}}{nu}'.format(ch=ch,nu="#bar{#nu}" if charge=='minus' else "#nu"))
+        #lat.DrawLatex(0.90, 0.03, '|Y_{W}|')
+        for ext in ['png', 'pdf']:
+            c2.SaveAs('{od}/genAbsY{norm}_pdfs_{ch}{suffix}.{ext}'.format(od=options.outdir, norm=normstr, ch=charge, suffix=options.suffix, ext=ext))
+
+
+def plotUnpolarizedValues(values,charge,channel,options):
+        c2 = ROOT.TCanvas('foo','', 800, 800)
+        c2.GetPad(0).SetTopMargin(0.09)
+        c2.GetPad(0).SetBottomMargin(0.35)
+        c2.GetPad(0).SetLeftMargin(0.15)
+        c2.GetPad(0).SetRightMargin(0.04)
+        c2.GetPad(0).SetTickx(1)
+        c2.GetPad(0).SetTicky(1)
+
+        ch = '#plus' if charge == 'plus' else '#minus'
+        if charge == 'asymmetry': ch = ''
+        date = datetime.date.today().isoformat()
+        if 'values_a0' in values.name: normstr = 'A0'
+        elif 'values_a4' in values.name: normstr = 'A4'
+        elif 'values_sumxsec' in values.name: normstr = 'xsec'
+        else: normstr = 'norm' if (options.normxsec and charge!='asymmetry') else ''
+
+        lat = ROOT.TLatex()
+        lat.SetNDC(); lat.SetTextFont(42)
+        legx1, legx2, legy1, legy2 = 0.2, 0.5, 0.7, 0.85
+        ## the graphs exist now. now starting to draw them
+        ## ===========================================================
+        if hasattr(values,'graph') and hasattr(values,'graph_fit'):
+                
+            mg = ROOT.TMultiGraph()
+            mg.Add(values.graph,'P2')
+            mg.Add(values.graph_fit)
+            mg.Draw('Pa')
+            mg.GetXaxis().SetRangeUser(0., options.maxRapidity) # max would be 6.
+            mg.GetXaxis().SetTitle('|Y_{W}|')
+            mg.GetXaxis().SetTitleOffset(5.5)
+            mg.GetXaxis().SetLabelSize(0)
+            if charge=='asymmetry':
+                 mg.GetYaxis().SetTitle('Charge asymmetry')
+                 mg.GetYaxis().SetRangeUser(-0.1,0.4)
+            else:
+                if normstr=='xsec':
+                    if options.normxsec: 
+                        mg.GetYaxis().SetTitle('#frac{d#sigma}{#sigma_{tot}^{fit}} / d|Y_{W}|')
+                        mg.GetYaxis().SetRangeUser(-0.05,0.8 if options.maxRapidity > 2.7 else 0.4)
+                    else: 
+                        mg.GetYaxis().SetTitle('d#sigma (pb) / d|Y_{W}|')
+                        mg.GetYaxis().SetRangeUser(1500,4500)
+                else:
+                    mg.GetYaxis().SetRangeUser(-0.05 if normstr=='A0' else -1,0.4 if normstr=='A0' else 2)
+                    mg.GetYaxis().SetTitle('|A_{0}|' if normstr=='A0' else '|A_{4}|')
+            mg.GetYaxis().SetTitleSize(0.06)
+            mg.GetYaxis().SetLabelSize(0.04)
+            mg.GetYaxis().SetTitleOffset(1.)
+     
+            leg = ROOT.TLegend(legx1, legy1, legx2, legy2)
+            leg.SetFillStyle(0)
+            leg.SetBorderSize(0)
+            leg.AddEntry(values.graph_fit , 'data', 'pl')
+            leg.AddEntry(values.graph     , REFMC, 'f')
+
+            leg.Draw('same')
+            lat.DrawLatex(0.16, 0.92, '#bf{CMS} #it{Preliminary}')
+            lat.DrawLatex(0.62, 0.92, '35.9 fb^{-1} (13 TeV)')
+            lat.DrawLatex(0.20, 0.50,  'W^{{{ch}}} #rightarrow {lep}^{{{ch}}}{nu}'.format(ch=ch,lep="#mu" if channel == "mu" else "e",nu="#bar{#nu}" if charge=='minus' else "#nu"))
+     
+
+        ## now make the relative error plot:
+        ## ======================================
+        if hasattr(values,'mg'):
+
+            pad2 = ROOT.TPad("pad2","pad2",0,0.,1,0.9)
+            pad2.SetTopMargin(0.65)
+            pad2.SetRightMargin(0.04)
+            pad2.SetLeftMargin(0.15)
+            pad2.SetFillColor(0)
+            pad2.SetGridy(0)
+            pad2.SetFillStyle(0)
+            pad2.SetTicky(1)
+
+            pad2.Draw()
+            pad2.cd()
+
+            line = ROOT.TF1("horiz_line","0" if charge=='asymmetry' else '1',0.0,3.0);
+            line.SetLineColor(ROOT.kBlack);
+            line.SetLineWidth(2);
+            yaxrange = (0,0)
+            if charge=='asymmetry':
+                yaxtitle = 'A_{Theory}-A_{Data}'
+                yaxrange = (-0.2, 0.2)
+            else:
+                yaxtitle = '#sigma_{Theory}/#sigma_{Data}'
+                yaxrange = (0.70, 1.30) if normstr=='xsec' else (-1.5, 3.5)
+
+            values.mg.Draw('Pa')
+            ## x axis fiddling
+            values.mg.GetXaxis().SetTitle('|Y_{W}|')
+            values.mg.GetXaxis().SetTitleOffset(1.)
+            values.mg.GetXaxis().SetRangeUser(0., options.maxRapidity)
+            values.mg.GetXaxis().SetTitleSize(0.1)
+            values.mg.GetXaxis().SetLabelSize(0.04)
+            ## y axis fiddling
+            values.mg.GetYaxis().SetTitleOffset(1.2)
+            values.mg.GetYaxis().SetTitleSize(0.06)
+            values.mg.GetYaxis().SetLabelSize(0.04)
+            values.mg.GetYaxis().SetTitle(yaxtitle)
+            values.mg.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
+            values.mg.GetYaxis().SetNdivisions(5)
+            values.mg.GetYaxis().CenterTitle()
+
+            line.Draw("Lsame");
+
+        for ext in ['png', 'pdf']:
+            c2.SaveAs('{od}/genAbsYUnpolarized{norm}_pdfs_{ch}{suffix}.{ext}'.format(od=options.outdir, norm=normstr, ch=charge, suffix=options.suffix, ext=ext))
+
+
+NPDFs = 60
+LUMINOSITY = 36000
+
+if __name__ == "__main__":
+
+    from optparse import OptionParser
+    parser = OptionParser(usage='%prog ybinfile workspace.root toys.root [options] ')
+    parser.add_option(      '--infile-mu'   , dest='infileMu' , default=''            , type='string', help='fitresults file with muon results')
+    parser.add_option(      '--infile-el'   , dest='infileEl' , default=''            , type='string', help='fitresults file with electron results')
+    parser.add_option(      '--infile-lep'  , dest='infileLep', default=''            , type='string', help='fitresults file with muon,electron combination results')
+    parser.add_option('-y', '--ybinfile'    , dest='ybinfile' , default=''            , type='string', help='file with the yw binning')
+    parser.add_option(      '--xsecfiles'    , dest='xsecfiles' , default=None          , type='string', help='files that contains the expected x sections with variations (one per charge,comma separated in the same order of the charges) ')
+    parser.add_option('-C', '--charge'      , dest='charge'   , default='plus,minus'  , type='string', help='process given charge. default is both')
+    parser.add_option('-o', '--outdir'      , dest='outdir'   , default='.'           , type='string', help='outdput directory to save the plots')
+    parser.add_option(      '--suffix'      , dest='suffix'   , default=''            , type='string', help='suffix for the correlation matrix')
+    parser.add_option('-n', '--normxsec'    , dest='normxsec' , default=False         , action='store_true',   help='if given, plot the differential xsecs normalized to the total xsec')
+    parser.add_option(      '--nolong'      , dest='nolong'   , default=False         , action='store_true',   help='if given, do not plot longitudinal component')
+    parser.add_option(      '--max-rap'     , dest='maxRapidity', default='2.75'       , type='float', help='Max value for rapidity range')
+    (options, args) = parser.parse_args()
+
+
+    if not os.path.isdir(options.outdir):
+        os.system('mkdir {od}'.format(od=options.outdir))
+        if os.path.exists("/afs/cern.ch"): os.system("cp /afs/cern.ch/user/g/gpetrucc/php/index.php {od}".format(od=options.outdir))
+
+    if options.ybinfile:
+        ybinfile = options.ybinfile
+    else:
+        ybinfile = os.path.dirname(os.path.abspath(options.infile))+'/binningYW.txt'
+
+
+    ## get the central values and uncertainties (only Hessian implemented)
+    valuesAndErrors = {}
+    valuesAndErrors['mu'] = utilities.getFromHessian(options.infileMu)
+    valuesAndErrors['el'] = utilities.getFromHessian(options.infileEl)
+    valuesAndErrors['lep'] = utilities.getFromHessian(options.infileLep)
+
+    ybinfile = open(ybinfile, 'r')
+    ybins = eval(ybinfile.read())
+    ybinfile.close()
+
+    ## calculate the bin widths for the rapidity bins
+    ybinwidths = {}
+    for k,v in ybins.items():
+        tmplist = list(abs(i - v[v.index(i)+1]) for i in v[:-1])
+        ybinwidths[k] = [float('{n:.2f}'.format(n=i)) for i in tmplist]
+
+    charges = options.charge.split(',')
+    xsecfiles = options.xsecfiles.split(',')
+    xsec_nominal_allCharges = {}; xsec_systematics_allCharges = {}
+    polarizations = ['left','right', 'long']
+    flavors = ['mu','el','lep']
+
+    nChan = 2
+    channel = 'lep'
+
+    for ic,charge in enumerate(charges):
+
+        sign = 1. if charge=='plus' else -1.
+
+        ## this gets the pdf central variation binned in the correct format
+        xsec_nominal = utilities.getXSecFromShapes(ybins,charge,xsecfiles[ic],0,nChan)
+        xsec_nominal_allCharges[charge] = xsec_nominal
+
+        value_syst = {}
+        for pol in polarizations:
+            histos = []
+            values = []
+            for ip in xrange(1,NPDFs+1):
+                # print "Loading polarization %s, histograms for pdf %d" % (pol,ip)
+                ## this gets the pdf variations after correctly rebinning the YW
+                xsec_pdf = utilities.getXSecFromShapes(ybins,charge,xsecfiles[ic],ip,nChan)
+                values.append(xsec_pdf[pol])
+            value_syst[pol] = values
+
+        xsec_systematics = {}
+        for pol in polarizations:
+            #print "===> Running pol = ",pol
+            xsec_systs=[]
+            for iy,y in enumerate(ybinwidths['{ch}_{pol}'.format(ch=charge,pol=pol if not pol=='long' else 'right')]):
+                xsec_nom = xsec_nominal[pol][iy]
+                #print "\tBin iy={iy},y={y}. Nom = {nom} ".format(iy=iy,y=y,nom=nom)
+                totUp=0; xsec_totUp=0
+                for ip,pdf in enumerate(value_syst[pol]):
+                    xsec_pdf = value_syst[pol][ip]
+                    #print "\tip = {ip}  pdf = {pdf}".format(ip=ip,pdf=pdf[iy])
+                    # debug
+                    xsec_relsyst = abs(xsec_nom-xsec_pdf[iy])/xsec_nom if xsec_nom else 0.0
+                    if xsec_relsyst>0.20:
+                        print "SOMETHING WENT WRONG WITH THIS PDF: %d HAS RELATIVE SYST = %f. SKIPPING !" % (ip,relsyst)
+                    else:
+                        xsec_totUp += math.pow(xsec_relsyst*xsec_nom,2)
+                xsec_totUp = math.sqrt(xsec_totUp)
+                # print "Rel systematic for Y bin %d = +/-%.3f" % (iy,totUp/nom)
+                # print "\tRel systematic on xsec for Y bin %d = +/-%.3f" % (iy,xsec_totUp/xsec_nom if xsec_nom else 0.)
+                xsec_systs.append(xsec_totUp)
+            xsec_systematics[pol]=xsec_systs
+        xsec_systematics_allCharges[charge] = xsec_systematics
+
+        angcoeff_nominal = {'sumxsec': [], 'a0': [], 'a4': []}
+        angcoeff_systematics = {'sumxsec': [], 'a0': [], 'a4': []}
+        for  iy,y in enumerate(ybinwidths['{ch}_{pol}'.format(ch=charge,pol=pol if not pol=='long' else 'right')]):
+            xsec_unpolarized_nominal_iy = sum([xsec_nominal[pol][iy] for pol in polarizations])
+            angcoeff_nominal['sumxsec'].append(xsec_unpolarized_nominal_iy)
+
+            coeffs_val = utilities.getCoeffs(xsec_nominal['left'][iy],     xsec_nominal['right'][iy],     xsec_nominal['long'][iy],
+                                             xsec_systematics['left'][iy], xsec_systematics['right'][iy], xsec_systematics['long'][iy])
+
+            angcoeff_nominal['a0'].append(coeffs_val['a0'][0])
+            angcoeff_nominal['a4'].append(sign*coeffs_val['a4'][0])
+
+            xsec_unpolarized_iy = sum([xsec_systematics[pol][iy] for pol in polarizations])
+            angcoeff_systematics['sumxsec'].append(xsec_unpolarized_iy)
+            angcoeff_systematics['a0'].append(coeffs_val['a0'][1])
+            angcoeff_systematics['a4'].append(coeffs_val['a4'][1])
+
+        nOuterBinsToExclude = 1  ### EDM hardcoded: out of acceptance Y bins
+
+        allValues = {}
+        normsigmaInFit = {}; normsigmaOutFit = {}
+        for flav in flavors:
+            nChan = 2 if flav=='lep' else 1
+            print "FLAV = ",flav
+            for pol in polarizations:
+                cp = '{ch}_{pol}'.format(ch=charge,pol=pol)
+                MAXYFORNORM = ybins[cp][-nOuterBinsToExclude-1] # exclude the outermost 2 bins which has huge error due to acceptance
+                normsigmaIn = sum([xsec_nominal[allpol][iy] for allpol in polarizations for iy,y in enumerate(ybins[cp][:-1]) if abs(y)<MAXYFORNORM])
+                normsigmaOut = sum([xsec_nominal[allpol][iy] for allpol in polarizations for iy,y in enumerate(ybins[cp][:-1]) if abs(y)>=MAXYFORNORM])
+                normsigmaInFit[flav] = sum([valuesAndErrors[flav]['W{charge}_{pol}_Ybin_{iy}_pmaskedexp'.format(charge=charge,pol=allpol,iy=iy)][0]/LUMINOSITY for allpol in polarizations for iy,y in enumerate(ybins[cp][:-1]) if abs(y)<MAXYFORNORM])/float(nChan)
+                normsigmaOutFit[flav] = sum([valuesAndErrors[flav]['W{charge}_{pol}_Ybin_{iy}_pmaskedexp'.format(charge=charge,pol=allpol,iy=iy)][0]/LUMINOSITY for allpol in polarizations for iy,y in enumerate(ybins[cp][:-1]) if abs(y)>=MAXYFORNORM])/float(nChan)
+     
+                print "total expected (fit for {flav}) xsec up to |Y|<{maxy} = {sigma:.3f} ({fit:.3f}) pb".format(flav=flav,maxy=MAXYFORNORM,sigma=normsigmaIn,fit=normsigmaInFit[flav])
+                print "total expected (fit for {flav}) xsec beyond |Y|>{maxy} = {sigma:.3f} ({fit:.3f}) pb".format(flav=flav,maxy=MAXYFORNORM,sigma=normsigmaOut,fit=normsigmaOutFit[flav])
+     
+                tmp_val = valueClass('values_'+charge+'_'+pol+'_'+flav)
+     
+                for iy,y in enumerate(ybinwidths['{ch}_{pol}'.format(ch=charge,pol=pol)]):
+                    normsigma = normsigmaInFit if abs(ybins[cp][iy])<MAXYFORNORM else normsigmaOutFit
+                    parname = 'W{charge}_{pol}_Ybin_{iy}'.format(charge=charge,pol=pol,iy=iy)
+     
+                    scale = 1.
+                    if options.normxsec:
+                        xsec_fit = [x/float(nChan) for x in valuesAndErrors[flav][parname+'_pmaskedexpnorm']]
+                    else:
+                        xsec_fit = [x/float(nChan) for x in valuesAndErrors[flav][parname+'_pmaskedexp']]
+                        scale = LUMINOSITY
+     
+                    if options.normxsec:
+                        rfit     = xsec_nominal[pol][iy]/normsigma/xsec_fit[0]
+                    else:
+                        rfit     = xsec_nominal[pol][iy]/xsec_fit[0]*scale
+                    rfit_err = rfit*abs(xsec_fit[0]-xsec_fit[1])/xsec_fit[0] 
+     
+                    tmp_val.val.append(xsec_nominal[pol][iy]/ybinwidths[cp][iy])
+                    tmp_val.ehi.append(xsec_systematics[pol][iy]/ybinwidths[cp][iy])
+                    tmp_val.elo.append(xsec_systematics[pol][iy]/ybinwidths[cp][iy]) # symmetric for the expected
+                    if options.normxsec:
+                        tmp_val.val[-1] = tmp_val.val[-1]/normsigma
+                        tmp_val.ehi[-1] = tmp_val.ehi[-1]/normsigma
+                        tmp_val.elo[-1] = tmp_val.elo[-1]/normsigma
+     
+                    tmp_val.relv. append(rfit);
+                    tmp_val.rello.append(xsec_systematics[pol][iy]/xsec_nominal[pol][iy])
+                    tmp_val.relhi.append(xsec_systematics[pol][iy]/xsec_nominal[pol][iy]) # symmetric for the expected
+                    
+                    tmp_val.val_fit.append(xsec_fit[0]/ybinwidths[cp][iy]/scale)
+                    tmp_val.elo_fit.append(abs(xsec_fit[0]-xsec_fit[1])/ybinwidths[cp][iy]/scale)
+                    tmp_val.ehi_fit.append(abs(xsec_fit[0]-xsec_fit[2])/ybinwidths[cp][iy]/scale)
+     
+                    units = '' if options.normxsec else '(pb)'
+                    print "par = {parname}, expected sigma = {sigma:.3f} {units}   fitted = {val:.3f} + {ehi:.3f} - {elo:.3f} {units}".format(parname=parname,
+                                                                                                                                              sigma=tmp_val.val[-1],units=units,
+                                                                                                                                              val=tmp_val.val_fit[-1],ehi=tmp_val.ehi_fit[-1],elo=tmp_val.elo_fit[-1])
+     
+                    tmp_val.relv_fit .append(1.)
+                    tmp_val.rello_fit.append(rfit_err)
+                    tmp_val.relhi_fit.append(rfit_err)
+     
+                    tmp_val.rap.append((ybins[cp][iy]+ybins[cp][iy+1])/2.)
+                    tmp_val.rlo.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+                    tmp_val.rhi.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+     
+                tmp_val.makeGraphs()
+     
+                allValues[(flav,pol)] = tmp_val
+
+        plotValues(allValues,charge,channel,options)
+        print "DEBUG DONE. EXIT."; exit(0)
+
+        if not options.normxsec: # this is only implemented for absolute xsecs
+            # now do the unpolarized ones
+            cp = 'plus_left' # this works if the binning for all the pol is the same
+            xsec_params = ['sumxsec','a0','a4']
+            for xs in xsec_params:
+                tmp_val = valueClass('values_{xs}_{charge}_unpolarized'.format(xs=xs,charge=charge))
+                for iy,y in enumerate(ybinwidths['{ch}_{pol}'.format(ch=charge,pol=pol)]):
+                    parname = 'W{charge}_Ybin_{iy}_{xs}'.format(charge=charge,iy=iy,xs=xs)
+                    if xs=='sumxsec':
+                        ybinwidth_scale = ybinwidths[cp][iy]
+                        scale = LUMINOSITY
+                    else:
+                        ybinwidth_scale = 1.
+                        scale = 1.
+
+                    tmp_val.val.append(abs(angcoeff_nominal[xs][iy]/ybinwidth_scale))
+                    experr = angcoeff_systematics[xs][iy]/ybinwidth_scale
+                    tmp_val.ehi.append(experr)
+                    tmp_val.elo.append(experr) # symmetric for the expected
+         
+                    xsec_fit = valuesAndErrors[parname]
+                    scale = LUMINOSITY*float(nChan) if xs=='sumxsec' else 1.
+         
+                    tmp_val.val_fit.append(xsec_fit[0]/ybinwidth_scale/scale)
+                    tmp_val.elo_fit.append(abs(xsec_fit[0]-xsec_fit[1])/ybinwidth_scale/scale)
+                    tmp_val.ehi_fit.append(abs(xsec_fit[0]-xsec_fit[2])/ybinwidth_scale/scale)
+
+                    tmp_val.relv. append(tmp_val.val[-1]/tmp_val.val_fit[-1])
+                    experrrel = angcoeff_systematics[xs][iy]/angcoeff_nominal[xs][iy]
+                    tmp_val.rello.append(experrrel)
+                    tmp_val.relhi.append(experrrel) # symmetric for the expected
+                    
+                    units = '(pb)' if xs=='sumxsec' else ''
+                    print "par = {parname}, expected value = {sigma:.3f} {units}   fitted = {val:.3f} + {ehi:.3f} - {elo:.3f} {units}".format(parname=parname, sigma=tmp_val.val[-1],units=units,
+                                                                                                                                              val=tmp_val.val_fit[-1],ehi=tmp_val.ehi_fit[-1],elo=tmp_val.elo_fit[-1])
+                    tmp_val.relv_fit .append(1.)
+                    tmp_val.rello_fit.append(tmp_val.elo_fit[-1]/tmp_val.val_fit[-1])
+                    tmp_val.relhi_fit.append(tmp_val.ehi_fit[-1]/tmp_val.val_fit[-1])
+         
+                    tmp_val.rap.append((ybins[cp][iy]+ybins[cp][iy+1])/2.)
+                    tmp_val.rlo.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+                    tmp_val.rhi.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+         
+                tmp_val.makeGraphs()
+                plotUnpolarizedValues(tmp_val,charge,channel,options)
+
+
+    if len(charges)>1:
+        print "Making charge asymmetry plots now..."
+        asymmetryValues = {}
+        
+        for pol in polarizations:
+            cp = 'plus_'+pol
+            tmp_val = valueClass('asymmetry_'+pol)
+            for iy,y in enumerate(ybinwidths[cp]):
+                chasy_val = utilities.getChargeAsy(xsec_nominal_allCharges['plus'][pol][iy],     xsec_nominal_allCharges['minus'][pol][iy],
+                                                   xsec_systematics_allCharges['plus'][pol][iy], xsec_systematics_allCharges['minus'][pol][iy])
+                tmp_val.val .append(chasy_val['asy'][0])
+                tmp_val.ehi.append(chasy_val['asy'][1])
+                tmp_val.elo.append(chasy_val['asy'][1])
+
+                asy_fit = valuesAndErrors['W_{pol}_Ybin_{iy}_chargeasym'.format(pol=pol,iy=iy)]
+                tmp_val.val_fit .append(asy_fit[0])
+                tmp_val.elo_fit.append(abs(asy_fit[0]-asy_fit[1]))
+                tmp_val.ehi_fit.append(abs(asy_fit[0]-asy_fit[2]))
+
+                # on the charge asymmetry, which is A~0, better to show the difference 
+                # Afit - Aexp wrt the ratio. The error on "exp" diff shows the error on Aexp, while the error bar the error on Afit
+                tmp_val.relv. append(tmp_val.val[-1] - tmp_val.val_fit[-1])
+                tmp_val.rello.append(chasy_val['asy'][1])
+                tmp_val.relhi.append(chasy_val['asy'][1])
+
+                tmp_val.relv_fit .append(0.)
+                tmp_val.rello_fit.append(tmp_val.elo_fit[-1])
+                tmp_val.relhi_fit.append(tmp_val.ehi_fit[-1])
+
+                tmp_val.rap.append((ybins[cp][iy]+ybins[cp][iy+1])/2.)
+                tmp_val.rlo.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+                tmp_val.rhi.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+
+            tmp_val.makeGraphs()
+            asymmetryValues[pol] = tmp_val        
+        plotValues(asymmetryValues,'asymmetry',channel,options)
+            
+        # now do the unpolarized ones
+        tmp_val = valueClass('asymmetry_unpolarized')
+        for iy,y in enumerate(ybinwidths['plus_left']): # this assumes that all the 3 polarizations have the same binning
+            xval = {'plus': 0, 'minus': 0}; xerr = {'plus': 0, 'minus': 0}
+            for charge in ['plus','minus']:
+                for pol in polarizations:
+                    xval[charge] += xsec_nominal_allCharges[charge][pol][iy]
+                    xerr[charge] += pow(xsec_systematics_allCharges[charge][pol][iy],2)
+                xerr[charge] = math.sqrt(xerr[charge])
+
+            chasy_val = utilities.getChargeAsy(xval['plus'], xval['minus'],
+                                               xerr['plus'], xerr['minus'])
+            
+            tmp_val.val .append(chasy_val['asy'][0])
+            tmp_val.ehi.append(chasy_val['asy'][1])
+            tmp_val.elo.append(chasy_val['asy'][1])
+
+            asy_fit = valuesAndErrors['W_Ybin_{iy}_chargemetaasym'.format(iy=iy)]
+            tmp_val.val_fit .append(asy_fit[0])
+            tmp_val.elo_fit.append(abs(asy_fit[0]-asy_fit[1]))
+            tmp_val.ehi_fit.append(abs(asy_fit[0]-asy_fit[2]))
+
+            tmp_val.relv. append(tmp_val.val[-1] - tmp_val.val_fit[-1])
+            tmp_val.rello.append(chasy_val['asy'][1])
+            tmp_val.relhi.append(chasy_val['asy'][1])
+
+            tmp_val.relv_fit .append(0.)
+            tmp_val.rello_fit.append(tmp_val.elo_fit[-1])
+            tmp_val.relhi_fit.append(tmp_val.ehi_fit[-1])
+
+            tmp_val.rap.append((ybins[cp][iy]+ybins[cp][iy+1])/2.)
+            tmp_val.rlo.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+            tmp_val.rhi.append(abs(ybins[cp][iy]-tmp_val.rap[-1]))
+
+        tmp_val.makeGraphs()
+        plotUnpolarizedValues(tmp_val,'asymmetry',channel,options)
+            


### PR DESCRIPTION
- plotYWCompatibility.py with a huge duplication of code from plotYW. 
- added to result plots. If in the results_config_lep there are xxx and xxx_el and xxx_mu it also runs the compatibility script.
Result plots make 
  * the single lepton flavor results
  * the combined results
  * the combined results, with the compatibility ratios (will be called _comp)

results like in [this link](https://emanuele.web.cern.ch/emanuele/Analysis/WMass/13TeV/plots/fit/absY/results/2019-03-25-testcomp2/rapiditySpectra/?match=exp0*comp)    