### PR TITLE
Fixes for alphaS and a0 a4 in the rapidity plots

### DIFF
--- a/WMass/python/plotter/w-helicity-13TeV/plotYW.py
+++ b/WMass/python/plotter/w-helicity-13TeV/plotYW.py
@@ -685,8 +685,10 @@ if __name__ == "__main__":
                         tmp_val.altval[-1] = tmp_val.altval[-1]/alt_normsigma
                     tmp_val.ehi[-1] = tmp_val.ehi[-1]/normsigma
                     tmp_val.elo[-1] = tmp_val.elo[-1]/normsigma
-                else:
+                elif xs=='sumxsec':
                     scale *= float(nChan)
+                else:
+                    pass # a0, a4 are already normalized
         
                 xsec_fit = valuesAndErrors[parname]
         

--- a/WMass/python/plotter/w-helicity-13TeV/utilities.py
+++ b/WMass/python/plotter/w-helicity-13TeV/utilities.py
@@ -126,6 +126,7 @@ class util:
                 for s in systs:
                     histo_systs = histo_file.Get(binname+'_'+s)
                     envelope = max(envelope, abs(histo_systs.Integral()/36000./float(nchannels) - nominal))
+                    if doAlphaS: envelope = 1.5*envelope # one sigma corresponds to +-0.0015 (weights correspond to +-0.001) 
                 xsecs.append(float(envelope))
             values[pol] = xsecs
         histo_file.Close()


### PR DESCRIPTION
- alphaS weights correspond to 0.67 sigma 
- a0 a4 are self normalized, remove the 0.5 in the combined plot normalization
(changes are only for plotting, nothing for the fit)