### PR TITLE
Updates to run a first complete round of datacards

### DIFF
--- a/WMass/python/plotter/w-mass-13TeV/wlike_mu/FRfast/sameSign_application_data.txt
+++ b/WMass/python/plotter/w-mass-13TeV/wlike_mu/FRfast/sameSign_application_data.txt
@@ -1,0 +1,3 @@
+## invert the cut for the OS pair
+cut-change: -169 : 169
+weight: 1.0

--- a/WMass/python/plotter/w-mass-13TeV/wlike_mu/make_cards_mu.py
+++ b/WMass/python/plotter/w-mass-13TeV/wlike_mu/make_cards_mu.py
@@ -12,7 +12,7 @@ QUEUE        = '1nd'
 
 VAR          = '\'returnChargeVal(LepGood1_pt,LepGood1_charge,LepGood2_pt,LepGood2_charge,evt),returnChargeVal(LepGood1_eta,LepGood1_charge,LepGood2_eta,LepGood2_charge,evt):returnChargeVal(LepGood1_eta,LepGood1_charge,LepGood2_eta,LepGood2_charge,evt)\''
 
-TREEPATH     = '/afs/cern.ch/work/e/emanuele/TREES/SKIM_2LEP_wlike_mu_V1/'
+TREEPATH     = '/afs/cern.ch/work/e/emanuele/TREES/SKIM_2LEP_wlike_mu_V2/'
 
 binningeta = [-2.4 + i*0.1 for i in range(49) ]
 binningeta = [float('{a:.3f}'.format(a=i)) for i in binningeta]

--- a/WMass/python/plotter/w-mass-13TeV/wlike_mu/mca-includes/mca-80X-wmunu-bkgmc.txt
+++ b/WMass/python/plotter/w-mass-13TeV/wlike_mu/mca-includes/mca-80X-wmunu-bkgmc.txt
@@ -1,6 +1,5 @@
 
-Top         : TTJets_SingleLeptonFromT_*          : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.09
-Top         : TTJets_SingleLeptonFromTbar_*       : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.09
+Top         : TTLep_pow_*                         : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.09
 Top         : TToLeptons_sch_amcatnlo             : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.04
 Top         : T_tch_powheg_part*                  : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.04
 Top         : TBar_tch_powheg_part*               : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.04

--- a/WMass/python/plotter/w-mass-13TeV/wlike_mu/mca-includes/mca-80X-wmunu-dy.txt
+++ b/WMass/python/plotter/w-mass-13TeV/wlike_mu/mca-includes/mca-80X-wmunu-dy.txt
@@ -1,24 +1,22 @@
-#
-#Z  : DYJetsToLL_M50_*    : 2008.4*3   ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04
-
 # the reweighting should work identical to before
 # signal from the weighted uncut sample
