### PR TITLE
Update BW weights to new MC, add explicit mass weights

### DIFF
--- a/RootTools/python/samples/samples_13TeV_RunIISummer16MiniAODv3.py
+++ b/RootTools/python/samples/samples_13TeV_RunIISummer16MiniAODv3.py
@@ -21,7 +21,7 @@ ZJToMuMu_mWPilot_powhegMiNNLO_pythia8_photos = kreator.makeMCComponent("ZJToMuMu
 
 
 # for private usage with some files
-myFiles = [f.strip() for f in open("%s/src/CMGTools/WMass/cfg/ZJToMuMu_mWPilot_listOn28April2020_first100files.txt" % os.environ['CMSSW_BASE'], "r")]
+myFiles = [f.strip() for f in open("%s/src/CMGTools/WMass/cfg/ZJToMuMu_mWPilot_listOn28April2020_files.txt" % os.environ['CMSSW_BASE'], "r")]
 PARTIAL_ZJToMuMu_mWPilot = kreator.makePrivateMCComponent('PARTIAL_ZJToMuMu_mWPilot',  '/ZJToMuMu_mWPilot_TuneCP5_13TeV-powheg-MiNNLO-pythia8-photos/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM', myFiles, 2008.4 )
 
 

--- a/WMass/cfg/run_wmass_cfg.py
+++ b/WMass/cfg/run_wmass_cfg.py
@@ -487,7 +487,7 @@ if test in[ 'testw' , 'testz' , 'testdata' , 'testwnew' , 'testznew', 'testw94x'
         #comp = ZJToMuMu_mWPilot_powhegMiNNLO_pythia8_photos
         #comp.files = ['/eos/cms/store/mc/RunIISummer16MiniAODv3/ZJToMuMu_mWPilot_TuneCP5_13TeV-powheg-MiNNLO-pythia8-photos/MINIAODSIM/PUMoriond17_94X_mcRun2_asymptotic_v3-v1/250000/D24DA931-7882-EA11-AAC9-0CC47A4D7634.root']
         comp = PARTIAL_ZJToMuMu_mWPilot
-        comp.files = comp.files[:50]
+        comp.files = comp.files[:1]
     elif test =='testz94x':
         comp = ZJToMuMu_powhegMiNNLO_pythia8_photos_testProd
         comp.files = comp.files[:1]

--- a/WMass/python/postprocessing/examples/genFriendProducer.py
+++ b/WMass/python/postprocessing/examples/genFriendProducer.py
@@ -176,9 +176,8 @@ class GenQEDJetProducer(Module):
         return idx_map[(mur,muf)]
 
     def bwWeight(self,genMass,imass, isW):
-        # default mass calculated from MG5 inputs
-        # width calculated with MG5_aMC_v2_6_3_2 loop_sm-ckm_no_b_mass for w+ > all all --> 2.05 +/- 7.65e-06 (GeV)
-        (m0,gamma) = (80419.,2050.0) if isW else (91187.6, 2495.2) # MeV . the Z values are from the PDG, not from the MC production!!!
+        # mass and width from MiNNLO samples, using PDG inputs + width-dependent scheme https://indico.cern.ch/event/908015/contributions/3820269
+        (m0,gamma) = (80351.972,2084.299) if isW else (91153.481, 2494.266) # MeV 
         newmass = m0 + imass*5.
         s_hat = pow(genMass,2)
         return (pow(s_hat - m0*m0,2) + pow(gamma*m0,2)) / (pow(s_hat - newmass*newmass,2) + pow(gamma*newmass,2))
@@ -539,18 +538,18 @@ class GenQEDJetProducer(Module):
 
             ## set here the nominal weight for the PDF set we want to use:
             ## the index should be:
-            ##   9 for NNPDF31_nnlo_hessian_pdfas
-            ## 120 for NNPDF31_nnlo_as_0118_CMSW1_hessian_100, where: CMSW1 => No CMS W data
-            ## 221 for NNPDF31_nnlo_as_0118_CMSW2_hessian_100, where: CMSW2 => No collider W data
-            ## 322 for NNPDF31_nnlo_as_0118_CMSW3_hessian_100, where: CMSW3 => No CMS W,Z data
-            ## 423 for NNPDF31_nnlo_as_0118_CMSW4_hessian_100, where: CMSW4 => No collider W,Z data
-            ## 524 for CT14nnlo             ATTENTION, number of hessianWeights is: 29
-            ## 583 for MMHT2014nnlo68cl     ATTENTION, number of hessianWeights is: 51, alphaS separate
-            ## 637 for ABMP16_5_nnlo        ATTENTION, number of hessianWeights is: 30
-            ## 667 for HERAPDF20_NNLO_EIG   ATTENTION, number of hessianWeights is: 29
-            ## 696 for HERAPDF20_NNLO_VAR   ATTENTION, number of hessianWeights is: 14, alphaS separate
+            ##  18 for NNPDF31_nnlo_hessian_pdfas
+            ## 129 for NNPDF31_nnlo_as_0118_CMSW1_hessian_100, where: CMSW1 => No CMS W data
+            ## 230 for NNPDF31_nnlo_as_0118_CMSW2_hessian_100, where: CMSW2 => No collider W data
+            ## 331 for NNPDF31_nnlo_as_0118_CMSW3_hessian_100, where: CMSW3 => No CMS W,Z data
+            ## 432 for NNPDF31_nnlo_as_0118_CMSW4_hessian_100, where: CMSW4 => No collider W,Z data
+            ## 533 for CT14nnlo             ATTENTION, number of hessianWeights is: 29
+            ## 592 for MMHT2014nnlo68cl     ATTENTION, number of hessianWeights is: 51, alphaS separate
+            ## 646 for ABMP16_5_nnlo        ATTENTION, number of hessianWeights is: 30
+            ## 676 for HERAPDF20_NNLO_EIG   ATTENTION, number of hessianWeights is: 29
+            ## 705 for HERAPDF20_NNLO_VAR   ATTENTION, number of hessianWeights is: 14, alphaS separate
 
-            centralPDFIndex  = 423 ## for CMSW4
+            centralPDFIndex  = 432 ## for CMSW4
             centralPDFWeight = lheweights[centralPDFIndex] ## 423 for CMSW4
 
             ## the PDF variations are saved as ratios w/r/t the nominal weight of the selected sample

--- a/WMass/python/postprocessing/postproc_batch.py
+++ b/WMass/python/postprocessing/postproc_batch.py
@@ -25,6 +25,7 @@ DEFAULT_MODULES = [("CMGTools.WMass.postprocessing.examples.puWeightProducer", "
                    #("CMGTools.WMass.postprocessing.examples.lepVarProducer","lepQCDAwayJet,muCalibrated,kamucaCentral,kamucaSyst"),
                    ("CMGTools.WMass.postprocessing.examples.lepVarProducer","lepQCDAwayJetAll,muCalibratedWithStatVar"),
                    ("CMGTools.WMass.postprocessing.examples.jetReCleaner","jetReCleaner,jetAllReCleaner"),
+                   ("CMGTools.WMass.postprocessing.examples.genFriendProducer","genQEDJets"),
                    #("CMGTools.WMass.postprocessing.examples.genFriendProducer","genQEDJetsWithVertex"),
                    #("CMGTools.WMass.postprocessing.examples.lepVarProducer","lepQCDAwayJet,muCalibrated"),
                    #("CMGTools.WMass.postprocessing.examples.jetReCleaner","jetReCleaner"),


### PR DESCRIPTION
- Set the central mass and width values to correspond to the current Z MiNNLO pilot sample and planned W MiNNLO sample.

- Add the mass weights from the explicit variations in MiNNLO in addition to the BW weights