### PR TITLE
Some updates also for helicity

### DIFF
--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -4,11 +4,11 @@ import ROOT, os, sys, re, array
 
 dryrun=0
 doMuons=1
-skipUnpack=1
-skipMergeRoot=1
-skipSingleCard=1
-skipMergeCard=1
-skipMergeCardFlavour=0 # requires both flavours, and the electron cards must have all signal bins considered as signal
+skipUnpack=0
+skipMergeRoot=0
+skipSingleCard=0
+skipMergeCard=0
+skipMergeCardFlavour=1 # requires both flavours, and the electron cards must have all signal bins considered as signal
 
 allPtBinsSignalElectron = 1
 
@@ -30,9 +30,9 @@ uncorrelateFakesNuisancesByCharge = False # need to rerun the MergeRoot when cha
 
 optionsForRootMerger = " --etaBordersForFakesUncorr " + ("0.5,1.0,1.4,1.6,2.0 " if doMuons else "0.5,1.0,1.4,1.6,2.0 ")
 
-optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --tauChargeLnN 0.03 --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous'  " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta ### --uncorrelate-fakes-by-charge   # .*FakesPtNormUncorrelated.* --fakesChargeLnN 0.03
+optionsForCardMaker = " --unbinned-QCDscale-Z --sig-out-bkg  --tauChargeLnN 0.03 --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous'  " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta ### --uncorrelate-fakes-by-charge   # .*FakesPtNormUncorrelated.* --fakesChargeLnN 0.03
 
-optionsForCardMakerMerger = " --postfix combinedLep --useSciPyMinimizer " #--no-text2hdf5 --no-combinetf " 
+optionsForCardMakerMerger = " --postfix combinedLep --sig-out-bkg --useSciPyMinimizer " #--no-text2hdf5 --no-combinetf " 
 
 optionsForCardMakerMergerFlavour = " --postfix combinedLep --useSciPyMinimizer " # --no-text2hdf5 --no-combinetf "  
 

--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -5,17 +5,19 @@ import ROOT, os, sys, re, array
 dryrun=0
 doMuons=1
 skipUnpack=1
-skipMergeRoot=0
-skipSingleCard=0
-skipMergeCard=0
-skipMergeCardFlavour=1 # requires both flavours, and the electron cards must have all signal bins considered as signal
+skipMergeRoot=1
+skipSingleCard=1
+skipMergeCard=1
+skipMergeCardFlavour=0 # requires both flavours, and the electron cards must have all signal bins considered as signal
+
+allPtBinsSignalElectron = 1
 
 # el
 folder_el = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/" # keep "/" at the end
-th3file_el = "cards/" + folder_el + "wel_pt56_L1prefire.root"
+th3file_el = "cards/" + folder_el + "wel_pt56_L1prefire_fixEffStat.root"
 # mu
 folder_mu = "diffXsec_mu_2019_03_12_ptMax56_dressed/" # keep "/" at the end
-th3file_mu = "cards/" + folder_mu + "wmu_pt56_L1prefire.root"
+th3file_mu = "cards/" + folder_mu + "wmu_pt56_L1prefire_fixEffStat.root"
 
 folder = folder_mu if doMuons else folder_el
 th3file = th3file_mu if doMuons else th3file_el
@@ -26,7 +28,7 @@ uncorrelateFakesNuisancesByCharge = False # need to rerun the MergeRoot when cha
 #================================
 # some more things are set below
 
-optionsForRootMerger = " --etaBordersForFakesUncorr " + ("0.5,1.0,1.6,2.0 " if doMuons else "0.5,1.0,1.4,1.6,2.0 ")
+optionsForRootMerger = " --etaBordersForFakesUncorr " + ("0.5,1.0,1.4,1.6,2.0 " if doMuons else "0.5,1.0,1.4,1.6,2.0 ")
 
 optionsForCardMaker = " --unbinned-QCDscale-Z  --sig-out-bkg  --tauChargeLnN 0.03 --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous'  " # --wXsecLnN 0.038 # exclude ptslope for fakes, we use that one uncorrelated versus eta ### --uncorrelate-fakes-by-charge   # .*FakesPtNormUncorrelated.* --fakesChargeLnN 0.03
 
@@ -42,7 +44,8 @@ if uncorrelateFakesNuisancesByCharge:
 
 flavour = "mu" if doMuons else "el"
 if flavour == "el":
-    optionsForCardMaker = optionsForCardMaker  # + " --pt-range-bkg 25.9 30.1  " #--eta-range-bkg 1.39 1.61 "
+    # when creating cards for mu-el combination, all signal bins must be treated in the same way as for muons, so as signal
+    optionsForCardMaker = optionsForCardMaker  + (" --pt-range-bkg 25.9 30.1  " if not allPtBinsSignalElectron else "") #--eta-range-bkg 1.39 1.61 "
 
 charges = ["plus", "minus"]
 

--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -4,8 +4,8 @@ import ROOT, os, sys, re, array
 
 # to run plots from Asimov fit and data. For toys need to adapt this script
 
-doMuElComb = 1
-dryrun = 0
+doMuElComb = 0
+dryrun = 1
 skipData = 1
 onlyData = 0
 
@@ -16,15 +16,17 @@ skipPostfit = 1  # only for Data
 skipCorr = 1
 skipImpacts = 1
 
+allPtBinsSignalElectron = 1
 
 seed = 123456789
 
-folder = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/"
-#folder = "diffXsec_mu_2019_03_12_ptMax56_dressed/"
+#folder = "diffXsec_el_2019_03_14_ptMax56_dressed_FRpol2Above48GeV/"
+folder = "diffXsec_mu_2019_03_12_ptMax56_dressed/"
 if doMuElComb:
     folder = "muElCombination"
 
-postfix = "corrNuisFakes_addEtaChargeUncorr0p02"
+#postfix = "corrNuisFakes_addEtaChargeUncorr0p02"
+postfix = "combinedLep"
 if doMuElComb:
     postfix = "combinedLep"
 postfix += "_bbb1_cxs1"
@@ -37,8 +39,8 @@ if doMuElComb:
 
 fits = ["Asimov", "Data"]
 
-ptBinsSetting = " --pt-range-bkg 25.9 30.1 --pt-range '30,56' " if flavour == "el"  else ""  # " --eta-range-bkg 1.39 1.61 "
-ptMinForImpacts = " --pt-min-signal 30" if flavour == "el"  else ""
+ptBinsSetting = " --pt-range-bkg 25.9 30.1 --pt-range '30,56' " if (flavour == "el" and not allPtBinsSignalElectron) else ""  # " --eta-range-bkg 1.39 1.61 "
+ptMinForImpacts = " --pt-min-signal 30" if (flavour == "el" and not allPtBinsSignalElectron) else ""
 optTemplate = " --norm-width --draw-selected-etaPt 0.55,39.5 --syst-ratio-range 'template' --palette 57 "  # --draw-selected-etaPt 0.45,38 --zmin 10 # kLightTemperature=87
 ptMaxTemplate = "56"
 ptMinTemplate = "30" if flavour == "el" else "26"
