### PR TITLE
Make the WTau and DY faster and uncorrelated QCD scales for L,R,long

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -472,7 +472,7 @@ if options.bkgdataCards and len(pdfsysts+inclqcdsysts)>1:
         for charge in ['plus','minus']:
             antich = 'plus' if charge == 'minus' else 'minus'
             if ivar==0: 
-                IARGS = ARGS
+                IARGS = ARGS.replace(MCA,"{outdir}/mca/mca_dy_nominal.txt".format(outdir=outdir))
             else: 
                 IARGS = ARGS.replace(MCA,"{outdir}/mca/mca{syst}.txt".format(outdir=outdir,syst=var))
                 IARGS = IARGS.replace(SYSTFILE,"{outdir}/mca/systEnv-dummy.txt".format(outdir=outdir))
@@ -511,7 +511,7 @@ if options.bkgdataCards and len(pdfsysts+qcdsysts)>1:
         for charge in ['plus','minus']:
             antich = 'plus' if charge == 'minus' else 'minus'
             if ivar==0: 
-                IARGS = ARGS
+                IARGS = ARGS.replace(MCA,"{outdir}/mca/mca_wtau_nominal.txt".format(outdir=outdir))
             else: 
                 IARGS = ARGS.replace(MCA,"{outdir}/mca/mca{syst}.txt".format(outdir=outdir,syst=var))
                 IARGS = IARGS.replace(SYSTFILE,"{outdir}/mca/systEnv-dummy.txt".format(outdir=outdir))

--- a/WMass/python/plotter/w-helicity-13TeV/postFitPlots.py
+++ b/WMass/python/plotter/w-helicity-13TeV/postFitPlots.py
@@ -349,7 +349,7 @@ if __name__ == "__main__":
     savErrorLevel = ROOT.gErrorIgnoreLevel; ROOT.gErrorIgnoreLevel = ROOT.kError;
     
     infile = ROOT.TFile(args[0], 'read')
-    channel = 'el' if any(['el_Ybin' in k.GetName() for k in infile.GetListOfKeys()]) else 'mu'
+    channel = utilities.getChannelFromFitresults(infile)
     print "From the list of histograms it seems that you are plotting results for channel ",channel
 
     full_outfileName = '{odir}/plots_{sfx}.root'.format(odir=outname,sfx=options.suffix)
@@ -490,8 +490,8 @@ if __name__ == "__main__":
      
             for projection in ['X','Y']:
                 nbinsProj = all_procs['obs'].GetNbinsY() if projection=='X' else all_procs['obs'].GetNbinsX()
-                hexpfull = h2_expfull_backrolled.ProjectionX("x_expfull_{sfx}_{ch}".format(sfx=prepost,ch=charge),1,nbinsProj,"e") if projection=='X' else h2_expfull_backrolled.ProjectionY("y_expfull_{sfx}_{ch}".format(sfx=prepost,ch=charge),1,nbinsProj,"e")
-                hdata = all_procs['obs'].ProjectionX("x_data_{ch}".format(ch=charge),1,nbinsProj,"e") if projection=='X' else all_procs['obs'].ProjectionY("y_data_{ch}".format(ch=charge),1,nbinsProj,"e")
+                hexpfull = h2_expfull_backrolled.ProjectionX("x_expfull_{sfx}_{ch}".format(sfx=prepost,ch=charge),0,-1,"e") if projection=='X' else h2_expfull_backrolled.ProjectionY("y_expfull_{sfx}_{ch}".format(sfx=prepost,ch=charge),0,-1,"e")
+                hdata = all_procs['obs'].ProjectionX("x_data_{ch}".format(ch=charge),0,-1,"e") if projection=='X' else all_procs['obs'].ProjectionY("y_data_{ch}".format(ch=charge),0,-1,"e")
                 htot = hdata.Clone('tot_{ch}'.format(ch=charge)); htot.Reset(); htot.Sumw2()
                 stack = ROOT.THStack("stack_{sfx}_{ch}".format(sfx=prepost,ch=charge),"")
                 

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -722,4 +722,8 @@ class util:
         if len(los)  > 1: return los[1] if 'EffStat' in s else los[0]
         return 0
         
+    def getChannelFromFitresults(self, fitresults):
+        t_fitres = fitresults.Get('fitresults')
+        channel = 'el' if 'ErfPar0EffStat1elminus' in t_fitres.GetListOfBranches() else 'mu'
+        return channel
 


### PR DESCRIPTION
- make (again?) the WTau and DY card making faster by loading only the respective files (as for the systematics)
- code by @mdunser for decorrelating the QCD scales for L,R,long (for electrons need to hack the existing cards)
- a couple of minor updates elsewhere