-Zplus_ac  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kGray+1   , FakeRate="w-mass-13TeV/fractionReweighting/weight_c_plus.txt" , Label="Z+ ac"
-Zplus_a0  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kGray+1   , FakeRate="w-mass-13TeV/fractionReweighting/weight_0_plus.txt" , Label="Z+ a0"
-Zplus_a1  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kBlue+1   , FakeRate="w-mass-13TeV/fractionReweighting/weight_1_plus.txt" , Label="Z+ a1"
-Zplus_a2  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kGreen+1  , FakeRate="w-mass-13TeV/fractionReweighting/weight_2_plus.txt" , Label="Z+ a2"
-Zplus_a3  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kRed+1    , FakeRate="w-mass-13TeV/fractionReweighting/weight_3_plus.txt" , Label="Z+ a3"
-Zplus_a4  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kCyan+1   , FakeRate="w-mass-13TeV/fractionReweighting/weight_4_plus.txt" , Label="Z+ a4"
-Zplus_a5  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kYellow+1 , FakeRate="w-mass-13TeV/fractionReweighting/weight_5_plus.txt" , Label="Z+ a5"
-Zplus_a6  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kAzure+1  , FakeRate="w-mass-13TeV/fractionReweighting/weight_6_plus.txt" , Label="Z+ a6"
-Zplus_a7  : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kMagenta+1, FakeRate="w-mass-13TeV/fractionReweighting/weight_7_plus.txt" , Label="Z+ a7"
+# Z xsec from FEWZ 3.1 and NNPDF 3.1: https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV
+Zplus_ac  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kGray+1   , FakeRate="w-mass-13TeV/fractionReweighting/weight_c_plus.txt" , Label="Z+ ac"
+Zplus_a0  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kGray+1   , FakeRate="w-mass-13TeV/fractionReweighting/weight_0_plus.txt" , Label="Z+ a0"
+Zplus_a1  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kBlue+1   , FakeRate="w-mass-13TeV/fractionReweighting/weight_1_plus.txt" , Label="Z+ a1"
+Zplus_a2  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kGreen+1  , FakeRate="w-mass-13TeV/fractionReweighting/weight_2_plus.txt" , Label="Z+ a2"
+Zplus_a3  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kRed+1    , FakeRate="w-mass-13TeV/fractionReweighting/weight_3_plus.txt" , Label="Z+ a3"
+Zplus_a4  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kCyan+1   , FakeRate="w-mass-13TeV/fractionReweighting/weight_4_plus.txt" , Label="Z+ a4"
+Zplus_a5  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kYellow+1 , FakeRate="w-mass-13TeV/fractionReweighting/weight_5_plus.txt" , Label="Z+ a5"
+Zplus_a6  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kAzure+1  , FakeRate="w-mass-13TeV/fractionReweighting/weight_6_plus.txt" , Label="Z+ a6"
+Zplus_a7  : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kMagenta+1, FakeRate="w-mass-13TeV/fractionReweighting/weight_7_plus.txt" , Label="Z+ a7"
 
-Zminus_ac : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kGray-2   , FakeRate="w-mass-13TeV/fractionReweighting/weight_c_minus.txt", Label="Z- ac"
-Zminus_a0 : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kGray-2   , FakeRate="w-mass-13TeV/fractionReweighting/weight_0_minus.txt", Label="Z- a0"
-Zminus_a1 : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kBlue-2   , FakeRate="w-mass-13TeV/fractionReweighting/weight_1_minus.txt", Label="Z- a1"
-Zminus_a2 : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kGreen-2  , FakeRate="w-mass-13TeV/fractionReweighting/weight_2_minus.txt", Label="Z- a2"
-Zminus_a3 : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kRed-2    , FakeRate="w-mass-13TeV/fractionReweighting/weight_3_minus.txt", Label="Z- a3"
-Zminus_a4 : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kCyan-2   , FakeRate="w-mass-13TeV/fractionReweighting/weight_4_minus.txt", Label="Z- a4"
-Zminus_a5 : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kYellow-2 , FakeRate="w-mass-13TeV/fractionReweighting/weight_5_minus.txt", Label="Z- a5"
-Zminus_a6 : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kAzure-2  , FakeRate="w-mass-13TeV/fractionReweighting/weight_6_minus.txt", Label="Z- a6"
-Zminus_a7 : DYJetsToLL_M50_* :3.*2008.4 : 1 ; FillColor=ROOT.kMagenta-2, FakeRate="w-mass-13TeV/fractionReweighting/weight_7_minus.txt", Label="Z- a7"
+Zminus_ac : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kGray-2   , FakeRate="w-mass-13TeV/fractionReweighting/weight_c_minus.txt", Label="Z- ac"
+Zminus_a0 : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kGray-2   , FakeRate="w-mass-13TeV/fractionReweighting/weight_0_minus.txt", Label="Z- a0"
+Zminus_a1 : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kBlue-2   , FakeRate="w-mass-13TeV/fractionReweighting/weight_1_minus.txt", Label="Z- a1"
+Zminus_a2 : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kGreen-2  , FakeRate="w-mass-13TeV/fractionReweighting/weight_2_minus.txt", Label="Z- a2"
+Zminus_a3 : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kRed-2    , FakeRate="w-mass-13TeV/fractionReweighting/weight_3_minus.txt", Label="Z- a3"
+Zminus_a4 : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kCyan-2   , FakeRate="w-mass-13TeV/fractionReweighting/weight_4_minus.txt", Label="Z- a4"
+Zminus_a5 : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kYellow-2 , FakeRate="w-mass-13TeV/fractionReweighting/weight_5_minus.txt", Label="Z- a5"
+Zminus_a6 : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kAzure-2  , FakeRate="w-mass-13TeV/fractionReweighting/weight_6_minus.txt", Label="Z- a6"
+Zminus_a7 : ZJToMuMu_powhegMiNNLO_pythia8_photos_* : 2025.7 : 1 ; FillColor=ROOT.kMagenta-2, FakeRate="w-mass-13TeV/fractionReweighting/weight_7_minus.txt", Label="Z- a7"

