### PR TITLE
now groups can mix signal and bkg processes

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -1290,35 +1290,15 @@ if __name__ == "__main__":
         ## first make a list of all the signal processes.
         ## then, some processes and/or polarizations might be removed
         tmp_sigprocs = [p for p in realprocesses if 'Wminus' in p or 'Wplus' in p]
-        polarizations = ['left','right']
+        polarizations = ['left','right','long']
 
-        if options.longBkg: 
-            tmp_sigprocs = filter(lambda x: 'long_' not in x,tmp_sigprocs)
-        else:
-            polarizations.append('long')
-
-        if options.ybinsBkg != '':
-            pruned_tmp_sigprocs = []
-            for thisproc in tmp_sigprocs:
-                thisybin = get_iy_from_process_name(thisproc)
-                if any(thisybin == x for x in bkgYBins): pass
-                else: pruned_tmp_sigprocs.append(thisproc)
-            tmp_sigprocs = pruned_tmp_sigprocs
-
-        # filters already made above (options.longLnN automatically activates options.longBkg)
-        #if options.longLnN: 
-        #    tmp_sigprocs = filter(lambda x: 'long_' not in x,tmp_sigprocs)
-        #else:
-        #    polarizations.append('long')
         print '============================================================================='
         print 'I WILL NOW WRITE CHARGE GROUPS AND ALL THAT STUFF FOR THE FOLLOWING PROCESSES'
         print tmp_sigprocs
         print '============================================================================='
         # in case long is missing, the sum groups will only sum WR and WL, while polGroup cannt be defined
         if not options.freezePOIs:
-            if not options.longLnN and not options.longBkg:
-                writePolGroup(combinedCard,tmp_sigprocs,polarizations,grouping='polGroup')
-            # the following works even if Wlong is missing, although their usefulness in this case is questionable
+            writePolGroup(combinedCard,tmp_sigprocs,polarizations,grouping='polGroup')
             writePolGroup(combinedCard,tmp_sigprocs,polarizations,grouping='sumGroup')
             writeRegGroup(combinedCard,tmp_sigprocs,polarizations,grouping='regGroup')
             writeChargeGroup(combinedCard,tmp_sigprocs,polarizations)


### PR DESCRIPTION
using the latest @bendavid update of combinetf. This simplifies things and:
- unpolarized xsec is now L+R+0 even if 0 is a bkg
- this gives the normalized unpolarized xsec 

need to merge https://github.com/WMass/HiggsAnalysis-CombinedLimit/pull/29 from the wmass repository