@@ -94,10 +96,10 @@ correlationMatrixTitle = {"allPDF"           : "all PDFs",
 
 # for impacts
 targets = [#"mu", 
-           "xsec", 
-           "xsecnorm",
-           "etaptasym",
-           "etaxsec",
+           #"xsec", 
+           #"xsecnorm",
+           #"etaptasym",
+           #"etaxsec",
            "etaxsecnorm",
            "etaasym"
            ]
@@ -245,6 +247,8 @@ for fit in fits:
     # --palette 70 --invertPalette: kDarkBody from light blue to red
     # with following line will make impacts with graphs, not matrix                        
     command += " --etaptbinfile cards/{fd}/binningPtEta.txt ".format(fd=folder)
+    if flavour != "lep":
+        command += " -c {fl}".format(fl=flavour)
     for nuis in impacts_nuis:
         if nuis == "GROUP":
             varopt = " --nuisgroups '{ng}' ".format(ng=groupnames)

--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -5,16 +5,16 @@ import ROOT, os, sys, re, array
 # to run plots from Asimov fit and data. For toys need to adapt this script
 
 doMuElComb = 0
-dryrun = 1
-skipData = 1
+dryrun = 0
+skipData = 0
 onlyData = 0
 
-skipPlot = 1
+skipPlot = 0
 skipTemplate = 1
-skipDiffNuis = 0
+skipDiffNuis = 1
 skipPostfit = 1  # only for Data
 skipCorr = 1
-skipImpacts = 1
+skipImpacts = 0
 
 allPtBinsSignalElectron = 1
 
@@ -48,10 +48,10 @@ ptMinTemplate = "30" if flavour == "el" else "26"
 # do not ask Wplus.*_ieta_.*_mu$ to select signal strength rejecting pmasked, because otherwise you must change diffNuisances.py
 # currently it uses GetFromHessian with keepGen=True, so _mu$ would create a problem (should implement the possibility to reject a regular expression)
 # if you want mu rejecting pmasked do _mu_mu or _el_mu (for electrons _mu works because it doesn't induce ambiguities with the flavour)
-diffNuisances_pois = ["pdf.*|alphaS|mW", 
-                      "muR.*|muF.*", 
-                      "Fakes(Eta|Pt).*[0-9]+mu.*", 
-                      "Fakes(Eta|Pt).*[0-9]+el.*", 
+diffNuisances_pois = [#"pdf.*|alphaS|mW", 
+                      #"muR.*|muF.*", 
+                      #"Fakes(Eta|Pt).*[0-9]+mu.*", 
+                      #"Fakes(Eta|Pt).*[0-9]+el.*", 
                       #"ErfPar0EffStat.*", 
                       #"ErfPar1EffStat.*", 
                       #"ErfPar2EffStat.*", 
@@ -99,7 +99,7 @@ targets = [#"mu",
            #"xsec", 
            #"xsecnorm",
            #"etaptasym",
-           #"etaxsec",
+           "etaxsec",
            "etaxsecnorm",
            "etaasym"
            ]

--- a/WMass/python/plotter/utilityMacros/src/loopNtuplesSkeleton.C
+++ b/WMass/python/plotter/utilityMacros/src/loopNtuplesSkeleton.C
@@ -787,11 +787,11 @@ void fillHistograms(const string& treedir = "./",
     for (Int_t ieff = 0; ieff < maxEffStat; ++ieff) {     
       etalow = etaminForEffStat + 0.1 * ieff;
       h3_charge_eta_pt_globalBin_ErfPar0EffStat[chargeIndex][ieff]->Fill(lep_eta[0],lep1calPt, globalBinEtaPt, 
-									 effSystEtaBins(0,lep_pdgId[0],lep_eta[0],lep_pt[0],etalow,etalow+0.1,chargeSign) * wgt);
+									 effSystEtaBins(0,lep_pdgId[0],lep_eta[0],lep1calPt,etalow,etalow+0.1,chargeSign) * wgt);
       h3_charge_eta_pt_globalBin_ErfPar1EffStat[chargeIndex][ieff]->Fill(lep_eta[0],lep1calPt, globalBinEtaPt, 
-									 effSystEtaBins(1,lep_pdgId[0],lep_eta[0],lep_pt[0],etalow,etalow+0.1,chargeSign) * wgt);
+									 effSystEtaBins(1,lep_pdgId[0],lep_eta[0],lep1calPt,etalow,etalow+0.1,chargeSign) * wgt);
       h3_charge_eta_pt_globalBin_ErfPar2EffStat[chargeIndex][ieff]->Fill(lep_eta[0],lep1calPt, globalBinEtaPt, 
-									 effSystEtaBins(2,lep_pdgId[0],lep_eta[0],lep_pt[0],etalow,etalow+0.1,chargeSign) * wgt);
+									 effSystEtaBins(2,lep_pdgId[0],lep_eta[0],lep1calPt,etalow,etalow+0.1,chargeSign) * wgt);
 
     }
 

--- a/WMass/python/plotter/w-helicity-13TeV/functionsWMass.cc
+++ b/WMass/python/plotter/w-helicity-13TeV/functionsWMass.cc
@@ -362,7 +362,15 @@ float _lepSF(int pdgId, float pt, float eta, float sf1, float sf2, float sf3, in
     else if (abseta<1.5)   syst = 0.004;
     else                   syst = 0.014;
   }
-  return sf1*sf2*sf3*sf4 + nSigma*syst;
+  double ret = sf1*sf2*sf3*sf4 + nSigma*syst;  
+  if (ret <= 0.0) {
+    cout << "Error: returning bad SF: " << ret << "    Please check! Returning 1" << endl;
+    cout << ">>> pdgId, pt, eta, sf1, sf2, sf3, nsigma --> " << pdgId << ", " << pt << ", " << eta << ", " << sf1 << ", " << sf2 << ", " << sf3 << ",  " << nSigma << endl;
+    return 1;
+  } else {
+    return ret;  
+  }
+
 }
 
 float lepSF(int pdgId, float pt, float eta, float sf1, float sf2, float sf3) {
@@ -745,5 +753,28 @@ float effSystEtaBins(int inuisance, int pdgId, float eta, float pt, float etamin
   }
   return ret;
 }
+
+float lepSFRmuUp(int pdgId, float pt, float eta, int charge, float sf2) {
+
+  // in this function SF1 is obtained inside here, while SF3 (reco SF, which would generally be 1) is treated as prefiring SF
+  // at this level we can have electrons, because the cuts are applied afterwards, and this would return bad numbers
+  if (fabs(pdgId) != 13) return 0;
+  double trigSF = _get_muonSF_selectionToTrigger(pdgId,pt,eta,charge);
+  double prefireSF = prefireJetsWeight(eta);
+  return _lepSF(pdgId,pt,eta,trigSF,sf2,prefireSF, 1)/_lepSF(pdgId,pt,eta,trigSF,sf2,prefireSF,0);
+
+}
+
+float lepSFRmuDn(int pdgId, float pt, float eta, int charge, float sf2) {
+
+  // in this function SF1 is obtained inside here, while SF3 (reco SF, which would generally be 1) is treated as prefiring SF
+  // at this level we can have electrons, because the cuts are applied afterwards, and this would return bad numbers
+  if (fabs(pdgId) != 13) return 0;
+  double trigSF = _get_muonSF_selectionToTrigger(pdgId,pt,eta,charge);
+  double prefireSF = prefireJetsWeight(eta);
+  return _lepSF(pdgId,pt,eta,trigSF,sf2,prefireSF, -1)/_lepSF(pdgId,pt,eta,trigSF,sf2,prefireSF,0);
+
+}
+
 
 #endif

--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -311,7 +311,7 @@ if options.addPdfSyst:
     # SYSTFILEALL = writePdfSystsToSystFile(SYSTFILE)
 if options.addQCDSyst:
     scales = ['muR','muF',"muRmuF", "alphaS"]
-    writeQCDScaleSystsToMCA(MCA,outdir+"/mca",scales=scales+["wptSlope", "mW"])
+    writeQCDScaleSystsToMCA(MCA,outdir+"/mca",scales=scales+["mW"])  # ["wptSlope", "mW"] we can remove wpt-slope, saves few jobs
     writeQCDScaleSystsToMCA(MCA,outdir+"/mca",scales=scales,incl_mca='incl_dy')
 
 # not needed if we fit eta/pt. Will be needed if we fit another variable correlated with eta/pt

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -271,7 +271,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
         elif doPtNorm:
             print 'this is ptbins', ptbins
             #ptBorders = [26, 32, 38, 45, 50, 56] if isMu else [30, 35, 40, 45, 50, 56]  # last pt bin for 2D xsec might be 56 or 55, now I am using 56
-            ptBorders = [26, 32, 38, 46] if isMu else [30, 35, 40, 45]
+            ptBorders = [26, 32, 38, 45] if isMu else [30, 35, 40, 45]
             if ptbins[-1] > ptBorders[-1]:
                 ptBorders.extend([50, 56])
             borderBins = []

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -967,9 +967,6 @@ if __name__ == "__main__":
             polarizations.append('long')
 
         if options.ybinsBkg:
