### PR TITLE
other updates for 2D xsec and for QCD scales

### DIFF
--- a/WMass/python/plotter/commandForDiffXsec.py
+++ b/WMass/python/plotter/commandForDiffXsec.py
@@ -6,9 +6,9 @@ dryrun=0
 doMuons=1
 skipUnpack=1
 skipMergeRoot=1
-skipSingleCard=1
-skipMergeCard=1
-skipMergeCardFlavour=0 # requires both flavours, and the electron cards must have all signal bins considered as signal
+skipSingleCard=0
+skipMergeCard=0
+skipMergeCardFlavour=1 # requires both flavours, and the electron cards must have all signal bins considered as signal
 
 allPtBinsSignal = 1
 
@@ -24,7 +24,7 @@ th3file_el = "cards/" + folder_el + "wel_15June2019_zptReweight.root"
 #th3file_mu = "cards/" + folder_mu + "wmu_recoEta0p1_recoPt1_genEta0p2from1p3_last2p1to2p4_genPt2.root"
 #folder_mu = "diffXsec_mu_2019_06_23_zptReweight_ptReco30/" # keep "/" at the end
 #th3file_mu = "cards/" + folder_mu + "wmu_23June2019_zptReweight_ptReco30.root"
-folder_mu = "diffXsec_mu_2019_06_17_zptReweight/" # keep "/" at the end
+folder_mu = "diffXsec_mu_2019_06_17_zptReweight_chargeUncorrQCDscales/" # keep "/" at the end
 th3file_mu = "cards/" + folder_mu + "wmu_15June2019_zptReweight.root"
 
 folder = folder_mu if doMuons else folder_el
@@ -36,9 +36,9 @@ uncorrelateFakesNuisancesByCharge = False # need to rerun the MergeRoot when cha
 #================================
 # some more things are set below
 
-optionsForRootMerger = " --test-eff-syst --etaBordersForFakesUncorr " + ("0.5,1.0,1.5,1.9 " if doMuons else "0.5,1.0,1.5,1.9 ") #+ " --useBinUncEffStat " 
+optionsForRootMerger = " --uncorrelate-QCDscales-by-charge --test-eff-syst --etaBordersForFakesUncorr " + ("0.5,1.0,1.5,1.9 " if doMuons else "0.5,1.0,1.5,1.9 ") #+ " --useBinUncEffStat " 
 binnedSystOpt = " --WZ-testEffSyst-shape '0.0,1.0,1.5' --WZ-ptScaleSyst-shape '0.0,2.1' " if doMuons else " --WZ-testEffSyst-shape '0.0,1.0,1.479,2.0' --WZ-ptScaleSyst-shape '0.0,1.0,1.5,2.1' "
-optionsForCardMaker = " --unbinned-QCDscale-Z --sig-out-bkg  --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous,CMS.*sig_lepeff' " 
+optionsForCardMaker = " --uncorrelate-QCDscales-by-charge --unbinned-QCDscale-Z --sig-out-bkg  --exclude-nuisances 'CMS_DY,CMS_.*FR.*_slope,CMS_.*FR.*_continuous,CMS.*sig_lepeff' " 
 optionsForCardMaker += binnedSystOpt # + " --useBinUncEffStat "
 
 #--WZ-testEffSyst-LnN 0.012" 
@@ -46,7 +46,7 @@ optionsForCardMaker += binnedSystOpt # + " --useBinUncEffStat "
 ### --uncorrelate-fakes-by-charge   
 # --fakesChargeLnN 0.03 --tauChargeLnN 0.03
 
-optionsForCardMakerMerger = " --postfix zptReweight  --sig-out-bkg " #--no-text2hdf5 --no-combinetf --useSciPyMinimizer  " 
+optionsForCardMakerMerger = " --postfix zptReweight_uncorrQCDscales  --sig-out-bkg " #--no-text2hdf5 --no-combinetf --useSciPyMinimizer  " 
 # --no-correlate-xsec-stat
 
 optionsForCardMakerMergerFlavour = " --postfix combinedLep_zptReweight --sig-out-bkg " # --no-text2hdf5 --no-combinetf --useSciPyMinimizer "  