--- a/WMass/python/plotter/w-mass-13TeV/wlike_mu/mca-wlike-mass.txt
+++ b/WMass/python/plotter/w-mass-13TeV/wlike_mu/mca-wlike-mass.txt
@@ -1,10 +1,12 @@
 ## MAIN SAMPLES
 
-incl_sig              : + ; IncludeMca="w-mass-13TeV/wlike_mu/mca-includes/mca-80X-wmunu-sig.txt"
+#incl_sig              : + ; IncludeMca="w-mass-13TeV/wlike_mu/mca-includes/mca-80X-wmunu-sig.txt"
 incl_bkgmc            : + ; IncludeMca="w-mass-13TeV/wlike_mu/mca-includes/mca-80X-wmunu-bkgmc.txt"
 incl_dy               : + ; IncludeMca="w-mass-13TeV/wlike_mu/mca-includes/mca-80X-wmunu-dy.txt"
 
-incl_datafakes        : + ; IncludeMca="w-mass-13TeV/wlike_mu/mca-includes/mca-data.txt", FakeRate="w-mass-13TeV/wlike_mu/FRfast/fakeRate_application_data.txt", Label="Fakes", FillColor=ROOT.kGray+2, FillStyle=3005, NormSystematic=0.30, PostFix='_fakes'
+incl_datass           : + ; IncludeMca="w-mass-13TeV/wlike_mu/mca-includes/mca-data.txt", FakeRate="w-mass-13TeV/wlike_mu/FRfast/sameSign_application_data.txt", Label="Fakes", FillColor=ROOT.kGray+2, FillStyle=3005, NormSystematic=0.30, PostFix='_fakes'
+
+#incl_datafakes        : + ; IncludeMca="w-mass-13TeV/wlike_mu/mca-includes/mca-data.txt", FakeRate="w-mass-13TeV/wlike_mu/FRfast/fakeRate_application_data.txt", Label="Fakes", FillColor=ROOT.kGray+2, FillStyle=3005, NormSystematic=0.30, PostFix='_fakes'
 
 ## DATA
 incl_data             : + ; IncludeMca="w-mass-13TeV/wlike_mu/mca-includes/mca-data.txt"

--- a/WMass/python/plotter/w-mass-13TeV/wlike_mu/skimming/mca-wlike.txt
+++ b/WMass/python/plotter/w-mass-13TeV/wlike_mu/skimming/mca-wlike.txt
@@ -1,5 +1,6 @@
-Z           : DYJetsToLL_M50_ext2*                : 1921.8*3                                              ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04
-Z           : DYJetsToLL_M50_part*                : 1921.8*3                                              ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04
+ZMuMu_py8    : ZJToMuMu_powhegMiNNLO_pythia8_testProd_part*                : 1921.8                                              ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04
+ZMuMu_py8photos    : ZJToMuMu_powhegMiNNLO_pythia8_photos_testProd_part*   : 1921.8                                              ; FillColor=ROOT.kAzure+2 , Label="Z", NormSystematic=0.04
+
 
 W    : WJetsToLNu_* : 3.*20508.9  ; FillColor=ROOT.kGray+1   , Label="W"
 
