### PR TITLE
small edit, adding cut back in the cut file

### DIFF
--- a/WMass/python/plotter/runWmassTHn.py
+++ b/WMass/python/plotter/runWmassTHn.py
@@ -182,8 +182,9 @@ if __name__ == "__main__":
         args.postfix += "_vptWeight"
         
     args.postfix += "_systTHn"
-    regionCut = "transverseMass >= 40.0 || Sum(goodCleanJets)>=1"
-    args.options += f" -A trigMatch regionCut '{regionCut}' "
+    # added back to cut file
+    #regionCut = "transverseMass >= 40.0 || Sum(goodCleanJets)>=1"
+    #args.options += f" -A trigMatch regionCut '{regionCut}' "
     print("")
     main(args)
     print('-'*30)

--- a/WMass/python/plotter/w-mass-13TeV/testingNano/cfg/test/cuts_fakerate.txt
+++ b/WMass/python/plotter/w-mass-13TeV/testingNano/cfg/test/cuts_fakerate.txt
@@ -8,7 +8,7 @@ accept     : valueInsideRange(Muon_pt[goodMuons][0],26,55)
 muonID     : Muon_mediumId[goodMuons][0] == 1 && Muon_isGlobal[goodMuons][0]
 #awayjet    : Sum(goodCleanJets)>=1
 #pfRelIso04 : Muon_pfRelIso04_all[goodMuons][0] < 0.15
-#regionCut: transverseMass >= 40.0 || Sum(goodCleanJets)>=1
+regionCut: transverseMass >= 40.0 || Sum(goodCleanJets)>=1
 trigMatch  : hasTriggerMatch(Muon_eta[goodMuons][0],Muon_phi[goodMuons][0],TrigObj_eta[goodTrigObjs],TrigObj_phi[goodTrigObjs])
 eventFilters: Flag_globalSuperTightHalo2016Filter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_goodVertices && Flag_HBHENoiseIsoFilter && Flag_HBHENoiseFilter && Flag_BadPFMuonFilter
 vetoelectrons: Sum(vetoElectrons) == 0


### PR DESCRIPTION
For Wmass analysis, there is a cut (mT> 40 OR someJetCuts), which makes so that in the low pt region one applies some jet requirements to define a region enriched in QCD events.
This cut was commented in **w-mass-13TeV/testingNano/cfg/test/cuts_fakerate.txt** and added from **runWmassTHn.py** for historical reasons.
Now the cut is uncommented in the cut file, so to avoid having hidden cuts around.

Note: in general there is no explicit isolation and mT cut, because for W analysis one makes all the iso-mT regions together to derive the QCD background estimate simultaneously with other shapes.
In case one want to run histograms specifically in the signal region (for example when only testing signal), one needs to add appropriate cuts (isolation and possibly also mT) somewhere in the cut file or from command line.

One way to do it from command line without modifying the cut file when using **runWmassTHn.py** is to use the following option (--skipPlot is usually already there)
--options " --skipPlot -A trigMatch isoAndMtCut 'transverseMass > 40 && Muon_pfRelIso04_all[goodMuons][0] < 0.15' "
which adds a new cut named isoAndMtCut after the one named trigMatch (you can put it after any cut you want, though)