--- a/WMass/python/plotter/makeCardsFromTH1.py
+++ b/WMass/python/plotter/makeCardsFromTH1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python                                                                                                     
+ #!/usr/bin/env python                                                                                                     
  
 from shutil import copyfile
 import re, sys, os, os.path, subprocess, json, ROOT
@@ -250,6 +250,7 @@ parser.add_option(       '--WZ-testEffSyst-LnN'   , dest='wzTestEffSystLnN'     
 parser.add_option(       '--WZ-testEffSyst-shape'   , dest='wzTestEffSystShape', default="", type='string', help='Add these nuisance passing comma-separated list of edges where eff.syst changes. For signal, only gen bins containing that region take this systematics. E.g.: pass 0,1.0,1.5')
 parser.add_option(       '--WZ-ptScaleSyst-shape'   , dest='wzPtScaleSystShape', default="", type='string', help='Add these nuisance passing comma-separated list of edges where pt-scale syst changes. For signal, only gen bins containing that region take this systematics. E.g.: pass 0,2.1 for muons, 0,1.0,1.5,2.1 for electrons')
 parser.add_option(       '--useBinUncEffStat', dest='useBinUncEffStat' , default=False, action='store_true', help='Will use uncertainty on signal made shifting trigger SF by their uncertainties (alternative to ErfPar.*EffStat nuisances (which should be disabled)')
+parser.add_option(       '--uncorrelate-QCDscales-by-charge', dest='uncorrelateQCDscalesByCharge' , default=False, action='store_true', help='Use charge-dependent QCD scales (on signal and tau)')
 (options, args) = parser.parse_args()
 
 print ""
@@ -696,9 +697,10 @@ if not isExcludedNuisance(excludeNuisances, "fsr"):
 
 qcdScale_wptBins = [] 
 for i in range(1,11):
-    qcdScale_wptBins.append("muR%d" % i)
-    qcdScale_wptBins.append("muF%d" % i)
-    qcdScale_wptBins.append("muRmuF%d" % i)
+    chargePostfixQCDscales = charge if options.uncorrelateQCDscalesByCharge else ""
+    qcdScale_wptBins.append("muR%d%s" % (i,charge))
+    qcdScale_wptBins.append("muF%d%s" % (i,charge))
+    qcdScale_wptBins.append("muRmuF%d%s" % (i,charge))
 for syst in qcdScale_wptBins:
     if isExcludedNuisance(excludeNuisances, syst): continue
     allSystForGroups.append(syst)

--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -4,14 +4,14 @@ import ROOT, os, sys, re, array
 
 # to run plots from Asimov fit and data. For toys need to adapt this script
 
-doMuElComb = 1
+doMuElComb = 0
 dryrun = 0
 skipData = 0
 onlyData = 1
 
-skipPlot = 0
+skipPlot = 1
 skipTemplate = 1
-skipDiffNuis = 1
+skipDiffNuis = 0
 skipPostfit = 1  # only for Data
 skipCorr = 1
 skipImpacts = 1
@@ -28,7 +28,8 @@ seed = 123456789
 #folder = "diffXsec_mu_2019_05_04_etaReco0p1_etaGen0p2from1p3_last2p1to2p4//"
 #folder = "diffXsec_mu_2019_05_09_recoEta0p1_recoPt1_genEta0p2from1p3_last2p1to2p4_genPt2/"
 #folder = "diffXsec_mu_2019_06_17_zptReweight/"
-folder = "diffXsec_el_2019_06_21_zptReweight/"
+#folder = "diffXsec_el_2019_06_21_zptReweight/"
+folder = "diffXsec_mu_2019_06_17_zptReweight_chargeUncorrQCDscales/"
 #folder = "diffXsec_mu_2019_06_23_zptReweight_ptReco30/"
 if doMuElComb:
     folder = "muElCombination"
@@ -42,7 +43,7 @@ if doMuElComb:
 #postfix = "finalTest_EffStatNotScaled"
 #postfix = "finalTest_EffStatNotScaled_noScipyMinimizer"
 #postfix = "zptReweight"
-postfix = "zptReweight"
+postfix = "zptReweight_uncorrQCDscales"
 #postfix = "combinedLep"
 if doMuElComb:
     postfix = "combinedLep_zptReweight"
@@ -60,23 +61,23 @@ fits = ["Asimov", "Data"]
 
 ptBinsSetting = " --pt-range-bkg 25.9 30.1 --pt-range '30,56' " if (not allPtBinsSignal) else ""  # " --eta-range-bkg 1.39 1.61 "
 ptMinForImpacts = " --pt-min-signal 30" if (not allPtBinsSignal) else ""
-optTemplate = " --norm-width --draw-selected-etaPt 0.55,39.5 --syst-ratio-range 'template' --palette 57 --do-signal-syst '.*TestEffStat.*|.*scale0.*|.*scale1.*|.*lepeff.*' "  # --draw-selected-etaPt 0.45,38 --zmin 10 # kLightTemperature=87
+optTemplate = " --norm-width --draw-selected-etaPt 2.05,35.0 --syst-ratio-range 'template' --palette 57 --do-signal-syst '.*TestEffStat.*|.*scale0.*|.*scale1.*|.*lepeff.*' "  # --draw-selected-etaPt 0.45,38 --zmin 10 # kLightTemperature=87
 ptMaxTemplate = "56"
 ptMinTemplate = "30" if (flavour == "el" or not allPtBinsSignal) else "26"
 
 # do not ask Wplus.*_ieta_.*_mu$ to select signal strength rejecting pmasked, because otherwise you must change diffNuisances.py
 # currently it uses GetFromHessian with keepGen=True, so _mu$ would create a problem (should implement the possibility to reject a regular expression)
 # if you want mu rejecting pmasked do _mu_mu or _el_mu (for electrons _mu works because it doesn't induce ambiguities with the flavour)
-diffNuisances_pois = ["pdf.*|alphaS|mW|fsr", 
+diffNuisances_pois = [#"pdf.*|alphaS|mW|fsr", 
                       "muR.*|muF.*", 
-                      "Fakes(Eta|Pt).*[0-9]+mu.*", 
+                      #"Fakes(Eta|Pt).*[0-9]+mu.*", 
                       #"Fakes(Eta|Pt).*[0-9]+el.*", 
-                      "ErfPar0EffStat.*", 
-                      "ErfPar1EffStat.*", 
-                      "ErfPar2EffStat.*", 
-                      "CMS_.*|.*TestEffSyst.*", 
-                      "Wplus.*_ieta_.*_mu",     
-                      "Wminus.*_ieta_.*_mu"
+                      #"ErfPar0EffStat.*", 
+                      #"ErfPar1EffStat.*", 
+                      #"ErfPar2EffStat.*", 
+                      #"CMS_.*|.*TestEffSyst.*", 
+                      #"Wplus.*_ieta_.*_mu",     
+                      #"Wminus.*_ieta_.*_mu"
                       ]
 
 # this is appended to nuis below

--- a/WMass/python/plotter/plotUtils/utility.py
+++ b/WMass/python/plotter/plotUtils/utility.py
@@ -924,8 +924,8 @@ def drawDataAndMC(h1, h2,
         h3.SetFillColor(ROOT.kRed+2)
         h3.SetFillStyle(3244)  # 3144 , 3244, 3003
         h3.Draw("E2 SAME")
-        for i in range(1,1+h3.GetNbinsX()):
-            print "PDF band: bin %d  val +/- error = %.3f +/- %.3f" % (i, h3.GetBinContent(i),h3.GetBinError(i))
+        #for i in range(1,1+h3.GetNbinsX()):
+        #    print "PDF band: bin %d  val +/- error = %.3f +/- %.3f" % (i, h3.GetBinContent(i),h3.GetBinError(i))
     h2line.Draw("HIST SAME")
     h1.Draw("EP SAME")
 

--- a/WMass/python/plotter/w-helicity-13TeV/diffNuisances.py
+++ b/WMass/python/plotter/w-helicity-13TeV/diffNuisances.py
@@ -8,6 +8,8 @@ import datetime
 from optparse import OptionParser
 #import HiggsAnalysis.CombinedLimit.calculate_pulls as CP 
 from make_diff_xsec_cards import get_ieta_ipt_from_process_name
+from make_diff_xsec_cards import get_ipt_from_process_name
+from make_diff_xsec_cards import get_ieta_from_process_name
 from subMatrix import niceName
 
 import ROOT
@@ -73,9 +75,12 @@ if __name__ == "__main__":
         params = sorted(params, key = lambda x: int(x.split('pdf')[-1]) if 'pdf' in x else 0, reverse=False)
     elif any(re.match('.*muR.*|.*muF.*',x) for x in params):
         params = sorted(params)
-        params = sorted(params, key= lambda x: int(re.sub('\D','',x)) if ('muRmuF' in x and x != "muRmuF")  else 0)
-        params = sorted(params, key= lambda x: int(re.sub('\D','',x)) if (''.join([j for j in x if not j.isdigit()]) == 'muR' and x != "muR") else 0)
-        params = sorted(params, key= lambda x: int(re.sub('\D','',x)) if (''.join([j for j in x if not j.isdigit()]) == 'muF' and x != "muF") else 0)
+        # params = sorted(params, key= lambda x: int(re.sub('\D','',x)) if ('muRmuF' in x and x != "muRmuF")  else 0)
+        # params = sorted(params, key= lambda x: int(re.sub('\D','',x)) if (''.join([j for j in x if not j.isdigit()]) == 'muR' and x != "muR") else 0)
+        # params = sorted(params, key= lambda x: int(re.sub('\D','',x)) if (''.join([j for j in x if not j.isdigit()]) == 'muF' and x != "muF") else 0)
+        params = sorted(params, key= lambda x: utilities.getNFromString(x))
+        params = sorted(params, key = lambda x: 0 if "muRmuF" in x else 1 if "muR" in x else 2 if "muF" in x else 3)
+        params = sorted(params, key = lambda x: 0 if "plus" in x else 1 if "minus" in x else 2)
     elif any(re.match('FakesEtaUncorrelated.*',x) for x in params):
         params = sorted(params, key = lambda x: utilities.getNFromString(x), reverse=False)
     elif any(re.match('FakesPtUncorrelated.*',x) for x in params):
@@ -302,7 +307,7 @@ if __name__ == "__main__":
         canvas_nuis.SetTopMargin(ctm)
 
         lat.DrawLatex(0.10, 0.92, '#bf{CMS} #it{Preliminary}')
-        lat.DrawLatex(0.71 +(0.1-crm), 0.92, '36 fb^{-1} (13 TeV)')
+        lat.DrawLatex(0.71 +(0.1-crm), 0.92, '35.9 fb^{-1} (13 TeV)')
         line.DrawLine(0., ycen, len(params), ycen)
         line.DrawLine(0., ymax, len(params), ymax)
         line.DrawLine(0., ymin, len(params), ymin)

--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsDiffXsec.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsDiffXsec.py
@@ -89,8 +89,13 @@ def getXsecs_etaPt(processes, systs, etaPtBins, infile, usePreFSR = True):
 
         hists.append(copy.deepcopy(tmp_hist))
 
-        for sys in systs:
+        for sys_tmp in systs:
 
+            sys = sys_tmp
+            if any(x in sys for x in ["muR","muF"]):
+                # if I want to uncorrelate QCD scales by charge I can still use the old histogram
+                sys = sys.replace(charge,'')
+                # print "sys_tmp = %s    sys = %s" % (sys_tmp,sys)
             # scales muR, muF, muRmuF in bins of pt are named like mu1RUp, where the number after muR goes from 1 to 10
             # pdf do not have Up and Dn inside file
             upn = sys+'Up' if not 'pdf' in sys else sys
@@ -129,12 +134,12 @@ def getXsecs_etaPt(processes, systs, etaPtBins, infile, usePreFSR = True):
                 ndn = sys_dn_hist.Integral(istart_eta, iend_eta-1, istart_pt,iend_pt-1)
 
             if 'pdf' in sys:
-                ndn = ncen*ncen/nup # ndn = 2.*ncen-nup ## or ncen/nup?  # FIXME: this should be decided and motivated
+                ndn = 2.*ncen - nup # ndn = 2.*ncen-nup ## or ncen/nup?  # FIXME: this should be decided and motivated
                 # I think we should be consistent with the histogram definition, which uses the ratio, but if central and up differs by an epsilon it doesn't matter
 
-            tmp_hist_up = ROOT.TH1F('x_'+process+'_'+sys+'Up','x_'+process+'_'+sys+'Up', 1, 0., 1.)
+            tmp_hist_up = ROOT.TH1F('x_'+process+'_'+sys_tmp+'Up','x_'+process+'_'+sys+'Up', 1, 0., 1.)
             tmp_hist_up.SetBinContent(1, nup)
-            tmp_hist_dn = ROOT.TH1F('x_'+process+'_'+sys+'Down','x_'+process+'_'+sys+'Dn', 1, 0., 1.)
+            tmp_hist_dn = ROOT.TH1F('x_'+process+'_'+sys_tmp+'Down','x_'+process+'_'+sys+'Dn', 1, 0., 1.)
             tmp_hist_dn.SetBinContent(1, ndn)
             hists.append(copy.deepcopy(tmp_hist_up))
             hists.append(copy.deepcopy(tmp_hist_dn))

--- a/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotDiffXsecChargeAsymmetry.py
@@ -325,8 +325,8 @@ if __name__ == "__main__":
                   passCanvas=canvas1D, lumi=options.lumiInt,
                   lowerPanelHeight=0.35, moreTextLatex=additionalText
                   )
-    legendCoords = "0.6,0.8,0.75,0.85"
-    texCoord = "0.6,0.65"
+    legendCoords = "0.2,0.4,0.45,0.55"
+    texCoord = "0.6,0.85"
     additionalText = "W #rightarrow {lep}#nu;{etatext}::{txc},0.08,0.04".format(lep="e" if channel == "el" else "#mu" if channel == "mu" else "l", 
                                                                                etatext=etaRangeText,
                                                                                txc=texCoord)
@@ -672,7 +672,7 @@ if __name__ == "__main__":
                       lowerPanelHeight=0.35, moreTextLatex=additionalText
                       )
         legendCoords = "0.65,0.85,0.75,0.85"
-        texCoord = "0.2,0.4"
+        texCoord = "0.2,0.5"
         additionalText = "W^{{{chs}}} #rightarrow {lep}#nu;{etatext}::{txc},0.08,0.04".format(chs=" "+chargeSign,
                                                                                              lep="e" if channel == "el" else "#mu" if channel == "mu" else "l",
                                                                                              etatext=etaRangeText,
@@ -1076,7 +1076,7 @@ if __name__ == "__main__":
                                   #histMCpartialUnc=hChAsymmPDF_1D, histMCpartialUncLegEntry="PDF unc."
                                   )
                     
-                    legendCoords = "0.2,0.4,0.3,0.4"
+                    legendCoords = "0.2,0.4,0.4,0.5"
                     texCoord = "0.6,0.88"
                     additionalText = "W #rightarrow {lep}#nu;{pttext}::{txc},0.08,0.04".format(lep="e" if channel == "el" else "#mu" if channel == "mu" else "l", 
                                                                                                pttext=etaRangeText,


### PR DESCRIPTION
Implementing QCD scales uncorrelated between charges for 2D xsec (only for those binned in W-pT applied to signal and tau)

Also, when plotting postfit nuisances for these scales, sort them so to separate charges and put indices in increasing order (unbinned scaled, applied only to Z, are put at the end)
See plot here showing the effect [0].

Could be useful to add vertical lines after "mu*10*" to better locate each set (which is correlated with the W-pT spectrum), but not fundamental for now

[0] http://mciprian.web.cern.ch/mciprian/wmass/13TeV/diffXsecAnalysis_new/muon/diffXsec_mu_2019_06_17_zptReweight_chargeUncorrQCDscales/diffNuisances/zptReweight_uncorrQCDscales_bbb1_cxs1/nuisances_muRmuF_Data.pdf