### PR TITLE
add alphaS in quadrature, one fix in the merger

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
+++ b/WMass/python/plotter/w-helicity-13TeV/mergeCardComponentsAbsY.py
@@ -75,7 +75,7 @@ def getXsecs(processes, systs, ybins, lumi, infile):
         for sys in systs:
 
             # skipping the look for xsec for the theory systematics which belong only to Wtau
-            if re.match('muR\d+(minus|plus)|muF\d+(minus|plus)|muRmuF\d+(minus|plus)',sys) and not any([pol in sys for pol in ['left','right','long']]): continue
+            if re.match('^muR\d+(minus|plus)|^muF\d+(minus|plus)|^muRmuF\d+(minus|plus)',sys): continue
 
             original_sys = sys
             if 'longmu' in sys or 'leftmu' in sys or 'rightmu' in sys:

--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -451,6 +451,7 @@ if __name__ == "__main__":
         ## this gets the pdf central variation binned in the correct format
         xsec_nominal     = utilities.getXSecFromShapes(ybins,charge,xsecfiles[ic],0,nChan, polarizations=polarizations )
         xsec_qcdenvelope = utilities.getQCDScaleEnvelope(ybins,charge,xsecfiles[ic],nChan, polarizations=polarizations )
+        xsec_alphas_syst = utilities.getQCDScaleEnvelope(ybins,charge,xsecfiles[ic],nChan, polarizations=polarizations, doAlphaS=True )
 
         xsec_nominal_allCharges[charge] = xsec_nominal
 
@@ -484,6 +485,8 @@ if __name__ == "__main__":
                         xsec_totUp += math.pow(xsec_relsyst*xsec_nom,2)
                 # now to the total PDF error, add the QCD scales envelope
                 xsec_totUp += math.pow(xsec_qcdenvelope[pol][iy],2)
+                # and add alphaS (which in principle is part of PDF variations)
+                xsec_totUp += math.pow(xsec_alphas_syst[pol][iy],2)
                 xsec_totUp = math.sqrt(xsec_totUp)
                 # print "Rel systematic for Y bin %d = +/-%.3f" % (iy,totUp/nom)
                 # print "\tRel systematic on xsec for Y bin %d = +/-%.3f" % (iy,xsec_totUp/xsec_nom if xsec_nom else 0.)

--- a/WMass/python/plotter/w-helicity-13TeV/plotYWCompatibility.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYWCompatibility.py
@@ -582,6 +582,7 @@ if __name__ == "__main__":
         ## this gets the pdf central variation binned in the correct format
         xsec_nominal     = utilities.getXSecFromShapes(ybins,charge,xsecfiles[ic],0,nChan, polarizations=polarizations)
         xsec_qcdenvelope = utilities.getQCDScaleEnvelope(ybins,charge,xsecfiles[ic],nChan, polarizations=polarizations )
+        xsec_alphas_syst = utilities.getQCDScaleEnvelope(ybins,charge,xsecfiles[ic],nChan, polarizations=polarizations, doAlphaS=True )
 
         xsec_nominal_allCharges[charge] = xsec_nominal
 
@@ -615,6 +616,8 @@ if __name__ == "__main__":
                         xsec_totUp += math.pow(xsec_relsyst*xsec_nom,2)
                 # now to the total PDF error, add the QCD scales envelope
                 xsec_totUp += math.pow(xsec_qcdenvelope[pol][iy],2)
+                # and add alphaS (which in principle is part of PDF variations)
+                xsec_totUp += math.pow(xsec_alphas_syst[pol][iy],2)
                 xsec_totUp = math.sqrt(xsec_totUp)
                 # print "Rel systematic for Y bin %d = +/-%.3f" % (iy,totUp/nom)
                 # print "\tRel systematic on xsec for Y bin %d = +/-%.3f" % (iy,xsec_totUp/xsec_nom if xsec_nom else 0.)


### PR DESCRIPTION
- one fix for a bug introduced by me in #541 
- alphaS is now added in quadrature to QCD scales and PDFs (no more included in the envelope of the scales as in #540 ) as suggested by @bendavid