-            # note, the following line can potentially match undesired bins (should require that there are no additional digits after {iy}
-            # however, one would typically exclude the bins at high Yw, so they would either have already two digits (and we don't have more than 99 Yw bins),
-            # or one digit larger than 1
             pruned_tmp_sigprocs = []
             for thisproc in tmp_sigprocs:
                 thisybin = get_iy_from_process_name(thisproc)
@@ -986,8 +983,7 @@ if __name__ == "__main__":
         print 'I WILL NOW WRITE CHARGE GROUPS AND ALL THAT STUFF FOR THE FOLLOWING PROCESSES'
         print tmp_sigprocs
         print '============================================================================='
-        #if not options.freezePOIs and not options.longLnN and not options.longBkg: # right now cannot group signal and backgrounds                                  
-        # in case long is missing, the sum groups will only sum WR and WL, but this need a fix in DatacardParser.py
+        # in case long is missing, the sum groups will only sum WR and WL, while polGroup cannt be defined
         if not options.freezePOIs:
             if not options.longLnN and not options.longBkg:
                 writePolGroup(combinedCard,tmp_sigprocs,polarizations,grouping='polGroup')

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -271,7 +271,7 @@ def putUncorrelatedFakes(infile,regexp,charge, outdir=None, isMu=True, etaBorder
         elif doPtNorm:
             print 'this is ptbins', ptbins
             #ptBorders = [26, 32, 38, 45, 50, 56] if isMu else [30, 35, 40, 45, 50, 56]  # last pt bin for 2D xsec might be 56 or 55, now I am using 56
-            ptBorders = [26, 32, 38, 45] if isMu else [30, 35, 40, 45]
+            ptBorders = [26, 32, 38, 46] if isMu else [30, 35, 40, 45]
             if ptbins[-1] > ptBorders[-1]:
                 ptBorders.extend([50, 56])
             borderBins = []
@@ -466,10 +466,10 @@ if __name__ == "__main__":
     parser.add_option('-C','--charge', dest='charge', default='plus,minus', type='string', help='process given charge. default is both')
     parser.add_option(     '--ybinsOutAcc', dest='ybinsOutAcc', type='string', default="11", help='Define which Y bins are out-of-acceptance. With format 14,15 ')
     parser.add_option(     '--ybinsBkg', dest='ybinsBkg', type='string', default="", help='Define which Y bins are to be considered as background. With format 14,15 ')
-    parser.add_option(     '--longBkg'   , dest='longBkg' , default=False, action='store_true', help='Treat all bins for long as background')
+    parser.add_option(     '--longBkg'   , dest='longBkg' , default=False, action='store_true', help='Treat all bins for long as background. Different from --long-lnN, which would also assing an additional LnN uncertainty')
     parser.add_option('-p','--POIs', dest='POIsToMinos', type='string', default=None, help='Decide which are the nuiscances for which to run MINOS (a.k.a. POIs). Default is all non fixed YBins. With format poi1,poi2 ')
     parser.add_option('--fp', '--freezePOIs'    , dest='freezePOIs'    , action='store_true'               , help='run tensorflow with --freezePOIs (for the pdf only fit)');
-    parser.add_option(        '--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components')
+    parser.add_option(        '--long-lnN', dest='longLnN', type='float', default=None, help='add a common lnN constraint to all longitudinal components. I t activates --longBkg')
     parser.add_option(     '--sf'    , dest='scaleFile'    , default='', type='string', help='path of file with the scaling/unfolding')
     parser.add_option(     '--xsecMaskedYields', dest='xsecMaskedYields', default=False, action='store_true', help='use the xsec in the masked channel, not the expected yield')
     parser.add_option(     '--pdf-shape-only'   , dest='pdfShapeOnly' , default=False, action='store_true', help='Normalize the mirroring of the pdfs to central rate.')
@@ -514,13 +514,9 @@ if __name__ == "__main__":
     print 'I WILL TREAT THESE BINS AS BACKGROUND IN THE FIT FOR ALL POLARIZATIONS:'
     print bkgYBins
     print '---------------------------------'
-
-
-    if options.longLnN:
-        print "Warning: you used option --long-lnN, so I guess you wanted to treat it as background." 
-        print "Actually you should still consider all the theory and experimental systematics, so this lnN should not be used. I suggest option --longBkg"
-        quit()
     
+    if options.longLnN: options.longBkg = True
+
     if options.longBkg:
         print 'I WILL TREAT ALL BINS FOR LONGITUDINAL POLARIZATON AS BACKGROUND'
         print '---------------------------------'
@@ -974,7 +970,7 @@ if __name__ == "__main__":
                 else: pruned_tmp_sigprocs.append(thisproc)
             tmp_sigprocs = pruned_tmp_sigprocs
 
-        # this options will now issue a warning suggesting to use option --longBkg, so I can comment the following two lines
+        # filters already made above (options.longLnN automatically activates options.longBkg)
         #if options.longLnN: 
         #    tmp_sigprocs = filter(lambda x: 'long_' not in x,tmp_sigprocs)
         #else:

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -991,6 +991,7 @@ if __name__ == "__main__":
         if not options.freezePOIs:
             if not options.longLnN and not options.longBkg:
                 writePolGroup(combinedCard,tmp_sigprocs,polarizations,grouping='polGroup')
+            # the following works even if Wlong is missing, although their usefulness in this case is questionable
             writePolGroup(combinedCard,tmp_sigprocs,polarizations,grouping='sumGroup')
             writeChargeGroup(combinedCard,tmp_sigprocs,polarizations)
             writeChargeMetaGroup(combinedCard,tmp_sigprocs)

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -31,10 +31,10 @@ class valueClass:
             self.charge = self.ch = ''
 
         # I tried the following two lines, but the next ones might be good as well
-        self.color  = ROOT.kBlue-7 if self.isleft else ROOT.kOrange+7 if self.isright else ROOT.kGray+2
-        self.colorf = ROOT.kBlue-4 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
-        #self.color  = ROOT.kBlue+2 if self.isleft else ROOT.kRed+1 if self.isright else ROOT.kGray+1
-        #self.colorf = ROOT.kAzure+1 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
+        #self.color  = ROOT.kBlue-7 if self.isleft else ROOT.kOrange+7 if self.isright else ROOT.kGray+2
+        #self.colorf = ROOT.kBlue-4 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
+        self.color  = ROOT.kBlue+2 if self.isleft else ROOT.kRed+1 if self.isright else ROOT.kGray+1
+        self.colorf = ROOT.kAzure+1 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
         if self.isunpolarized: 
             self.color = ROOT.kSpring-6
             self.colorf = ROOT.kSpring-7
@@ -71,15 +71,15 @@ class valueClass:
     def makeMultiGraphRel(self):
         self.mg = ROOT.TMultiGraph()
         self.mg.SetTitle() ## no title 'W^{{{ch}}}: {p}'.format(ch=self.ch,p=self.pol))
-        #self.shiftPoints(self.graph_fit_rel)
+        self.shiftPoints(self.graph_fit_rel)
         self.mg.Add(self.graph_rel,'P2')
         self.mg.Add(self.graph_fit_rel)
 
     def graphStyle(self):
-        fillstyles = {'left': 3244, 'right': 3001, 'long': 3144, 'unpolarized': 3001}
-        fillstyles_rel = {'left': 3244, 'right': 3001, 'long': 3144, 'unpolarized': 3001}
-        #fillstyles = {'left': 3244, 'right': 3244, 'long': 3244, 'unpolarized': 3244}
-        #fillstyles_rel = {'left': 3444, 'right': 3444, 'long': 3444, 'unpolarized': 3244}
+        #fillstyles = {'left': 3244, 'right': 3001, 'long': 3144, 'unpolarized': 3001}
+        #fillstyles_rel = {'left': 3244, 'right': 3001, 'long': 3144, 'unpolarized': 3001}
+        fillstyles = {'left': 3244, 'right': 3244, 'long': 3244, 'unpolarized': 3244}
+        fillstyles_rel = {'left': 3444, 'right': 3444, 'long': 3444, 'unpolarized': 3244}
         if hasattr(self,'graph'):
             self.graph.SetLineColor(self.color)
             self.graph.SetFillColor(self.colorf)
@@ -404,6 +404,9 @@ if __name__ == "__main__":
     ybins = eval(ybinfile.read())
     ybinfile.close()
 
+    #print ybins
+    
+
     #print ybins    
     bkgYBins = []
     if options.ybinsBkg:
@@ -531,7 +534,9 @@ if __name__ == "__main__":
 
             for iy,y in enumerate(ybinwidths['{ch}_{pol}'.format(ch=charge,pol=pol)]):
                 if any(iy == x for x in bkgYBins): continue
-                normsigma = normsigmaInFit if abs(ybins[cp][iy])<MAXYFORNORM else normsigmaOutFit
+                # normsigma is used to normalize the expected: then, the sum should be the one on the expected
+                # which is also less sensitive to fluctuations, since in data some bins can be 0
+                normsigma = normsigmaIn if abs(ybins[cp][iy])<MAXYFORNORM else normsigmaOut
                 parname = 'W{charge}_{pol}_Ybin_{iy}'.format(charge=charge,pol=pol,iy=iy)
 
                 scale = 1.

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -71,7 +71,7 @@ class valueClass:
     def makeMultiGraphRel(self):
         self.mg = ROOT.TMultiGraph()
         self.mg.SetTitle() ## no title 'W^{{{ch}}}: {p}'.format(ch=self.ch,p=self.pol))
-        self.shiftPoints(self.graph_fit_rel)
+        #self.shiftPoints(self.graph_fit_rel)
         self.mg.Add(self.graph_rel,'P2')
         self.mg.Add(self.graph_fit_rel)
 

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -31,10 +31,10 @@ class valueClass:
             self.charge = self.ch = ''
 
         # I tried the following two lines, but the next ones might be good as well
-        #self.color  = ROOT.kBlue-7 if self.isleft else ROOT.kOrange+7 if self.isright else ROOT.kGray+2
-        #self.colorf = ROOT.kBlue-4 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
-        self.color  = ROOT.kBlue+2 if self.isleft else ROOT.kRed+1 if self.isright else ROOT.kGray+1
-        self.colorf = ROOT.kAzure+1 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
+        self.color  = ROOT.kBlue-7 if self.isleft else ROOT.kOrange+7 if self.isright else ROOT.kGray+2
+        self.colorf = ROOT.kBlue-4 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
+        #self.color  = ROOT.kBlue+2 if self.isleft else ROOT.kRed+1 if self.isright else ROOT.kGray+1
+        #self.colorf = ROOT.kAzure+1 if self.isleft else ROOT.kOrange+1 if self.isright else ROOT.kGray+3
         if self.isunpolarized: 
             self.color = ROOT.kSpring-6
             self.colorf = ROOT.kSpring-7
@@ -76,8 +76,8 @@ class valueClass:
         self.mg.Add(self.graph_fit_rel)
 
     def graphStyle(self):
-        #fillstyles = {'left': 3244, 'right': 3001, 'long': 3144, 'unpolarized': 3001}
-        fillstyles = {'left': 3244, 'right': 3244, 'long': 3244, 'unpolarized': 3244}
+        fillstyles = {'left': 3244, 'right': 3001, 'long': 3144, 'unpolarized': 3001}
+        #fillstyles = {'left': 3244, 'right': 3244, 'long': 3244, 'unpolarized': 3244}
         fillstyles_rel = {'left': 3444, 'right': 3444, 'long': 3444, 'unpolarized': 3244}
         if hasattr(self,'graph'):
             self.graph.SetLineColor(self.color)

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -77,8 +77,9 @@ class valueClass:
 
     def graphStyle(self):
         fillstyles = {'left': 3244, 'right': 3001, 'long': 3144, 'unpolarized': 3001}
+        fillstyles_rel = {'left': 3244, 'right': 3001, 'long': 3144, 'unpolarized': 3001}
         #fillstyles = {'left': 3244, 'right': 3244, 'long': 3244, 'unpolarized': 3244}
-        fillstyles_rel = {'left': 3444, 'right': 3444, 'long': 3444, 'unpolarized': 3244}
+        #fillstyles_rel = {'left': 3444, 'right': 3444, 'long': 3444, 'unpolarized': 3244}
         if hasattr(self,'graph'):
             self.graph.SetLineColor(self.color)
             self.graph.SetFillColor(self.colorf)
@@ -159,7 +160,7 @@ def plotValues(values,charge,channel,options, polarizations=['left','right','lon
      
             mg.Draw('Pa')
             mg.GetXaxis().SetRangeUser(0., options.maxRapidity) # max would be 6.
-            mg.GetXaxis().SetTitle('|Y_{W}|')
+            mg.GetXaxis().SetTitle('')
             mg.GetXaxis().SetLabelSize(0)
             if charge=='asymmetry':
                 mg.GetYaxis().SetTitle('Charge asymmetry')
@@ -185,10 +186,12 @@ def plotValues(values,charge,channel,options, polarizations=['left','right','lon
             pad2.SetTopMargin(0.65)
             pad2.SetRightMargin(0.04)
             pad2.SetLeftMargin(0.17)
+            pad2.SetBottomMargin(0.14)
             pad2.SetFillColor(0)
             pad2.SetGridy(0)
             pad2.SetFillStyle(0)
             pad2.SetTicky(1)
+            pad2.SetTickx(1)
 
             pad2.Draw()
             pad2.cd()
@@ -220,14 +223,14 @@ def plotValues(values,charge,channel,options, polarizations=['left','right','lon
                     values[hel].mg.GetYaxis().SetLabelSize(0.04)
                     values[hel].mg.GetYaxis().SetTitle(yaxtitle)
                     values[hel].mg.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])
-                    values[hel].mg.GetYaxis().SetNdivisions(510)
+                    values[hel].mg.GetYaxis().SetNdivisions(4)
                     values[hel].mg.GetYaxis().CenterTitle()
             line.Draw("Lsame");
             c2.cd()
-            lat.DrawLatex(0.16, 0.92, '#bf{CMS} #it{Preliminary}')
-            lat.DrawLatex(0.62, 0.92, '35.9 fb^{-1} (13 TeV)')
+            lat.DrawLatex(0.16, 0.94, '#bf{CMS} #it{Preliminary}')
+            lat.DrawLatex(0.62, 0.94, '35.9 fb^{-1} (13 TeV)')
             lat.DrawLatex(0.20, 0.80,  'W^{{{ch}}} #rightarrow {lep}^{{{ch}}}{nu}'.format(ch=ch,lep="#mu" if channel == "mu" else "e",nu="#bar{#nu}" if charge=='minus' else "#nu"))
-            lat.DrawLatex(0.90, 0.03, '|Y_{W}|')
+            lat.DrawLatex(0.88, 0.03, '|Y_{W}|')
         for ext in ['png', 'pdf']:
             c2.SaveAs('{od}/genAbsY{norm}_pdfs_{ch}{suffix}_{t}.{ext}'.format(od=options.outdir, norm=normstr, ch=charge, suffix=options.suffix, ext=ext,t=options.type))
 
@@ -236,7 +239,7 @@ def plotUnpolarizedValues(values,charge,channel,options):
         c2 = ROOT.TCanvas('foo','', 800, 800)
         c2.GetPad(0).SetTopMargin(0.09)
         c2.GetPad(0).SetBottomMargin(0.35)
-        c2.GetPad(0).SetLeftMargin(0.15)
+        c2.GetPad(0).SetLeftMargin(0.17)
         c2.GetPad(0).SetRightMargin(0.04)
         c2.GetPad(0).SetTickx(1)
         c2.GetPad(0).SetTicky(1)
@@ -261,7 +264,7 @@ def plotUnpolarizedValues(values,charge,channel,options):
             mg.Add(values.graph_fit)
             mg.Draw('Pa')
             mg.GetXaxis().SetRangeUser(0., options.maxRapidity) # max would be 6.
-            mg.GetXaxis().SetTitle('|Y_{W}|')
+            mg.GetXaxis().SetTitle('')
             mg.GetXaxis().SetTitleOffset(5.5)
             mg.GetXaxis().SetLabelSize(0)
             if charge=='asymmetry':
@@ -278,9 +281,9 @@ def plotUnpolarizedValues(values,charge,channel,options):
                 else:
                     mg.GetYaxis().SetRangeUser(-0.05 if normstr=='A0' else -1,0.4 if normstr=='A0' else 2)
                     mg.GetYaxis().SetTitle('|A_{0}|' if normstr=='A0' else '|A_{4}|')
-            mg.GetYaxis().SetTitleSize(0.06)
+            mg.GetYaxis().SetTitleSize(0.04)
             mg.GetYaxis().SetLabelSize(0.04)
-            mg.GetYaxis().SetTitleOffset(1.)
+            mg.GetYaxis().SetTitleOffset(2.0)
      
             leg = ROOT.TLegend(legx1, legy1, legx2, legy2)
             leg.SetFillStyle(0)
@@ -289,10 +292,10 @@ def plotUnpolarizedValues(values,charge,channel,options):
             leg.AddEntry(values.graph     , REFMC, 'f')
 
             leg.Draw('same')
-            lat.DrawLatex(0.16, 0.92, '#bf{CMS} #it{Preliminary}')
-            lat.DrawLatex(0.62, 0.92, '35.9 fb^{-1} (13 TeV)')
-            lat.DrawLatex(0.20, 0.50,  'W^{{{ch}}} #rightarrow {lep}^{{{ch}}}{nu}'.format(ch=ch,lep="#mu" if channel == "mu" else "e",nu="#bar{#nu}" if charge=='minus' else "#nu"))
-     
+            lat.DrawLatex(0.16, 0.94, '#bf{CMS} #it{Preliminary}')
+            lat.DrawLatex(0.62, 0.94, '35.9 fb^{-1} (13 TeV)')
+            lat.DrawLatex(0.20, 0.40,  'W^{{{ch}}} #rightarrow {lep}^{{{ch}}}{nu}'.format(ch=ch,lep="#mu" if channel == "mu" else "e",nu="#bar{#nu}" if charge=='minus' else "#nu"))
+            lat.DrawLatex(0.88, 0.03, '|Y_{W}|')
 
         ## now make the relative error plot:
         ## ======================================
@@ -301,11 +304,13 @@ def plotUnpolarizedValues(values,charge,channel,options):
             pad2 = ROOT.TPad("pad2","pad2",0,0.,1,0.9)
             pad2.SetTopMargin(0.65)
             pad2.SetRightMargin(0.04)
-            pad2.SetLeftMargin(0.15)
+            pad2.SetLeftMargin(0.17)
+            pad2.SetBottomMargin(0.14)
             pad2.SetFillColor(0)
             pad2.SetGridy(0)
             pad2.SetFillStyle(0)
             pad2.SetTicky(1)
+            pad2.SetTickx(1)
 
             pad2.Draw()
             pad2.cd()
@@ -323,14 +328,13 @@ def plotUnpolarizedValues(values,charge,channel,options):
 
             values.mg.Draw('Pa')
             ## x axis fiddling
-            values.mg.GetXaxis().SetTitle('|Y_{W}|')
-            values.mg.GetXaxis().SetTitleOffset(1.)
+            values.mg.GetXaxis().SetTitle('')
             values.mg.GetXaxis().SetRangeUser(0., options.maxRapidity)
-            values.mg.GetXaxis().SetTitleSize(0.1)
+            values.mg.GetXaxis().SetTitleSize(0.14)
             values.mg.GetXaxis().SetLabelSize(0.04)
             ## y axis fiddling
-            values.mg.GetYaxis().SetTitleOffset(1.2)
-            values.mg.GetYaxis().SetTitleSize(0.06)
+            values.mg.GetYaxis().SetTitleOffset(1.8)
+            values.mg.GetYaxis().SetTitleSize(0.04)
             values.mg.GetYaxis().SetLabelSize(0.04)
             values.mg.GetYaxis().SetTitle(yaxtitle)
             values.mg.GetYaxis().SetRangeUser(yaxrange[0],yaxrange[1])

--- a/WMass/python/plotter/w-helicity-13TeV/templateRolling.py
+++ b/WMass/python/plotter/w-helicity-13TeV/templateRolling.py
@@ -102,7 +102,6 @@ if __name__ == "__main__":
     parser.add_option(     '--skipBkg', dest='skipBackground', default=False, action='store_true', help='Skip histograms for background processes')
     parser.add_option('-r','--syst-ratio-range', dest='syst_ratio_range', default='0.98,1.02', type='string', help='Comma separated pair of floats used to define the range for the syst/nomi ratio. If "template" is passed, the template min and max values are used (it will be different for each template). This option is for signal templates only') 
     parser.add_option(     '--pt-range', dest='ptRange', default='template', type='string', help='Comma separated pair of floats used to define the pt range. If "template" is passed, the template min and max values are used')
-    #parser.add_option(     '--no-group-name', dest="noGroupInName", default=False, action='store_true', help="If True, _group_<N> is not in the signal process name");
     parser.add_option(      '--palette', dest='palette', default=55, type=int, help='Pass number for palette (default is kRainbow, but check)')
     parser.add_option(      '--zmin', dest='zaxisMin', default=0, type=float, help='Minimum value for Z axis (default is 0)')
     parser.add_option('-n', '--norm-width', dest='normWidth', default=False, action='store_true', help='Normalize histogram by bin width.')
@@ -175,10 +174,7 @@ if __name__ == "__main__":
     for x in allsysts:
         if not re.match(options.doSigSyst,x): continue
         allsystsUpDn.append(x+"Up")
-        allsystsUpDn.append(x+"Down")
-
-    
-    
+        allsystsUpDn.append(x+"Down")    
 
     xaxisTitle = '%s #eta' % lepton
     if options.ptRange == "template":
@@ -256,7 +252,7 @@ if __name__ == "__main__":
                     for k in infile.GetListOfKeys():
                         name=k.GetName()
                         obj=k.ReadObj()
-                        signalMatch = "{ch}_{pol}_{flav}_Ybin_".format(ch=charge,pol=pol,flav=channel)                        
+                        signalMatch = "{ch}_{pol}_Ybin_".format(ch=charge,pol=pol)                        
                         # name.split('_')[-2] == "Ybin" : this excludes systematics
                         if obj.InheritsFrom("TH1") and signalMatch in name:
 
@@ -276,9 +272,9 @@ if __name__ == "__main__":
                                 # ymin = list(i for i in tmp_line if '(genw_y)>' in i)[0].replace('\'','').split('>')[-1]
                                 # ymax = list(i for i in tmp_line if '(genw_y)<' in i)[0].replace('\'','').split('<')[-1]               
                                 ybin = name.split('_')[-1]                            
-                                ymin = str(bins_charge_pol[int(ybin)]) # "X" # dummy for the moment
+                                ymin = str(bins_charge_pol[int(ybin)]) 
                                 ymax = str(bins_charge_pol[int(ybin)+1])
-                                name2D = 'W{ch}_{pol}_W{ch}_{pol}_{flav}_Ybin_{ybin}'.format(ch=charge,pol=pol,flav=channel,ybin=ybin)
+                                name2D = 'W{ch}_{pol}_Ybin_{ybin}'.format(ch=charge,pol=pol,ybin=ybin)
                                 title2D = 'W{chs} {pol} : |Yw| #in [{ymin},{ymax})'.format(ymin=ymin,ymax=ymax,pol=pol,ybin=ybin,chs=chs)
                                 h2_backrolled_1 = dressed2D(obj,binning,name2D,title2D)
                                 if options.normWidth: 
@@ -302,11 +298,12 @@ if __name__ == "__main__":
                             elif not options.skipSyst:
                                 systvar = name.split('_')[-1]
                                 if re.match(options.doSigSyst,systvar):
+                                    #print "systvar: " + systvar
                                     h2_backrolled_1 = dressed2D(obj,binning,name+"_tmp","")                            
                                     if options.normWidth:
                                         h2_backrolled_1.Scale(1.,"width")
                                     hSigInclusivePol_syst[systvar].Add(h2_backrolled_1)
-                                    #print "systvar = %s: adding %s   integral = %.1f" % (systvar, h2_backrolled_1.GetName(),hSigInclusivePol_syst[systvar].Integral())
+                                    print "systvar = %s: adding %s   integral = %.1f" % (systvar, h2_backrolled_1.GetName(),hSigInclusivePol_syst[systvar].Integral())
                                 
 
                     hSigInclusive[pol].Write()
@@ -322,8 +319,8 @@ if __name__ == "__main__":
 
                         if not options.skipSyst:
                             for systvar in allsystsUpDn:
-                                #print "systvar = %s: integral = %.1f" % (systvar, hSigInclusivePol_syst[systvar].Integral())
-                                #print "Inclusive template: integral = %.1f" % hSigInclusive.Integral()
+                                print "systvar = %s: integral = %.1f" % (systvar, hSigInclusivePol_syst[systvar].Integral())
+                                print "Inclusive template: integral = %.1f" % hSigInclusive[pol].Integral()
                                 hSigInclusive_syst[systvar].Add(hSigInclusivePol_syst[systvar])
                                 hSigInclusivePol_syst[systvar].Divide(hSigInclusive[pol])
                                 if options.syst_ratio_range == "template":

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -85,7 +85,7 @@ class util:
         values = {}
         if not infile:
             for pol in polarizations: 
-                cp = '{ch}_{pol}'.format(ch=charge,pol=pol if not pol == 'long' else 'right')
+                cp = '{ch}_{pol}'.format(ch=charge,pol=pol)
                 xsecs = []
                 for iv in xrange(len(ybins[cp][:-1])):
                     if any(iv == x for x in excludeYbins): continue
@@ -98,7 +98,7 @@ class util:
         pstr = '' if not ip else '_pdf{ip}Up'.format(ip=ip)
     
         for pol in polarizations:
-            cp = '{ch}_{pol}'.format(ch=charge,pol=pol if not pol == 'long' else 'right')  # ??? what's that?
+            cp = '{ch}_{pol}'.format(ch=charge,pol=pol)
             xsecs = []
             for iv, val in enumerate(ybins[cp][:-1]):                
                 if any(iv == x for x in excludeYbins): continue

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -81,13 +81,14 @@ class util:
         histo_file.Close()
         return histos
 
-    def getXSecFromShapes(self, ybins, charge, infile, ip, nchannels=1):
+    def getXSecFromShapes(self, ybins, charge, infile, ip, nchannels=1, polarizations = ['left','right','long'], excludeYbins = []):
         values = {}
         if not infile:
-            for pol in ['left','right','long']: 
+            for pol in polarizations: 
                 cp = '{ch}_{pol}'.format(ch=charge,pol=pol if not pol == 'long' else 'right')
                 xsecs = []
                 for iv in xrange(len(ybins[cp][:-1])):
+                    if any(iv == x for x in excludeYbins): continue
                     xsecs.append(0.)
                 values[pol] = xsecs
             return values
@@ -96,11 +97,13 @@ class util:
     
         pstr = '' if not ip else '_pdf{ip}Up'.format(ip=ip)
     
-        for pol in ['left','right','long']:
-            cp = '{ch}_{pol}'.format(ch=charge,pol=pol if not pol == 'long' else 'right')
+        for pol in polarizations:
+            cp = '{ch}_{pol}'.format(ch=charge,pol=pol if not pol == 'long' else 'right')  # ??? what's that?
             xsecs = []
-            for iv, val in enumerate(ybins[cp][:-1]):
-                name = 'x_W{ch}_{pol}_Ybin_{iy}{suffix}'.format(ch=charge,pol=pol,iy=iv,ip=ip,suffix=pstr)
+            for iv, val in enumerate(ybins[cp][:-1]):                
+                if any(iv == x for x in excludeYbins): continue
+                name = 'x_W{ch}_{pol}_Ybin_{iy}{suffix}'.format(ch=charge,pol=pol,iy=iv,ip=ip,suffix=pstr)                
+                #print name
                 histo = histo_file.Get(name)
                 val = histo.Integral()/36000./float(nchannels) # xsec file yields normalized to 36 fb-1
                 xsecs.append(float(val))
@@ -654,10 +657,14 @@ class util:
         if index<len(SAFE_COLOR_LIST): return SAFE_COLOR_LIST[index]
         else: return index
 
-    def getCoeffs(self,xL,xR,x0,err_xL,err_xR,err_x0, toyEvents=10000):
+    def getCoeffs(self,xL,xR,x0,err_xL,err_xR,err_x0, toyEvents=10000):        
         histos = { 'a0': ROOT.TH1D('a0','',100,-0.4,0.6),
                    'a4': ROOT.TH1D('a4','',100,-0.4,3.0)
                    }
+        # given that we use mean and RMS, for security reason use Under/Overflow values to compute them
+        # so we don't have to tune the range (even though the one about is already very sensible for a0 and a4)
+        histos['a0'].SetStatOverflows(1)
+        histos['a4'].SetStatOverflows(1)
         #print "getCoeffs: ",toyEvents," toyMC running..."
         for i in xrange(toyEvents):
             ixL = np.random.normal(xL,err_xL)
@@ -665,6 +672,7 @@ class util:
             ix0 = np.random.normal(x0,err_x0)
             sumPol = ixL+ixR+ix0
             histos['a0'].Fill(2*ix0/sumPol)
+            #histos['a0'].Fill(2*(1-ixL-ixR)/sumPol)
             histos['a4'].Fill(2*(ixL-ixR)/sumPol)
         #print "toyMC done"
         ret = {}

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt
@@ -44,8 +44,8 @@ incl_datafakes_FRe_slope_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-inclu
 incl_datafakes_FRe_slope_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-ptdown.txt", SkipMe=True, PostFix='_fakes_FRe_slope_Dn'
 
 # fake-lepton background systematics due to change of awayJet_pt from 30 -> 45 GeV
-incl_datafakes_FRe_awayJetPt45 : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-jetpt_syst.txt", SkipMe=True, PostFix='_fakes_FRe_awayJetPt45'
+#incl_datafakes_FRe_awayJetPt45 : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-jetpt_syst.txt", SkipMe=True, PostFix='_fakes_FRe_awayJetPt45'
 
 # norm vs eta and pt as shape
-incl_datafakes_FRe_continuous_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-normup.txt", SkipMe=True, PostFix='_fakes_FRe_continuous_Up'
-incl_datafakes_FRe_continuous_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-normdown.txt", SkipMe=True, PostFix='_fakes_FRe_continuous_Dn'
+#incl_datafakes_FRe_continuous_Up : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-normup.txt", SkipMe=True, PostFix='_fakes_FRe_continuous_Up'
+#incl_datafakes_FRe_continuous_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_e/mca-includes/mca-data-legacy2016.txt", FakeRate="w-helicity-13TeV/wmass_e/fakerate-vars/fakeRate-frdata-e-normdown.txt", SkipMe=True, PostFix='_fakes_FRe_continuous_Dn'

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_e/systsEnv.txt
@@ -15,7 +15,7 @@ CMS_We_lepVeto           : Z : .* : 1.03
 # Z xsec from FEWZ 3.1: https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV
 # Top (take a conservative value as the maximum uncertainty among single-t and ttbar (ttbar from: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO)
 # ==================================================================
-CMS_DY               : Z                            : .* : 1.038
+#CMS_DY               : Z                            : .* : 1.038
 CMS_VV               : DiBosons                     : .* : 1.16
 CMS_Top              : Top                          : .* : 1.06 
 CMS_Tau              : TauDecaysW                   : .* : 1.30

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/cuts_wmu.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/cuts_wmu.txt
@@ -3,7 +3,7 @@ alwaystrue : 1
 trigger    : (HLT_BIT_HLT_IsoMu24_v > 0 || HLT_BIT_HLT_IsoTkMu24_v > 0 )
 onelep     : nLepGood == 1
 mu         : abs(LepGood1_pdgId)==13
-kinAccept  : ptMuFull(LepGood1_calPt,LepGood1_eta) > 26. && abs(LepGood1_eta) < 2.4 && ptMuFull(LepGood1_calPt,LepGood1_eta) < 45.
+kinAccept  : ptMuFull(LepGood1_calPt,LepGood1_eta) > 26. && abs(LepGood1_eta) < 2.4 && ptMuFull(LepGood1_calPt,LepGood1_eta) < 45.5
 muMediumId  : LepGood1_mediumMuonId  > 0
 muTightIso : LepGood1_relIso04 < 0.15
 ##

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/cuts_wmu.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/cuts_wmu.txt
@@ -3,7 +3,7 @@ alwaystrue : 1
 trigger    : (HLT_BIT_HLT_IsoMu24_v > 0 || HLT_BIT_HLT_IsoTkMu24_v > 0 )
 onelep     : nLepGood == 1
 mu         : abs(LepGood1_pdgId)==13
-kinAccept  : ptMuFull(LepGood1_calPt,LepGood1_eta) > 26. && abs(LepGood1_eta) < 2.4 && ptMuFull(LepGood1_calPt,LepGood1_eta) < 45.5
+kinAccept  : ptMuFull(LepGood1_calPt,LepGood1_eta) > 26. && abs(LepGood1_eta) < 2.4 && ptMuFull(LepGood1_calPt,LepGood1_eta) < 45
 muMediumId  : LepGood1_mediumMuonId  > 0
 muTightIso : LepGood1_relIso04 < 0.15
 ##

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/make_cards_mu.py
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/make_cards_mu.py
@@ -25,6 +25,7 @@ etabinning = '['+','.join('{a:.1f}'.format(a=i) for i in binningeta)+']'
 
 ## variable binning in pt
 ptbinning = '['+','.join(str(i) for i in range(26,46))+']'
+#ptbinning = '['+','.join(str(26+1.5*i) for i in range(0,14))+']'
 
 BINNING      = '\''+etabinning+'*'+ptbinning+'\''
 ## do with histogram. sick of friends !! WEIGHTSTRING = ' \'puw2016_nTrueInt_36fb(nTrueInt)*LepGood_SF1[0]*LepGood_SF2[0]\' '
@@ -33,6 +34,7 @@ OUTDIR       = 'helicity_%s' % datetime.now().strftime('%Y_%m_%d')
 
 #components=[' -b ', ' -s ']
 components=[' -s ']
+#components=[' -b ']
     
 
 if __name__ == '__main__':

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-wmu-helicity.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-wmu-helicity.txt
@@ -13,8 +13,19 @@ incl_data             : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/m
 ## ## SYSTEMATICS 
 
 ## lepton efficiency systematics
-incl_sig_lepeff_Up  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRelUp(LepGood1_pdgId\,LepGood1_pt\,LepGood1_eta\,LepGood1_SF1\,LepGood1_SF2\,1.)", SkipMe=True, PostFix='_lepeff_Up'
-incl_sig_lepeff_Dn  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRelDn(LepGood1_pdgId\,LepGood1_pt\,LepGood1_eta\,LepGood1_SF1\,LepGood1_SF2\,1.)", SkipMe=True, PostFix='_lepeff_Dn'
+# use prefire as SF3 instead of 1 for real reco SF, otherwise the variation computed by multiplying for prefire a posteriori might be wrong
+#incl_sig_lepeff_Up  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRelUp(LepGood1_pdgId\,LepGood1_pt\,LepGood1_eta\,LepGood1_SF1\,LepGood1_SF2\,1.)", SkipMe=True, PostFix='_lepeff_Up'
+#incl_sig_lepeff_Dn  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRelDn(LepGood1_pdgId\,LepGood1_pt\,LepGood1_eta\,LepGood1_SF1\,LepGood1_SF2\,1.)", SkipMe=True, PostFix='_lepeff_Dn'
+
+# need to use correct scale factors for trigger and the rest. Pass prefiring as if it was SF3, otherwise the variation gets wrong (prefiring would be applied as another multiplicative factor after scalign the SF weights, while one wants to include it in the SF weight, and then vary it by a global uncertainty)
+# here we use these new functions lepSFRmuUp and lepSFRmuDn defined in functionsWMass.cc
+
+incl_sig_lepeff_Up  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRmuUp(LepGood1_pdgId\,LepGood1_calPt\,LepGood1_eta\,LepGood_charge[0]\,LepGood1_SF2)", SkipMe=True, PostFix='_lepeff_Up'
+incl_sig_lepeff_Dn  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRmuDn(LepGood1_pdgId\,LepGood1_calPt\,LepGood1_eta\,LepGood_charge[0]\,LepGood1_SF2)", SkipMe=True, PostFix='_lepeff_Dn'
+
+# on 29/03/2019lep efficiency for Z was missing !!!!
+Z_lepeff_Up   : DYJetsToLL_M50_* : 2008.4*3; FillColor=ROOT.kAzure+2, AddWeight="lepSFRmuUp(LepGood1_pdgId\,LepGood1_calPt\,LepGood1_eta\,LepGood_charge[0]\,LepGood1_SF2)", Label="Z lep scale Up", NormSystematic=0.04, SkipMe=True
+Z_lepeff_Dn   : DYJetsToLL_M50_* : 2008.4*3; FillColor=ROOT.kAzure+2, AddWeight="lepSFRmuDn(LepGood1_pdgId\,LepGood1_calPt\,LepGood1_eta\,LepGood_charge[0]\,LepGood1_SF2)", Label="Z lep scale Dn", NormSystematic=0.04, SkipMe=True
 
 ## muon scale systematics 
 Wplus_long_muscale_Up   : WJetsToLNu_* : 3.*20508.9   : prefsrw_decayId == 14 && prefsrw_charge>0  ; FillColor=ROOT.kRed+2  , FakeRate="w-helicity-13TeV/wmass_mu/variations/reweighting_0_plus_lepUp.txt", Label="W+ long lep scale Up", SkipMe=True 
@@ -33,18 +44,19 @@ Wminus_right_muscale_Dn : WJetsToLNu_* : 3.*20508.9   : prefsrw_decayId == 14 &&
 
 Z_muscale_Up   : DYJetsToLL_M50_* : 2008.4*3; FillColor=ROOT.kAzure+2, FakeRate="w-helicity-13TeV/wmass_mu/variations/reweighting_Z_lepUp.txt", Label="Z lep scale Up", NormSystematic=0.04, SkipMe=True
 Z_muscale_Dn   : DYJetsToLL_M50_* : 2008.4*3; FillColor=ROOT.kAzure+2, FakeRate="w-helicity-13TeV/wmass_mu/variations/reweighting_Z_lepDn.txt", Label="Z lep scale Dn", NormSystematic=0.04, SkipMe=True
+
  
 ## # fake-lepton background systematics (shape systematics)
 incl_datafakes_FRmu_slope_Up : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-data.txt", FakeRate="w-helicity-13TeV/wmass_mu/fakerate-vars/fakeRate-frdata-mu-slopeup.txt"  , SkipMe=True, PostFix='_fakes_FRmu_slope_Up' , FillColor=ROOT.kGreen-1
 incl_datafakes_FRmu_slope_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-data.txt", FakeRate="w-helicity-13TeV/wmass_mu/fakerate-vars/fakeRate-frdata-mu-slopedown.txt", SkipMe=True, PostFix='_fakes_FRmu_slope_Dn' , FillColor=ROOT.kBlue-1
 
 ## continuous shape in eta
-incl_datafakes_FRmu_continuous_Up : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-data.txt", FakeRate="w-helicity-13TeV/wmass_mu/fakerate-vars/fakeRate-frdata-mu-continuousup.txt"  , SkipMe=True, PostFix='_fakes_FRmu_continuous_Up'
-incl_datafakes_FRmu_continuous_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-data.txt", FakeRate="w-helicity-13TeV/wmass_mu/fakerate-vars/fakeRate-frdata-mu-continuousdown.txt", SkipMe=True, PostFix='_fakes_FRmu_continuous_Dn'
+#incl_datafakes_FRmu_continuous_Up : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-data.txt", FakeRate="w-helicity-13TeV/wmass_mu/fakerate-vars/fakeRate-frdata-mu-continuousup.txt"  , SkipMe=True, PostFix='_fakes_FRmu_continuous_Up'
+#incl_datafakes_FRmu_continuous_Dn : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-data.txt", FakeRate="w-helicity-13TeV/wmass_mu/fakerate-vars/fakeRate-frdata-mu-continuousdown.txt", SkipMe=True, PostFix='_fakes_FRmu_continuous_Dn'
 
 
 ## systematic with varied awayjet pT to 45 (from 30) GeV
-incl_datafakes_FRmu_awayJetPt45 : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-data.txt", FakeRate="w-helicity-13TeV/wmass_mu/fakerate-vars/fakeRate_application_jetPt45_data.txt", SkipMe=True, PostFix='_fakes_FRmu_awayJetPt45'
+#incl_datafakes_FRmu_awayJetPt45 : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-data.txt", FakeRate="w-helicity-13TeV/wmass_mu/fakerate-vars/fakeRate_application_jetPt45_data.txt", SkipMe=True, PostFix='_fakes_FRmu_awayJetPt45'
 
 
 ## the next two are obsolete

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-wmu-helicity.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-wmu-helicity.txt
@@ -17,7 +17,7 @@ incl_data             : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/m
 #incl_sig_lepeff_Up  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRelUp(LepGood1_pdgId\,LepGood1_pt\,LepGood1_eta\,LepGood1_SF1\,LepGood1_SF2\,1.)", SkipMe=True, PostFix='_lepeff_Up'
 #incl_sig_lepeff_Dn  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRelDn(LepGood1_pdgId\,LepGood1_pt\,LepGood1_eta\,LepGood1_SF1\,LepGood1_SF2\,1.)", SkipMe=True, PostFix='_lepeff_Dn'
 
-# need to use correct scale factors for trigger and the rest. Pass prefiring as if it was SF3, otherwise the variation gets wrong (prefiring would be applied as another multiplicative factor after scalign the SF weights, while one wants to include it in the SF weight, and then vary it by a global uncertainty)
+# need to use correct scale factors for trigger and the rest. Pass prefiring as if it was SF3, otherwise the variation gets wrong (prefiring would be applied as another multiplicative factor after scaling the SF weights, while one wants to include it in the SF weight, and then vary it by a global uncertainty)
 # here we use these new functions lepSFRmuUp and lepSFRmuDn defined in functionsWMass.cc
 
 incl_sig_lepeff_Up  : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sig.txt", AddWeight="lepSFRmuUp(LepGood1_pdgId\,LepGood1_calPt\,LepGood1_eta\,LepGood_charge[0]\,LepGood1_SF2)", SkipMe=True, PostFix='_lepeff_Up'

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-wmu-xsec.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/mca-wmu-xsec.txt
@@ -25,8 +25,9 @@ incl_sig_muscale_Up   : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/m
 incl_sig_muscale_Dn   : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-sigInclCharge_binned_eta_pt.txt", FakeRate="w-helicity-13TeV/wmass_mu/variations/doSyst_lepScaleDn_xsec.txt" , SkipMe=True, PostFix='_muscale_Dn'
 
 # lepton efficiency systematics for Z
-incl_dy_lepeff_Up      : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-dy.txt",   AddWeight="lepSFRelUp(LepGood1_pdgId\,LepGood1_pt\,LepGood1_eta\,LepGood1_SF1\,LepGood1_SF2\,1)", SkipMe=True, PostFix='_lepeff_Up'
-incl_dy_lepeff_Dn      : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-dy.txt",   AddWeight="lepSFRelDn(LepGood1_pdgId\,LepGood1_pt\,LepGood1_eta\,LepGood1_SF1\,LepGood1_SF2\,1)", SkipMe=True, PostFix='_lepeff_Dn'
+# need to use correct scale factors for trigger and the rest. Pass prefiring as if it was SF3, otherwise the variation gets wrong (prefiring would be applied as another multiplicative factor after scalign the SF weights, while one wants to include it in the SF weight, and then vary it by a global uncertainty)
+incl_dy_lepeff_Up      : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-dy.txt",   AddWeight="lepSFRmuUp(LepGood1_pdgId\,LepGood1_calPt\,LepGood1_eta\,LepGood_charge[0]\,LepGood1_SF2)", SkipMe=True, PostFix='_lepeff_Up'
+incl_dy_lepeff_Dn      : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-dy.txt",   AddWeight="lepSFRmuDn(LepGood1_pdgId\,LepGood1_calPt\,LepGood1_eta\,LepGood_charge[0]\,LepGood1_SF2)", SkipMe=True, PostFix='_lepeff_Dn'
 
 # muon scale systematics for Z
 incl_dy_muscale_Up   : + ; IncludeMca="w-helicity-13TeV/wmass_mu/mca-includes/mca-80X-wmunu-dy.txt", FakeRate="w-helicity-13TeV/wmass_mu/variations/doSyst_lepScaleUp_xsec.txt" , SkipMe=True, PostFix='_muscale_Up'

--- a/WMass/python/plotter/w-helicity-13TeV/wmass_mu/systsEnv.txt
+++ b/WMass/python/plotter/w-helicity-13TeV/wmass_mu/systsEnv.txt
@@ -21,7 +21,7 @@ CMS_Wmu_lepVeto      : Z                            : .* : 1.02
 # ==================================================================
 ## no longer needed. all scales etc are there now CMS_DY               : Z                            : .* : 1.038
 #
-CMS_DY               : Z                            : .* : 1.038
+#CMS_DY               : Z                            : .* : 1.038
 CMS_VV               : DiBosons                     : .* : 1.16
 CMS_Top              : Top                          : .* : 1.06 
 CMS_Tau              : TauDecaysW                   : .* : 1.30


### PR DESCRIPTION
The updates that affect helicity were tested and seem to work. They are implemented in such a way to reproduce previous behaviour when new options/features are not used.
Note that:
- muR,muF,muRmuF were applied also to signal, while we should not. This is fixed in the merger by excluding those nuisances when making the cards (but one should also fix make_helicity_cards.py to avoid making the histograms, it saves few jobs.
- CMS_DY should not be used, I commented that in the systEnv.txt (but could be rejected afterwards when making cards using regular expressions, now implemented
- the lepton efficiency for signal (syst part) was wrong for muons (trigger SF by-charge not used), and it was not applied to Z, while it should

**w-helicity-13TeV/functionsWMass.cc**
protection in function to get SF, needed when using muons with other functions (if abs(pdgid)==11 the function can return 0, which is bad when using it at denominator in lepSF*Up/Dn)
Also, adding new functions for muon SF up and down, which automatically use trigger ans prefiring SF

**w-helicity-13TeV/utilities.py**
adapt things so to deal with missing Wlong or bins of YW

**w-helicity-13TeV/wmass_e/mca-80X-wenu-helicity.txt**
comment histograms not to be made (minor fix, saves time when running jobs)

**w-helicity-13TeV/wmass_mu/mca-wmu-helicity.txt**
add lepeff for Z, and fix function to apply it. Also, remove unnecessary histograms

**w-helicity-13TeV/mergeCardComponentsAbsY.py**
functions to exclude nuisances with regular expressions when making the cards, and get Ybin index from name. 
Adding options to:
- exclude nuisances
- add postfix to hdf5 file (when combining cards for charge), useful not to overwrite stuff, no need to move to different folders
- option to treat WLong as background (--longBkg, which improves upon --long-lnN). We might not use it, but it is useful for tests
- option to treat some Y bins as background (e.g. last bin). Similar to --ybinsOutAcc, but those bins are not fitted, just treated as background. 
Some of this options are also in plotYW.py, to make plots consistently

**w-helicity-13TeV/plotYW.py**
Changing plot style (borders, axis title's offset, size, etc.)
Small fixes in legend's dimension
Changing style and colours of graph and band
Adding options to deal with missing bins (YW bins treated as background) or Wlong as background
