### PR TITLE
possibility to apply the DY PT reweighting to W,DY,Wtau

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -211,7 +211,7 @@ def writeFSRSystsToMCA(mcafile,odir,syst="fsr",incl_mca='incl_sig',append=False)
     incl_file=getMcaIncl(mcafile,incl_mca)
     postfix = "_{proc}_{syst}".format(proc=incl_mca.split('_')[1],syst=syst)
     mcafile_syst = open("%s/mca%s.txt" % (odir,postfix), "w")
-    weightFcn = 'fsrPhotosWeight(GenLepPreFSR_pdgId[0]\,GenLepPreFSR_eta[0]\,GenLepPreFSR_pt[0]\,GenLepDressed_fsrDR[0])'
+    weightFcn = 'fsrPhotosWeight(GenLepDressed_pdgId[0]\,GenLepDressed_eta[0]\,GenLepDressed_pt[0]\,GenLepBare_pt[0])'
     mcafile_syst.write(incl_mca+postfix+'   : + ; IncludeMca='+incl_file+', AddWeight="'+weightFcn+'", PostFix="'+postfix+'" \n')
     fsrsysts.append(postfix)
     print "written ",syst," systematics relative to ",incl_mca
@@ -253,7 +253,6 @@ Error      = {pid}.error
 getenv      = True
 environment = "LS_SUBCWD={here}"
 request_memory = 4000
