### PR TITLE
rescale pt-reweighted W and Wtau back to the total xsec prediction of MC@NLO

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/functionsWMass.cc
+++ b/WMass/python/plotter/w-helicity-13TeV/functionsWMass.cc
@@ -132,14 +132,17 @@ float fsrPhotosWeight(int pdgId, float dresseta, float dresspt, float barept) {
 TFile *_file_dyptWeights = NULL;
 TH1F *amcnlody = NULL; 
 
-float dyptWeight(float pt2l) {
+float dyptWeight(float pt2l, int isZ) {
   if (!amcnlody) {
     _file_dyptWeights = new TFile("w-helicity-13TeV/dyReweighting/zpt_weights.root");
     amcnlody = (TH1F*)(_file_dyptWeights->Get("amcnlo"));
   }
   int ptbin = std::max(1, std::min(amcnlody->GetNbinsX(), amcnlody->GetXaxis()->FindFixBin(pt2l)));
+  // for the Z, change the pT *and* normalization to the measured one in data
+  // for the W, change only the pT, but scale back to the total xsec of MC@NLO (factor comptued for total xsec)
+  float scaleToMCaNLO = isZ ? 1. : 0.958;
   // plots are MC/data
-  return 1./amcnlody->GetBinContent(ptbin);
+  return scaleToMCaNLO / amcnlody->GetBinContent(ptbin);
 }
 
 

--- a/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
+++ b/WMass/python/plotter/w-helicity-13TeV/make_helicity_cards.py
@@ -404,7 +404,7 @@ if options.signalCards:
                     if options.queue and not os.path.exists(outdir+"/jobs"): os.mkdir(outdir+"/jobs")
                     syst = '' if ivar==0 else var
                     dcname = "W{charge}_{hel}_{channel}_Ybin_{iy}{syst}".format(charge=charge, hel=helicity, channel=options.channel,iy=iy,syst=syst)
-                    zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenPromptNu_pt[0],GenPromptNu_phi[0]))'
+                    zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenPromptNu_pt[0],GenPromptNu_phi[0]),0)'
                     fullWeight = options.weightExpr+'*'+zptWeight if 'W' in options.procsToPtReweight else options.weightExpr
                     BIN_OPTS=OPTIONS + " -W '" + fullWeight+ "'" + " -o "+dcname+" --od "+outdir + xpsel + ycut
                     if options.queue:
@@ -482,7 +482,7 @@ if options.bkgdataCards and len(pdfsysts+inclqcdsysts)>1:
             xpsel=' --xp "[^Z]*" --asimov '
             syst = '' if ivar==0 else var
             dcname = "Z_{channel}_{charge}{syst}".format(channel=options.channel, charge=charge,syst=syst)
-            zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenLepDressed_pt[1],GenLepDressed_phi[1]))'
+            zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenLepDressed_pt[1],GenLepDressed_phi[1]),1)'
             fullWeight = options.weightExpr+'*'+zptWeight if 'Z' in options.procsToPtReweight else options.weightExpr
             BIN_OPTS=OPTIONS + " -W '" + fullWeight + "'" + " -o "+dcname+" --od "+outdir + xpsel + chcut
             if options.queue:
@@ -521,7 +521,7 @@ if options.bkgdataCards and len(pdfsysts+qcdsysts)>1:
             xpsel=' --xp "[^TauDecaysW]*" --asimov '
             syst = '' if ivar==0 else var
             dcname = "TauDecaysW_{channel}_{charge}{syst}".format(channel=options.channel, charge=charge,syst=syst)
-            zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenPromptNu_pt[0],GenPromptNu_phi[0]))'
+            zptWeight = 'dyptWeight(pt_2(GenLepDressed_pt[0],GenLepDressed_phi[0],GenPromptNu_pt[0],GenPromptNu_phi[0]),0)'
             fullWeight = options.weightExpr+'*'+zptWeight if 'TauDecaysW' in options.procsToPtReweight else options.weightExpr
             BIN_OPTS=OPTIONS + " -W '" + fullWeight + "'" + " -o "+dcname+" --od "+outdir + xpsel + chcut
             if options.queue:

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -744,6 +744,8 @@ def cleanProcessName(name):
     cleanName = '_'.join([t for t in uniquet if (t!='el' and t!='mu')])
     return cleanName
 
+W_MCANLO_over_DATA_fromZ = 0.958
+
 if __name__ == "__main__":
     
 
@@ -771,6 +773,7 @@ if __name__ == "__main__":
     parser.add_option(       '--postfix',    dest='postfix', type="string", default="", help="Postfix for .hdf5 file created with text2hdf5.py when combining charges");
     parser.add_option(       '--no-text2hdf5'  , dest='skip_text2hdf5', default=False, action='store_true', help='when combining charges, skip running text2hdf5.py at the end')
     parser.add_option(       '--WZ-testEffSyst-shape'   , dest='wzTestEffSystShape', default=False, action='store_true', help='Add efficiency systematics in bins of eta calling putTestEffSyst(). Eta bins are not exclusive, but overalps (e.g. one all over the template, one only for |eta|>XX and so on). If True, the nuisance CMS_Wxx_sig_lepeff is disabled')
+    parser.add_option(       '--rescaleWBackToMCaNLO'   , dest='rescaleWBackToMCaNLO', default=False, action='store_true', help='Rescale the W process back to pure MC@NLO. NOT TO BE USED IF THE RESCALING WAS DONE AT THE WPT REWEIGHTING LEVEL ! ')
     (options, args) = parser.parse_args()
     
     if options.combineCharges:
@@ -809,6 +812,10 @@ if __name__ == "__main__":
 
     if options.longBkg:
         print 'I WILL TREAT ALL BINS FOR LONGITUDINAL POLARIZATON AS BACKGROUND'
+        print '---------------------------------'
+
+    if options.rescaleWBackToMCaNLO:
+        print 'I WILL RESCALE THE W AND WTAU OF A FACTOR ',W_MCANLO_over_DATA_fromZ,'. THIS ASSUMES YOU HAVE NOT RESCALED IT IN THE REWEIGHTING IN THE DC MAKING PROCESS !'
         print '---------------------------------'
 
     excludeNuisances = []
@@ -905,6 +912,8 @@ if __name__ == "__main__":
                                     if longBKG and re.match('(Wplus_long|Wminus_long)',p): newprocname = p
                                     newname = name.replace(p,newprocname)
                                     newprocname = cleanProcessName(newprocname); newname = cleanProcessName(newname)
+                                    if re.match('x_(Wplus|Wminus|TauDecaysW)_.*',newname) and options.rescaleWBackToMCaNLO:
+                                        obj.Scale(W_MCANLO_over_DATA_fromZ)
                                     if irf==0:
                                         if newname not in plots:
                                             ############### special case to fix jet pt syst on FR


### PR DESCRIPTION
- when re-making the cards, the boson pt reweighting will do by default:
   * Z pt will be rescaled in shape AND normalization according to the SMP-17-010 (see pr #517 #518 ). 
   * W (signal and tau decays) will be reweighted in shape, but the total yield rescaled back to MC@NLO 
- since we have cards done with the boson reweighting that has W rescaled also in normalization, add an option to the merger to rescale back to MC@NLO here. 
Since this need will vanish when we will have new cards, the option is *FALSE* by default. To turn it ON, add: 

`--rescaleWBackToMCaNLO`
