### PR TITLE
Fixing impacts

### DIFF
--- a/WMass/python/plotter/plotDiffXsec.py
+++ b/WMass/python/plotter/plotDiffXsec.py
@@ -10,21 +10,21 @@ combineElePt01asBkg = 0
 dryrun = 0
 skipPreliminary = True # passed as an option to some scripts to print "Preliminary" in plot
 skipData = 0
-onlyData = 0
+onlyData = 1
 corrXsecStat = 1 # default should be 1, i.e. combinetf had option correlate-xsec-stat, else 0
 
 skipInclusivePlot = 1
-skipPlot = 0
+skipPlot = 1
 skipTemplate = 1
 skipDiffNuis = 1
 skipPostfit = 1  # only for Data
 skipCorr = 1
 skipCorr1D = 1
 skipCorrAll4HEPdata = 1
-skipImpacts = 1
+skipImpacts = 0
 skipImpactsAll4HEPdata = 1
 skipImpactsEtaPt = 1
-skipMuElComparison = 0
+skipMuElComparison = 1
 #outFolderComparison = "test_nativeMCatNLOxsecW_profileLepScale_cropNegBinNomi_uncorrFSRbyFlav_clipSyst1p3_clipSigSyst1p15_clipPtScale1p15_decorrPtScaleSystByEta_noSplitElePtSystByPt_FSRshapeOnly" # update name here when using skipMuElComparison, or just use postfix
 
 useXsecWptWeights = 0 # to plot the band better to keep the unweighted xsec (so keep 0)
@@ -205,7 +205,7 @@ impacts_nuis = ["GROUP"]     # this will do groups, I can filter some of them, b
 #impacts_nuis = ["muTestEffSyst0","muTestEffSyst1","muTestEffSyst2"] 
 #groupnames = 'binByBinStat,stat,pdfs,wmodel,EffStat,scales,alphaS'
 #groupnames = 'binByBinStat,stat,luminosity,pdfs,QCDTheo,Fakes,OtherBkg,OtherExp,EffStat,EffSyst,lepScale,QEDTheo'
-groupnames = 'binByBinStat,stat,pdfs,QCDTheo,Fakes,EffStat'
+groupnames = 'EffStat,Fakes,QCDTheo,pdfs,luminosity,stat,binByBinStat'
 groupnames_4HEPdata = 'binByBinStat,stat,luminosity,pdfs,QCDTheo,Fakes,OtherBkg,OtherExp,EffStat,EffSyst,lepScale,QEDTheo'
 #if flavour == "el" or doMuElComb:
 #    groupnames += ',L1Prefire'
@@ -456,8 +456,8 @@ for fit in fits:
                 poi_regexp = ["W.*_ieta_.*_ipt_%d_.*" % i for i in  [2, 3, 7, 16] ]
 
             if nuis == "GROUP":
-                if any(target == x for x in ["etaxsec", "ptxsec"]) and "luminosity" not in groupnames:
-                    varopt = " --nuisgroups '{ng},luminosity' ".format(ng=groupnames)
+                if all(target != x for x in ["etaxsec", "ptxsec"]):
+                    varopt = " --nuisgroups '{ng}' ".format(ng=groupnames.replace(',luminosity',''))
                 else:
                     varopt = " --nuisgroups '{ng}' ".format(ng=groupnames)
             else:

--- a/WMass/python/plotter/plotUtils/utility.py
+++ b/WMass/python/plotter/plotUtils/utility.py
@@ -343,8 +343,8 @@ def drawCorrelationPlot(h2D_tmp,
     adjustSettings_CMS_lumi()
 
     if (rebinFactorX): 
-        if isinstance(rebinFactorX, int): h2D_tmp.RebinY(rebinFactorX)
-        else:                             h2D_tmp.RebinY(len(rebinFactorX)-1,"",array('d',rebinFactorX)) # case in which rebinFactorX is a list of bin edges
+        if isinstance(rebinFactorX, int): h2D_tmp.RebinX(rebinFactorX)
+        else:                             h2D_tmp.RebinX(len(rebinFactorX)-1,"",array('d',rebinFactorX)) # case in which rebinFactorX is a list of bin edges
 
     if (rebinFactorY): 
         if isinstance(rebinFactorY, int): h2D_tmp.RebinY(rebinFactorY)

--- a/WMass/python/plotter/resultPlots.py
+++ b/WMass/python/plotter/resultPlots.py
@@ -177,7 +177,7 @@ if __name__ == '__main__':
         poisGroups = ['W{ch}.*{pol}.*'.format(ch=charge,pol=pol) for charge in ['plus','minus'] for pol in ['left','right','long']]
         singleNuisGroups = ['CMS.*','pdf.*','mu.*','ErfPar0.*','ErfPar1.*','ErfPar2.*']
         targets = ['xsec','xsecnorm','asym','unpolasym','unpolxsec','unpolxsecnorm','A0','A4']
-        nuisgroups = 'pdfs,binByBinStat,EffStat,Fakes,lumi,QCDTheo,stat,Total'
+        nuisgroups = 'EffStat,Fakes,QCDTheo,pdfs,luminosity,stat,binByBinStat'
         POIsForSummary = {'xsec': '.*', 'xsecnorm': '.*', 'asym': '.*chargeasym', 'unpolasym': '.*chargemetaasym', 'unpolxsec': '.*sumxsec', 'unpolxsecnorm': '.*sumxsecnorm', 'A0': '.*a0', 'A4': '.*a4'}
         for t in toysHessian:
             for tmp_file in [i for i in results.keys() if re.match('both_floatingPOIs_{toyhess}'.format(toyhess=t),i)]:
@@ -204,7 +204,7 @@ if __name__ == '__main__':
                 for target in targets:
                     print "RUNNING 1D SUMMARIES OF SYSTEMATICS..."
                     if 'norm' in target or 'asy' in target or 'A' in target:
-                        target_nuisgroups = nuisgroups.replace('lumi,','')
+                        target_nuisgroups = nuisgroups.replace(',luminosity','')
                     else:
                         target_nuisgroups = nuisgroups
                     cmd = 'python w-helicity-13TeV/impactPlots.py {fr} -o {od} --nuisgroups {ng} --pois {pois} -y {cd}/binningYW.txt --target {tg} --suffix summary_{sfx} --longBkg '.format(fr=results[tmp_file], od=tmp_outdir, pois=POIsForSummary[target], cd=results['cardsdir'], tg=target, sfx=tmp_suffix, ng=target_nuisgroups)


### PR DESCRIPTION
There was a problem for both helicity and 2D xsec. 
In the former, some lines could be missing in the plots (luminosity) due to input options and the way those were manipulated inside.
In the latter, swapping two items of the legend was actually affecting the lines themselves, so lines for  Effstat and Fakes were swapped but still being assigned the right colour.
Now fixed.

In short, the order on the legend is given by the order of the input groups passed to option --nuisgroups, so we only had to coordinate on that between the two analyses, no hack needed inside the script (which eventually had messed everything up)