-requirements = (OpSysAndVer =?= "SLCern6")
 +MaxRuntime = {rt}
 queue 1\n
 '''.format(scriptName=srcFile, pid=srcFile.replace('.sh',''), rt=getCondorTime(options.queue), here=os.environ['PWD'] ) )
@@ -278,6 +277,7 @@ parser.add_option("--qcd-syst", dest="addQCDSyst", action="store_true", default=
 parser.add_option("--useLSF", action='store_true', default=False, help="force use LSF. default is using condor");
 parser.add_option('-g', "--group-jobs", dest="groupJobs", type=int, default=20, help="group signal jobs so that one job runs multiple makeShapeCards commands");
 parser.add_option('-w', "--wvar", type="string", default='prefsrw', help="switch between genw and prefsrw. those are the only options (default %default)");
+parser.add_option('--vpt-weight', dest='procsToPtReweight', action="append", default=[], help="processes to be reweighted according the measured/predicted DY pt. Default is none (possible W,TauDecaysW,Z).");
 (options, args) = parser.parse_args()
 
 if not options.wvar in ['genw', 'prefsrw']:
@@ -401,7 +401,9 @@ if options.signalCards:
                     if options.queue and not os.path.exists(outdir+"/jobs"): os.mkdir(outdir+"/jobs")
                     syst = '' if ivar==0 else var
                     dcname = "W{charge}_{hel}_{channel}_Ybin_{iy}{syst}".format(charge=charge, hel=helicity, channel=options.channel,iy=iy,syst=syst)
-                    BIN_OPTS=OPTIONS + " -W '" + options.weightExpr + "'" + " -o "+dcname+" --od "+outdir + xpsel + ycut
+                    zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenPromptNu_pt[0],GenPromptNu_phi[0]))'
+                    fullWeight = options.weightExpr+'*'+zptWeight if 'W' in options.procsToPtReweight else options.weightExpr
+                    BIN_OPTS=OPTIONS + " -W '" + fullWeight+ "'" + " -o "+dcname+" --od "+outdir + xpsel + ycut
                     if options.queue:
                         mkShCardsCmd = "python makeShapeCards.py {args} \n".format(dir = os.getcwd(), args = IARGS+" "+BIN_OPTS)
                         ## here accumulate signal jobs if running with long. make long+right+left one job
@@ -467,7 +469,7 @@ if options.bkgdataCards and len(pdfsysts+inclqcdsysts)>1:
         for charge in ['plus','minus']:
             antich = 'plus' if charge == 'minus' else 'minus'
             if ivar==0: 
-                IARGS = ARGS.replace(MCA,"{outdir}/mca/mca{syst}.txt".format(outdir=outdir,syst=var))
+                IARGS = ARGS
             else: 
                 IARGS = ARGS.replace(MCA,"{outdir}/mca/mca{syst}.txt".format(outdir=outdir,syst=var))
                 IARGS = IARGS.replace(SYSTFILE,"{outdir}/mca/systEnv-dummy.txt".format(outdir=outdir))
@@ -477,7 +479,9 @@ if options.bkgdataCards and len(pdfsysts+inclqcdsysts)>1:
             xpsel=' --xp "[^Z]*" --asimov '
             syst = '' if ivar==0 else var
             dcname = "Z_{channel}_{charge}{syst}".format(channel=options.channel, charge=charge,syst=syst)
-            BIN_OPTS=OPTIONS + " -W '" + options.weightExpr + "'" + " -o "+dcname+" --od "+outdir + xpsel + chcut
+            zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenLepDressed_pt[1],GenLepDressed_phi[1]))'
+            fullWeight = options.weightExpr+'*'+zptWeight if 'Z' in options.procsToPtReweight else options.weightExpr
+            BIN_OPTS=OPTIONS + " -W '" + fullWeight + "'" + " -o "+dcname+" --od "+outdir + xpsel + chcut
             if options.queue:
                 mkShCardsCmd = "python makeShapeCards.py {args} \n".format(dir = os.getcwd(), args = IARGS+" "+BIN_OPTS)
                 if options.useLSF:
@@ -504,7 +508,7 @@ if options.bkgdataCards and len(pdfsysts+qcdsysts)>1:
         for charge in ['plus','minus']:
             antich = 'plus' if charge == 'minus' else 'minus'
             if ivar==0: 
-                IARGS = ARGS.replace(MCA,"{outdir}/mca/mca{syst}.txt".format(outdir=outdir,syst=var))
+                IARGS = ARGS
             else: 
                 IARGS = ARGS.replace(MCA,"{outdir}/mca/mca{syst}.txt".format(outdir=outdir,syst=var))
                 IARGS = IARGS.replace(SYSTFILE,"{outdir}/mca/systEnv-dummy.txt".format(outdir=outdir))
@@ -514,7 +518,9 @@ if options.bkgdataCards and len(pdfsysts+qcdsysts)>1:
             xpsel=' --xp "[^TauDecaysW]*" --asimov '
             syst = '' if ivar==0 else var
             dcname = "TauDecaysW_{channel}_{charge}{syst}".format(channel=options.channel, charge=charge,syst=syst)
-            BIN_OPTS=OPTIONS + " -W '" + options.weightExpr + "'" + " -o "+dcname+" --od "+outdir + xpsel + chcut
+            zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenPromptNu_pt[0],GenPromptNu_phi[0]))'
+            fullWeight = options.weightExpr+'*'+zptWeight if 'TauDecaysW' in options.procsToPtReweight else options.weightExpr
+            BIN_OPTS=OPTIONS + " -W '" + fullWeight + "'" + " -o "+dcname+" --od "+outdir + xpsel + chcut
             if options.queue:
                 mkShCardsCmd = "python makeShapeCards.py {args} \n".format(dir = os.getcwd(), args = IARGS+" "+BIN_OPTS)
                 if options.useLSF:
@@ -614,7 +620,6 @@ Output     = {jd}/$(ProcId).out
 Error      = {jd}/$(ProcId).error
 getenv      = True
 environment = "LS_SUBCWD={here}"
-requirements = (OpSysAndVer =?= "SLCern6")
 request_memory = 4000
 +MaxRuntime = {rt}\n
 '''.format(de=os.path.abspath(dummy_exec.name), jd=os.path.abspath(jobdir), rt=getCondorTime(options.queue), here=os.environ['PWD'] ) )


### PR DESCRIPTION
to enable it on signal W, Z or TauDecaysW, add: 

`parser.add_option('--vpt-weight', dest='procsToPtReweight', action="append", default=[], help="processes to be reweighted according the measured/predicted DY pt. Default is none (possible W,TauDecaysW,Z)`

the default is no reweight, as before.
@bendavid we can test the separate impact on Z-only, Z-only + W(both signal and W->tau).

The weights applied are the ones for MC@NLO (**inverse** of top panel from SMP-17-010):

![image](https://user-images.githubusercontent.com/4517974/59201587-087b4980-8b9b-11e9-9315-650207fcb70e.png)
 

 
