### PR TITLE
make the FSR systematics shape-only

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -956,10 +956,11 @@ if __name__ == "__main__":
                                                 tokens = patt.findall(newname)
                                                 sysname = tokens[0][0]; isys = int(tokens[0][1])
                                                 newname = "{pfx}_{sysname}{isys}".format(pfx=pfx,sysname=sysname,isys=isys)
+                                                (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname,options.pdfShapeOnly)
                                             else:
                                                 tokens = newname.split("_"); pfx = '_'.join(tokens[:-2]); syst = tokens[-1]
                                                 newname = "{pfx}_{syst}".format(pfx=pfx,syst=syst)
-                                            (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname,options.pdfShapeOnly)
+                                                (alternate,mirror) = mirrorShape(nominals[pfx],obj,newname,alternateShapeOnly=True)
                                             for alt in [alternate,mirror]:
                                                 if alt.GetName() not in plots:
                                                     plots[alt.GetName()] = alt.Clone()


### PR DESCRIPTION
in the way as it is implemented should not change much the normalization (the photos/pythia ratio is normalized to same rate in coarse lepton eta/pt bins).

This is the effect on electron pt for W+ left:
![image](https://user-images.githubusercontent.com/4517974/59914084-ecd53600-9419-11e9-81ee-3a2a7f1a64f1.png)