@@ -10,6 +11,7 @@ Top         : T_tch_powheg_part*                  : xsec                        
 Top         : TBar_tch_powheg_part*               : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.04
 Top         : T_tWch_ext                          : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.06
 Top         : TBar_tWch_ext                       : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.06
+Top         : TTLep_pow_part*                     : xsec                                                  ; FillColor=ROOT.kGreen+2 , Label="Top", NormSystematic=0.06
 
 DiBosons    : WW+WW_ext                           : xsec                                                  ; FillColor=ROOT.kViolet+2, Label="DiBosons", NormSystematic=0.03
 DiBosons    : WZ+WZ_ext                           : xsec                                                  ; FillColor=ROOT.kViolet+2, Label="DiBosons", NormSystematic=0.05

--- a/WMass/python/plotter/w-mass-13TeV/wlike_mu/skimming/skimCuts2mu.txt
+++ b/WMass/python/plotter/w-mass-13TeV/wlike_mu/skimming/skimCuts2mu.txt
@@ -1,7 +1,7 @@
 alwaystrue : 1
 trigger    : (HLT_BIT_HLT_IsoMu24_v > 0 || HLT_BIT_HLT_IsoTkMu24_v > 0 )
 twolep     : nLepGood == 2
-osmuons    : LepGood1_pdgId*LepGood2_pdgId == -169
+twomuons   : abs(LepGood1_pdgId*LepGood2_pdgId) == 169
 kinl1      : LepGood1_pt > 23. && abs(LepGood1_eta)<2.4
 kinl2      : LepGood2_pt > 23. && abs(LepGood2_eta)<2.4
 mediuml1   : LepGood1_mediumMuonId  > 0

--- a/WMass/python/plotter/w-mass-13TeV/wlike_mu/skimming/varsToKeep.txt
+++ b/WMass/python/plotter/w-mass-13TeV/wlike_mu/skimming/varsToKeep.txt
@@ -142,4 +142,6 @@ LepGood_dr03TkSumPt
 LepGood_trackIso 
 LepGood_matchedTrgObjMuPt
 LepGood_matchedTrgObjTkMuPt
-
+LepGood_mcMatchId
+LepGood_mcMatchAny
+LepGood_mcMatchTau

--- a/WMass/scripts/cmgCheckProduction.sh
+++ b/WMass/scripts/cmgCheckProduction.sh
@@ -29,7 +29,7 @@ MVDIR=$2
 # sometime I tried removing -z option because it induced "fake" zombie files in the output
 echo "# Check the trees..."
 #cmgListChunksToResub -t treeProducerWMass/tree.root -z -p $DIR > clean.sh
-cmgListChunksToResub -t treeProducerWMass/tree.root -p $DIR > clean.sh
+cmgListChunksToResub -t treeProducerWMass/tree.root.url -p $DIR > clean.sh
 echo "# Check the RLTInfo.root..."
 #cmgListChunksToResub -t JSONAnalyzer/RLTInfo.root -z $DIR >> clean.sh
 cmgListChunksToResub -t JSONAnalyzer/RLTInfo.root $DIR >> clean.sh


### PR DESCRIPTION
**Cards making:**
1. update the samples (new signal for ZJets), TTLep powheg for ttbar, remove WJets accounted by fakes
2. use the Same-sign leptons (just raw) for the fakes 
3. use the FEWZ 3.1 / NNPDF3.1 xsec for the Zjets (2025.7 pb)

** skimming** 
1. remove the OS requirement in the 2L skim
2. add the mcMatch variables in the saved trees

(this is still first approximation / technical completeness test)